### PR TITLE
add multiple network interface support for socks5 plugin

### DIFF
--- a/conf/frpc_full.ini
+++ b/conf/frpc_full.ini
@@ -168,6 +168,17 @@ plugin = socks5
 plugin_user = abc
 plugin_passwd = abc
 
+[plugin_socks5_bind_addr]
+type = tcp
+remote_port = 6007
+plugin = socks5
+plugin_user = abc
+plugin_passwd = abc
+# Similar with wget(--bind-address) or cURL(--interface),
+# you can bind with a specific network interface.
+# The parameter can be a host name.
+plugin_bind_addr = 172.21.0.107
+
 [plugin_static_file]
 type = tcp
 remote_port = 6006


### PR DESCRIPTION
 Similar with wget(--bind-address) or cURL(--interface),
 you can bind with a specific network interface.

config file like this: 
```
[plugin_socks5_bind_addr]
type = tcp
remote_port = 6007
plugin = socks5
plugin_user = abc
plugin_passwd = abc
plugin_bind_addr = 172.21.0.107
```
