### PR TITLE
Changed LoginFailExit to LoginFailRetry

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -75,16 +75,21 @@ func (svr *Service) GetController() *Control {
 
 func (svr *Service) Run() error {
 	// first login
+	retries := g.GlbClientCfg.LoginFailRetry
 	for {
 		conn, session, err := svr.login()
 		if err != nil {
 			log.Warn("login to server failed: %v", err)
 
-			// if login_fail_exit is true, just exit this program
+			// if retries exceeded login_fail_retry, just exit this program
 			// otherwise sleep a while and try again to connect to server
-			if g.GlbClientCfg.LoginFailExit {
+			if retries == 0 {
 				return err
 			} else {
+				//if retries < 0 we always retry
+				if retries > 0 {
+					retries--
+				}
 				time.Sleep(10 * time.Second)
 			}
 		} else {

--- a/conf/frpc_full.ini
+++ b/conf/frpc_full.ini
@@ -37,8 +37,13 @@ tcp_mux = true
 user = your_name
 
 # decide if exit program when first login failed, otherwise continuous relogin to frps
-# default is -1, meaning always retry. 0 exits after first fail, 5 retries 5 times...
-login_fail_retry = -1
+# default is true. Will be overridden by login_fail_retry
+login_fail_exit = true
+
+# decide if exit program when first login failed, otherwise continuous relogin to frps
+# default is 0, meaning exits after first failed attempt (and it's equivalent to login_fail_exit = true).
+# -1 never exits, 5 retries 5 times...
+login_fail_retry = 0
 
 # communication protocol used to connect to server
 # now it supports tcp and kcp and websocket, default is tcp

--- a/conf/frpc_full.ini
+++ b/conf/frpc_full.ini
@@ -37,8 +37,8 @@ tcp_mux = true
 user = your_name
 
 # decide if exit program when first login failed, otherwise continuous relogin to frps
-# default is true
-login_fail_exit = true
+# default is -1, meaning always retry. 0 exits after first fail, 5 retries 5 times...
+login_fail_retry = -1
 
 # communication protocol used to connect to server
 # now it supports tcp and kcp and websocket, default is tcp

--- a/models/config/client_common.go
+++ b/models/config/client_common.go
@@ -41,7 +41,7 @@ type ClientCommonConf struct {
 	TcpMux            bool                `json:"tcp_mux"`
 	User              string              `json:"user"`
 	DnsServer         string              `json:"dns_server"`
-	LoginFailExit     bool                `json:"login_fail_exit"`
+	LoginFailRetry    int                 `json:"login_fail_retry"`
 	Start             map[string]struct{} `json:"start"`
 	Protocol          string              `json:"protocol"`
 	HeartBeatInterval int64               `json:"heartbeat_interval"`
@@ -66,7 +66,7 @@ func GetDefaultClientConf() *ClientCommonConf {
 		TcpMux:            true,
 		User:              "",
 		DnsServer:         "",
-		LoginFailExit:     true,
+		LoginFailRetry:    -1,
 		Start:             make(map[string]struct{}),
 		Protocol:          "tcp",
 		HeartBeatInterval: 30,
@@ -179,10 +179,13 @@ func UnmarshalClientConfFromIni(defaultCfg *ClientCommonConf, content string) (c
 		}
 	}
 
-	if tmpStr, ok = conf.Get("common", "login_fail_exit"); ok && tmpStr == "false" {
-		cfg.LoginFailExit = false
-	} else {
-		cfg.LoginFailExit = true
+	if tmpStr, ok = conf.Get("common", "login_fail_retry"); ok {
+		v, err = strconv.ParseInt(tmpStr, 10, 0)
+		if err != nil {
+			err = fmt.Errorf("Parse conf error: invalid login_fail_retry")
+			return
+		}
+		cfg.LoginFailRetry = int(v)
 	}
 
 	if tmpStr, ok = conf.Get("common", "protocol"); ok {


### PR DESCRIPTION
When client attempts a connection to the server, attempts a certain amount of times before exiting.