### PR TITLE
api error fix due to status code

### DIFF
--- a/server/dashboard_api.go
+++ b/server/dashboard_api.go
@@ -279,6 +279,7 @@ func (svr *Service) getProxyStatsByTypeAndName(proxyType string, proxyName strin
 		proxyInfo.CurConns = ps.CurConns
 		proxyInfo.LastStartTime = ps.LastStartTime
 		proxyInfo.LastCloseTime = ps.LastCloseTime
+		code = 200
 	}
 
 	return


### PR DESCRIPTION
the status code was not updated on **api/proxy/:type/:name** API endpoint for successful responses. The API call fails because of the Code != 200.