### PR TITLE
[ADDED] 增加remote_addr 客户端指定监听地址

### DIFF
--- a/models/config/proxy.go
+++ b/models/config/proxy.go
@@ -94,6 +94,7 @@ type BaseProxyConf struct {
 
 	UseEncryption  bool `json:"use_encryption"`
 	UseCompression bool `json:"use_compression"`
+	
 }
 
 func (cfg *BaseProxyConf) GetName() string {
@@ -140,16 +141,22 @@ func (cfg *BaseProxyConf) UnMarshalToMsg(pMsg *msg.NewProxy) {
 	pMsg.ProxyType = cfg.ProxyType
 	pMsg.UseEncryption = cfg.UseEncryption
 	pMsg.UseCompression = cfg.UseCompression
+	//pMsg.RemoteAddr = cfg.RemoteAddr
+
 }
 
 // Bind info
 type BindInfoConf struct {
 	BindAddr   string `json:"bind_addr"`
 	RemotePort int64  `json:"remote_port"`
+	RemoteAddr string `json:"remote_addr"`
+
 }
 
 func (cfg *BindInfoConf) LoadFromMsg(pMsg *msg.NewProxy) {
+	 
 	cfg.BindAddr = ServerCommonCfg.BindAddr
+	cfg.RemoteAddr = pMsg.RemoteAddr
 	cfg.RemotePort = pMsg.RemotePort
 }
 
@@ -158,6 +165,14 @@ func (cfg *BindInfoConf) LoadFromFile(name string, section ini.Section) (err err
 		tmpStr string
 		ok     bool
 	)
+	
+	
+	if tmpStr, ok = section["remote_addr"]; ok {
+		cfg.RemoteAddr = tmpStr
+	} else {
+		cfg.RemoteAddr = ""
+	}
+
 	if tmpStr, ok = section["remote_port"]; ok {
 		if cfg.RemotePort, err = strconv.ParseInt(tmpStr, 10, 64); err != nil {
 			return fmt.Errorf("Parse conf error: proxy [%s] remote_port error", name)
@@ -170,6 +185,7 @@ func (cfg *BindInfoConf) LoadFromFile(name string, section ini.Section) (err err
 
 func (cfg *BindInfoConf) UnMarshalToMsg(pMsg *msg.NewProxy) {
 	pMsg.RemotePort = cfg.RemotePort
+	pMsg.RemoteAddr = cfg.RemoteAddr
 }
 
 func (cfg *BindInfoConf) check() (err error) {

--- a/models/msg/msg.go
+++ b/models/msg/msg.go
@@ -90,7 +90,8 @@ type NewProxy struct {
 
 	// tcp and udp only
 	RemotePort int64 `json:"remote_port"`
-
+	RemoteAddr string `json:"remote_addr"`
+	
 	// http and https only
 	CustomDomains     []string `json:"custom_domains"`
 	SubDomain         string   `json:"subdomain"`

--- a/server/proxy.go
+++ b/server/proxy.go
@@ -15,8 +15,8 @@
 package server
 
 import (
-	"context"
 	"fmt"
+	"golang.org/x/net/context"
 	"io"
 	"net"
 	"sync"
@@ -156,13 +156,13 @@ type TcpProxy struct {
 }
 
 func (pxy *TcpProxy) Run() error {
-	listener, err := frpNet.ListenTcp(config.ServerCommonCfg.BindAddr, pxy.cfg.RemotePort)
+	listener, err := frpNet.ListenTcp(pxy.cfg.RemoteAddr, pxy.cfg.RemotePort)
 	if err != nil {
 		return err
 	}
 	listener.AddLogPrefix(pxy.name)
 	pxy.listeners = append(pxy.listeners, listener)
-	pxy.Info("tcp proxy listen port [%d]", pxy.cfg.RemotePort)
+	pxy.Info("tcp proxy listen host:port [%s:%d]", pxy.cfg.RemoteAddr,pxy.cfg.RemotePort)
 
 	pxy.startListenHandler(pxy, HandleUserTcpConnection)
 	return nil


### PR DESCRIPTION
有时作为隧道使用. 不想监听在公网地址. 仅对tcp有效.

[ssh]
type = tcp
local_ip = 127.0.0.1
local_port = 22
remote_addr=127.0.0.1 # listen on localhost
remote_port = 7003
