### PR TITLE
增加frp docker版本

### DIFF
--- a/conf/openrc/frpc.sh
+++ b/conf/openrc/frpc.sh
@@ -1,0 +1,38 @@
+#!/sbin/openrc-run
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+pidfile="/run/frpc.pid"
+configfile="/etc/frp/frpc.ini"
+command="/usr/bin/frpc"
+command_opts=" -c $configfile"
+
+depend() {
+    need net
+    need localmount
+}
+
+start() {
+    ebegin "Starting frpc"
+    start-stop-daemon --start --background \
+    --exec $command \
+    -- $command_opts \
+    --make-pidfile --pidfile $pidfile
+    eend $?
+}
+
+stop() {
+    ebegin "Stopping frpc"
+    start-stop-daemon --stop \
+    --exec $command \
+    --pidfile $pidfile
+    eend $?
+}
+
+reload() {
+    ebegin "Reloading frpc"
+    start-stop-daemon --exec $command \
+    --pidfile $pidfile \
+    -s 1
+    eend $?
+}

--- a/conf/openrc/frpc.sh
+++ b/conf/openrc/frpc.sh
@@ -15,9 +15,9 @@ depend() {
 start() {
     ebegin "Starting frpc"
     start-stop-daemon --start --background \
+    --make-pidfile --pidfile $pidfile \
     --exec $command \
-    -- $command_opts \
-    --make-pidfile --pidfile $pidfile
+    -- $command_opts
     eend $?
 }
 

--- a/conf/openrc/frps.sh
+++ b/conf/openrc/frps.sh
@@ -1,0 +1,38 @@
+#!/sbin/openrc-run
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+pidfile="/run/frps.pid"
+configfile="/etc/frp/frps.ini"
+command="/usr/bin/frps"
+command_opts=" -c $configfile"
+
+depend() {
+    need net
+    need localmount
+}
+
+start() {
+    ebegin "Starting frps"
+    start-stop-daemon --start --background \
+    --exec $command \
+    -- $command_opts \
+    --make-pidfile --pidfile $pidfile
+    eend $?
+}
+
+stop() {
+    ebegin "Stopping frps"
+    start-stop-daemon --stop \
+    --exec $command \
+    --pidfile $pidfile
+    eend $?
+}
+
+reload() {
+    ebegin "Reloading frps"
+    start-stop-daemon --exec $command \
+    --pidfile $pidfile \
+    -s 1
+    eend $?
+}

--- a/conf/openrc/frps.sh
+++ b/conf/openrc/frps.sh
@@ -15,9 +15,9 @@ depend() {
 start() {
     ebegin "Starting frps"
     start-stop-daemon --start --background \
+    --make-pidfile --pidfile $pidfile \
     --exec $command \
-    -- $command_opts \
-    --make-pidfile --pidfile $pidfile
+    -- $command_opts
     eend $?
 }
 

--- a/docker/frpc/Dockerfile
+++ b/docker/frpc/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache openrc \
     &&  cp frpc /usr/bin/ \
     &&  mkdir -p /etc/frp \
     &&  cp frpc.ini /etc/frp \
+    &&  cd root \
     &&  rm frp_${FRP_VERSION}_linux_amd64.tar.gz \
     &&  rm -rf frp_${FRP_VERSION}_linux_amd64/ 
 

--- a/docker/frpc/Dockerfile
+++ b/docker/frpc/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.9
+
+ENV FRP_VERSION 0.24.1
+
+VOLUME [ “/sys/fs/cgroup” ]
+
+RUN apk add --no-cache openrc \
+    && cd root \
+    &&  wget -c https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/frp_${FRP_VERSION}_linux_amd64.tar.gz \
+    &&  tar zxvf frp_${FRP_VERSION}_linux_amd64.tar.gz  \
+    &&  cd frp_${FRP_VERSION}_linux_amd64/ \
+    &&  cp frpc /usr/bin/ \
+    &&  mkdir -p /etc/frp \
+    &&  cp frpc.ini /etc/frp \
+    &&  rm frp_${FRP_VERSION}_linux_amd64.tar.gz \
+    &&  rm -rf frp_${FRP_VERSION}_linux_amd64/ 
+
+ENTRYPOINT /usr/bin/frpc -c /etc/frp/frpc.ini

--- a/docker/frpc/Dockerfile
+++ b/docker/frpc/Dockerfile
@@ -5,14 +5,14 @@ ENV FRP_VERSION 0.24.1
 VOLUME [ “/sys/fs/cgroup” ]
 
 RUN apk add --no-cache openrc \
-    && cd root \
+    && cd /root \
     &&  wget -c https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/frp_${FRP_VERSION}_linux_amd64.tar.gz \
     &&  tar zxvf frp_${FRP_VERSION}_linux_amd64.tar.gz  \
     &&  cd frp_${FRP_VERSION}_linux_amd64/ \
     &&  cp frpc /usr/bin/ \
     &&  mkdir -p /etc/frp \
     &&  cp frpc.ini /etc/frp \
-    &&  cd root \
+    &&  cd /root \
     &&  rm frp_${FRP_VERSION}_linux_amd64.tar.gz \
     &&  rm -rf frp_${FRP_VERSION}_linux_amd64/ 
 

--- a/docker/frps/Dockerfile
+++ b/docker/frps/Dockerfile
@@ -5,14 +5,14 @@ ENV FRP_VERSION 0.24.1
 VOLUME [ “/sys/fs/cgroup” ]
 
 RUN apk add --no-cache openrc \
-    && cd root \
+    && cd /root \
     &&  wget -c https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/frp_${FRP_VERSION}_linux_amd64.tar.gz \
     &&  tar zxvf frp_${FRP_VERSION}_linux_amd64.tar.gz  \
     &&  cd frp_${FRP_VERSION}_linux_amd64/ \
     &&  cp frps /usr/bin/ \
     &&  mkdir -p /etc/frp \
     &&  cp frps.ini /etc/frp \
-    &&  cd root \
+    &&  cd /root \
     &&  rm frp_${FRP_VERSION}_linux_amd64.tar.gz \
     &&  rm -rf frp_${FRP_VERSION}_linux_amd64/ 
 

--- a/docker/frps/Dockerfile
+++ b/docker/frps/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.9
+
+ENV FRP_VERSION 0.24.1
+
+VOLUME [ “/sys/fs/cgroup” ]
+
+RUN apk add --no-cache openrc \
+    && cd root \
+    &&  wget -c https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/frp_${FRP_VERSION}_linux_amd64.tar.gz \
+    &&  tar zxvf frp_${FRP_VERSION}_linux_amd64.tar.gz  \
+    &&  cd frp_${FRP_VERSION}_linux_amd64/ \
+    &&  cp frps /usr/bin/ \
+    &&  mkdir -p /etc/frp \
+    &&  cp frps.ini /etc/frp \
+    &&  rm frp_${FRP_VERSION}_linux_amd64.tar.gz \
+    &&  rm -rf frp_${FRP_VERSION}_linux_amd64/ 
+
+ENTRYPOINT /usr/bin/frps -c /etc/frp/frps.ini

--- a/docker/frps/Dockerfile
+++ b/docker/frps/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache openrc \
     &&  cp frps /usr/bin/ \
     &&  mkdir -p /etc/frp \
     &&  cp frps.ini /etc/frp \
+    &&  cd root \
     &&  rm frp_${FRP_VERSION}_linux_amd64.tar.gz \
     &&  rm -rf frp_${FRP_VERSION}_linux_amd64/ 
 


### PR DESCRIPTION
1. 基于alpine:3.9打包frp的docker版本（分frpc和frps）
2. 增加openrc配置文件
