### PR TITLE
Fix Bug for closing an exist ProxyServer when another ProxyServer wit…

### DIFF
--- a/src/models/server/server.go
+++ b/src/models/server/server.go
@@ -285,7 +285,7 @@ func (p *ProxyServer) Close() {
 	p.Release()
 
 	// if the proxy created by PrivilegeMode, delete it when closed
-	if p.PrivilegeMode && oldStatus != consts.Closed {
+	if p.PrivilegeMode && oldStatus == consts.Working {
 		// NOTE: this will take the global ProxyServerMap's lock
 		// if we only want to release resources, use Release() instead
 		DeleteProxy(p.Name)


### PR DESCRIPTION
Assure state is `Working` before releasing and deleting ProxyServer instance when `privilege_mode = true` in order that if there is another frpc client is online with same proxy name, it will not be deleted from `ProxyServers` map.