### PR TITLE
add custom dashboard bind address

### DIFF
--- a/conf/frps_full.ini
+++ b/conf/frps_full.ini
@@ -19,7 +19,10 @@ kcp_bind_port = 7000
 vhost_http_port = 80
 vhost_https_port = 443
 
-# set dashboard_port to view dashboard of frps
+# set dashboard_addr and dashboard_port to view dashboard of frps
+# dashboard_addr's default value is same with bind_addr
+# dashboard is available only if dashboard_port is set
+dashboard_addr = 0.0.0.0
 dashboard_port = 7500
 
 # dashboard user and pwd for basic auth protect, if not set, both default value is admin

--- a/models/config/server_common.go
+++ b/models/config/server_common.go
@@ -39,6 +39,7 @@ type ServerCommonConf struct {
 
 	// if VhostHttpsPort equals 0, don't listen a public port for https protocol
 	VhostHttpsPort int64
+	DashboardAddr  string
 
 	// if DashboardPort equals 0, dashboard is not available
 	DashboardPort  int64
@@ -72,6 +73,7 @@ func GetDefaultServerCommonConf() *ServerCommonConf {
 		ProxyBindAddr:    "0.0.0.0",
 		VhostHttpPort:    0,
 		VhostHttpsPort:   0,
+		DashboardAddr:    "0.0.0.0",
 		DashboardPort:    0,
 		DashboardUser:    "admin",
 		DashboardPwd:     "admin",
@@ -156,6 +158,13 @@ func LoadServerCommonConf(conf ini.File) (cfg *ServerCommonConf, err error) {
 		}
 	} else {
 		cfg.VhostHttpsPort = 0
+	}
+
+	tmpStr, ok = conf.Get("common", "dashboard_addr")
+	if ok {
+		cfg.DashboardAddr = tmpStr
+	} else {
+		cfg.DashboardAddr = cfg.BindAddr
 	}
 
 	tmpStr, ok = conf.Get("common", "dashboard_port")

--- a/server/service.go
+++ b/server/service.go
@@ -143,12 +143,12 @@ func NewService() (svr *Service, err error) {
 
 	// Create dashboard web server.
 	if cfg.DashboardPort > 0 {
-		err = RunDashboardServer(cfg.BindAddr, cfg.DashboardPort)
+		err = RunDashboardServer(cfg.DashboardAddr, cfg.DashboardPort)
 		if err != nil {
 			err = fmt.Errorf("Create dashboard web server error, %v", err)
 			return
 		}
-		log.Info("Dashboard listen on %s:%d", cfg.BindAddr, cfg.DashboardPort)
+		log.Info("Dashboard listen on %s:%d", cfg.DashboardAddr, cfg.DashboardPort)
 	}
 	return
 }


### PR DESCRIPTION
类似（但不是一个功能）场景及讨论 https://github.com/fatedier/frp/issues/327 https://github.com/fatedier/frp/pull/371 ，此 PR 用于解决 dashboard 默认采用 frps 的监听 ip 不够灵活的问题。
1. 服务器多网卡。对外提供服务的网卡和 dashboard 监控网卡分离，因为业务上没有绑定在一起的必然性。
2. 权限问题。监听 127.0.0.1 只用于本地或者 nginx 反代等特定方式访问，或仅用于内网等场景的访问。虽然防火墙能够做到，但此功能不应与防火墙耦合。对外暴露的验证也不是绝对的安全。实现场景类似 tomcat 默认的 manager 及 host-manager 配置，需手动添加授权用户且默认只允许 127.0.0.1 本地访问。
3. Issues 只有反应问题的模板，以 `dashboard` 为关键字并没有搜索到类似情况，所以直接申请 PR，请见谅。