### PR TITLE
Make it clear that HTTPS can be password-protected too

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Anyone who can guess your tunnel URL can access your local web server unless you
 
 This enforces HTTP Basic Auth on all requests with the username and password you specify in frpc's configure file.
 
-It can be only enabled when proxy type is http.
+It can be enabled only when proxy type is http/https.
 
 ```ini
 # frpc.ini

--- a/README_zh.md
+++ b/README_zh.md
@@ -382,7 +382,7 @@ host_header_rewrite = dev.yourdomain.com
 
 frp 支持通过 HTTP Basic Auth 来保护你的 web 服务，使用户需要通过用户名和密码才能访问到你的服务。
 
-该功能目前仅限于 http 类型的代理，需要在 frpc 的代理配置中添加用户名和密码的设置。
+该功能目前仅限于 http/https 类型的代理，需要在 frpc 的代理配置中添加用户名和密码的设置。
 
 ```ini
 # frpc.ini


### PR DESCRIPTION
Had to [look in the code](https://github.com/fatedier/frp/blob/3f9749488a2c485ebcb6f10b4a76b04b679205cc/src/models/server/server.go#L186) to make sure that HTTPS can be password-protected.