### PR TITLE
do not ignore config parsing error

### DIFF
--- a/cmd/frps/root.go
+++ b/cmd/frps/root.go
@@ -82,13 +82,17 @@ var rootCmd = &cobra.Command{
 			return nil
 		}
 
+		var err error
 		if cfgFile != "" {
-			parseServerCommonCfg(CfgFileTypeIni, cfgFile)
+			err = parseServerCommonCfg(CfgFileTypeIni, cfgFile)
 		} else {
-			parseServerCommonCfg(CfgFileTypeCmd, "")
+			err = parseServerCommonCfg(CfgFileTypeCmd, "")
+		}
+		if err != nil {
+			return err
 		}
 
-		err := runServer()
+		err = runServer()
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -113,8 +117,6 @@ func parseServerCommonCfg(fileType int, filePath string) (err error) {
 		return
 	}
 
-	g.GlbServerCfg.CfgFile = cfgFile
-
 	err = g.GlbServerCfg.ServerCommonConf.Check()
 	if err != nil {
 		return
@@ -136,6 +138,7 @@ func parseServerCommonCfgFromIni(filePath string) (err error) {
 		return err
 	}
 	g.GlbServerCfg.ServerCommonConf = *cfg
+	g.GlbServerCfg.CfgFile = filePath
 	return
 }
 


### PR DESCRIPTION
1、目前 server 命令行解析或者配置文件解析出错时，这个 error 会被忽略，从而继续使用 default 配置