### PR TITLE
Upgrade dockerfile golang to 1.10

### DIFF
--- a/Dockerfile_multiple_build
+++ b/Dockerfile_multiple_build
@@ -1,4 +1,4 @@
-FROM golang:1.8 as frpBuild
+FROM golang:1.10 as frpBuild
 
 COPY . /go/src/github.com/fatedier/frp
 


### PR DESCRIPTION
Same as #684

I tested with:

```sh
docker build -t frp -f Dockerfile_multiple_build .
```

then 

```
Successfully built de3d1be831d2
Successfully tagged frp:latest
```

I like Dockerfile_multiple_build, since it provide small image size 😄 