### PR TITLE
Fix setting basic auth password doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ type = http
 local_port = 80
 custom_domains = test.yourdomain.com
 http_user = abc
-http_passwd = abc
+http_pwd = abc
 ```
 
 Visit `http://test.yourdomain.com` and now you need to input username and password.


### PR DESCRIPTION
Fix setting basic auth password doc
`http_passwd` doesn't work it should be `http_pwd`