### PR TITLE
imporve iconfont path

### DIFF
--- a/src/assets/static/css/iconfont.css
+++ b/src/assets/static/css/iconfont.css
@@ -1,10 +1,10 @@
 
 @font-face {font-family: "iconfont";
-  src: url('/static/font/iconfont.eot'); /* IE9*/
-  src: url('/static/font/iconfont.eot#iefix') format('embedded-opentype'), /* IE6-IE8 */
-  url('/static/font/iconfont.woff') format('woff'), /* chrome, firefox */
-  url('/static/font/iconfont.ttf') format('truetype'), /* chrome, firefox, opera, Safari, Android, iOS 4.2+*/
-  url('/static/font/iconfont.svg#iconfont') format('svg'); /* iOS 4.1- */
+  src: url('../font/iconfont.eot'); /* IE9*/
+  src: url('../font/iconfont.eot#iefix') format('embedded-opentype'), /* IE6-IE8 */
+  url('../font/iconfont.woff') format('woff'), /* chrome, firefox */
+  url('../font/iconfont.ttf') format('truetype'), /* chrome, firefox, opera, Safari, Android, iOS 4.2+*/
+  url('../font/iconfont.svg#iconfont') format('svg'); /* iOS 4.1- */
 }
 
 .iconfont {


### PR DESCRIPTION
将 dashboard 放置于 nginx 后端时，想跑在已有的 443 端口的子目录下，配置如：

```nginx
location /frp/ {
    proxy_pass http://127.0.0.1:7500/;
}
```

会导致字体文件加载失败。

将字体文件路径改为相对路径即可解决。