### PR TITLE
client: add start params

### DIFF
--- a/cmd/frpc/main.go
+++ b/cmd/frpc/main.go
@@ -106,7 +106,7 @@ func main() {
 		}
 	}
 
-	pxyCfgs, err := config.LoadProxyConfFromFile(conf)
+	pxyCfgs, err := config.LoadProxyConfFromFile(config.ClientCommonCfg.User, conf, config.ClientCommonCfg.Start)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/conf/frpc_full.ini
+++ b/conf/frpc_full.ini
@@ -32,6 +32,10 @@ user = your_name
 # default is true
 login_fail_exit = true
 
+# proxy names you want to start divided by ','
+# default is empty, means all proxies
+# start = ssh,dns
+
 # heartbeat configure, it's not recommended to modify the default value
 # the default value of heartbeat_interval is 10 and heartbeat_timeout is 90
 # heartbeat_interval = 30

--- a/models/config/client_common.go
+++ b/models/config/client_common.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	ini "github.com/vaughan0/go-ini"
 )
@@ -39,6 +40,7 @@ type ClientCommonConf struct {
 	TcpMux            bool
 	User              string
 	LoginFailExit     bool
+	Start             map[string]struct{}
 	HeartBeatInterval int64
 	HeartBeatTimeout  int64
 }
@@ -58,6 +60,7 @@ func GetDeaultClientCommonConf() *ClientCommonConf {
 		TcpMux:            true,
 		User:              "",
 		LoginFailExit:     true,
+		Start:             make(map[string]struct{}),
 		HeartBeatInterval: 30,
 		HeartBeatTimeout:  90,
 	}
@@ -134,6 +137,14 @@ func LoadClientCommonConf(conf ini.File) (cfg *ClientCommonConf, err error) {
 	tmpStr, ok = conf.Get("common", "user")
 	if ok {
 		cfg.User = tmpStr
+	}
+
+	tmpStr, ok = conf.Get("common", "start")
+	if ok {
+		proxyNames := strings.Split(tmpStr, ",")
+		for _, name := range proxyNames {
+			cfg.Start[name] = struct{}{}
+		}
 	}
 
 	tmpStr, ok = conf.Get("common", "login_fail_exit")

--- a/models/config/proxy.go
+++ b/models/config/proxy.go
@@ -466,14 +466,21 @@ func (cfg *HttpsProxyConf) Check() (err error) {
 	return
 }
 
-func LoadProxyConfFromFile(conf ini.File) (proxyConfs map[string]ProxyConf, err error) {
-	var prefix string
-	if ClientCommonCfg.User != "" {
-		prefix = ClientCommonCfg.User + "."
+// if len(startProxy) is 0, start all
+// otherwise just start proxies in startProxy map
+func LoadProxyConfFromFile(prefix string, conf ini.File, startProxy map[string]struct{}) (proxyConfs map[string]ProxyConf, err error) {
+	if prefix != "" {
+		prefix += "."
+	}
+
+	startAll := true
+	if len(startProxy) > 0 {
+		startAll = false
 	}
 	proxyConfs = make(map[string]ProxyConf)
 	for name, section := range conf {
-		if name != "common" {
+		_, shouldStart := startProxy[name]
+		if name != "common" && (startAll || shouldStart) {
 			cfg, err := NewProxyConfFromFile(name, section)
 			if err != nil {
 				return proxyConfs, err

--- a/utils/version/version.go
+++ b/utils/version/version.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 )
 
-var version string = "0.10.0"
+var version string = "0.11.0"
 
 func Full() string {
 	return version
@@ -54,8 +54,8 @@ func Minor(v string) int64 {
 
 // add every case there if server will not accept client's protocol and return false
 func Compat(client string) (ok bool, msg string) {
-	if LessThan(client, version) {
-		return false, "Please upgrade your frpc version to 0.10.0"
+	if LessThan(client, "0.10.0") {
+		return false, "Please upgrade your frpc version to at least 0.10.0"
 	}
 	return true, ""
 }


### PR DESCRIPTION
Proxy names specified in 'start' params divided by ',' will be started.
If it is empty or not defined, all proxies will be started.