### PR TITLE
frpc: fixup ini config parse problem in sub command `status` and `rel…

### DIFF
--- a/cmd/frpc/sub/reload.go
+++ b/cmd/frpc/sub/reload.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/fatedier/frp/client"
 	"github.com/fatedier/frp/g"
+	"github.com/fatedier/frp/models/config"
 )
 
 func init() {
@@ -37,7 +38,13 @@ var reloadCmd = &cobra.Command{
 	Use:   "reload",
 	Short: "Hot-Reload frpc configuration",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := parseClientCommonCfg(CfgFileTypeIni, cfgFile)
+		iniContent, err := config.GetRenderedConfFromFile(cfgFile)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		err = parseClientCommonCfg(CfgFileTypeIni, iniContent)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/cmd/frpc/sub/status.go
+++ b/cmd/frpc/sub/status.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/fatedier/frp/client"
 	"github.com/fatedier/frp/g"
+	"github.com/fatedier/frp/models/config"
 )
 
 func init() {
@@ -38,7 +39,13 @@ var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Overview of all proxies status",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := parseClientCommonCfg(CfgFileTypeIni, cfgFile)
+		iniContent, err := config.GetRenderedConfFromFile(cfgFile)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		err = parseClientCommonCfg(CfgFileTypeIni, iniContent)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)


### PR DESCRIPTION
frpc: fixup ini config parse problem in sub command `status` and `reload`

problem:
when run `frpc -c /path-to/frpc.ini status` or `frpc -c /path-to/frpc.ini reload`, 
we'll get the error result:
> parse ini conf file error: invalid INI syntax on line 1: /path-to/frpc.ini

since `func parseClientCommonCfg(fileType int, content string) (err error)` 
only accept **file content**, not a **filename**.

we should call `config.GetRenderedConfFromFile` first to avoid the problem.
just like the code in cmd/frpc/sub/root.go:
```go
	content, err = config.GetRenderedConfFromFile(cfgFilePath)
	if err != nil {
		return
	}
	g.GlbClientCfg.CfgFile = cfgFilePath

	err = parseClientCommonCfg(CfgFileTypeIni, content)
```
