### PR TITLE
frpc 添加--user，--server-dynamic  支持从指定url获取frps服务器

### DIFF
--- a/cmd/frpc/main.go
+++ b/cmd/frpc/main.go
@@ -43,7 +43,7 @@ var (
 var usage string = `frpc is the client of frp
 
 Usage: 
-    frpc [-c config_file] [-L log_file] [--log-level=<log_level>] [--server-addr=<server_addr>]
+    frpc [-c config_file] [-L log_file] [--log-level=<log_level>] [--user=<user_name>] [--server-addr=<server_addr>] [--server-dynamic=<http_url>]
     frpc [-c config_file] --reload
     frpc -h | --help
     frpc -v | --version
@@ -53,6 +53,7 @@ Options:
     -L log_file                 set output log file, including console
     --log-level=<log_level>     set log level: debug, info, warn, error
     --server-addr=<server_addr> addr which frps is listening for, example: 0.0.0.0:7000
+    --server-dynamic=<http_url> get frps addr from http_url, example: http://server.com/frp/
     --reload                    reload configure file without program exit
     -h --help                   show this screen
     -v --version                show version
@@ -132,6 +133,14 @@ func main() {
 
 	if args["--log-level"] != nil {
 		config.ClientCommonCfg.LogLevel = args["--log-level"].(string)
+	}
+
+	if args["--user"] != nil {
+		config.ClientCommonCfg.User = args["--user"].(string)
+	}
+
+	if args["--server-dynamic"] != nil {
+		config.ClientCommonCfg.ServerDynamic = args["--server-dynamic"].(string)
 	}
 
 	if args["--server-addr"] != nil {

--- a/models/config/client_common.go
+++ b/models/config/client_common.go
@@ -28,6 +28,7 @@ var ClientCommonCfg *ClientCommonConf
 // client common config
 type ClientCommonConf struct {
 	ConfigFile        string
+	ServerDynamic     string
 	ServerAddr        string
 	ServerPort        int64
 	ServerUdpPort     int64 // this is specified by login response message from frps
@@ -54,6 +55,7 @@ type ClientCommonConf struct {
 func GetDeaultClientCommonConf() *ClientCommonConf {
 	return &ClientCommonConf{
 		ConfigFile:        "./frpc.ini",
+		ServerDynamic:     "",
 		ServerAddr:        "0.0.0.0",
 		ServerPort:        7000,
 		ServerUdpPort:     0,
@@ -86,9 +88,9 @@ func LoadClientCommonConf(conf ini.File) (cfg *ClientCommonConf, err error) {
 	)
 	cfg = GetDeaultClientCommonConf()
 
-	tmpStr, ok = conf.Get("common", "server_addr")
+	tmpStr, ok = conf.Get("common", "server_dynamic")
 	if ok {
-		cfg.ServerAddr = tmpStr
+		cfg.ServerDynamic = tmpStr
 	}
 
 	tmpStr, ok = conf.Get("common", "server_port")


### PR DESCRIPTION
主要是为了支持动态IP地址，但是可以实现更多功能。
比如：
--server-dynamic=http://myserver/
启动会从 http://myserver/?user=<user_name> 获取服务器ip地址信息。

在服务端可以跟据不同来源返回不同的IP信息。

