### PR TITLE
protocol = wss

### DIFF
--- a/cmd/frpc/sub/http.go
+++ b/cmd/frpc/sub/http.go
@@ -28,7 +28,7 @@ import (
 func init() {
 	httpCmd.PersistentFlags().StringVarP(&serverAddr, "server_addr", "s", "127.0.0.1:7000", "frp server's address")
 	httpCmd.PersistentFlags().StringVarP(&user, "user", "u", "", "user")
-	httpCmd.PersistentFlags().StringVarP(&protocol, "protocol", "p", "tcp", "tcp or kcp or websocket")
+	httpCmd.PersistentFlags().StringVarP(&protocol, "protocol", "p", "tcp", "tcp or kcp or websocket or wss")
 	httpCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "auth token")
 	httpCmd.PersistentFlags().StringVarP(&logLevel, "log_level", "", "info", "log level")
 	httpCmd.PersistentFlags().StringVarP(&logFile, "log_file", "", "console", "console or file path")

--- a/cmd/frpc/sub/https.go
+++ b/cmd/frpc/sub/https.go
@@ -28,7 +28,7 @@ import (
 func init() {
 	httpsCmd.PersistentFlags().StringVarP(&serverAddr, "server_addr", "s", "127.0.0.1:7000", "frp server's address")
 	httpsCmd.PersistentFlags().StringVarP(&user, "user", "u", "", "user")
-	httpsCmd.PersistentFlags().StringVarP(&protocol, "protocol", "p", "tcp", "tcp or kcp or websocket")
+	httpsCmd.PersistentFlags().StringVarP(&protocol, "protocol", "p", "tcp", "tcp or kcp or websocket or wss")
 	httpsCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "auth token")
 	httpsCmd.PersistentFlags().StringVarP(&logLevel, "log_level", "", "info", "log level")
 	httpsCmd.PersistentFlags().StringVarP(&logFile, "log_file", "", "console", "console or file path")

--- a/cmd/frpc/sub/stcp.go
+++ b/cmd/frpc/sub/stcp.go
@@ -27,7 +27,7 @@ import (
 func init() {
 	stcpCmd.PersistentFlags().StringVarP(&serverAddr, "server_addr", "s", "127.0.0.1:7000", "frp server's address")
 	stcpCmd.PersistentFlags().StringVarP(&user, "user", "u", "", "user")
-	stcpCmd.PersistentFlags().StringVarP(&protocol, "protocol", "p", "tcp", "tcp or kcp or websocket")
+	stcpCmd.PersistentFlags().StringVarP(&protocol, "protocol", "p", "tcp", "tcp or kcp or websocket or wss")
 	stcpCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "auth token")
 	stcpCmd.PersistentFlags().StringVarP(&logLevel, "log_level", "", "info", "log level")
 	stcpCmd.PersistentFlags().StringVarP(&logFile, "log_file", "", "console", "console or file path")

--- a/cmd/frpc/sub/udp.go
+++ b/cmd/frpc/sub/udp.go
@@ -27,7 +27,7 @@ import (
 func init() {
 	udpCmd.PersistentFlags().StringVarP(&serverAddr, "server_addr", "s", "127.0.0.1:7000", "frp server's address")
 	udpCmd.PersistentFlags().StringVarP(&user, "user", "u", "", "user")
-	udpCmd.PersistentFlags().StringVarP(&protocol, "protocol", "p", "tcp", "tcp or kcp or websocket")
+	udpCmd.PersistentFlags().StringVarP(&protocol, "protocol", "p", "tcp", "tcp or kcp or websocket or wss")
 	udpCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "auth token")
 	udpCmd.PersistentFlags().StringVarP(&logLevel, "log_level", "", "info", "log level")
 	udpCmd.PersistentFlags().StringVarP(&logFile, "log_file", "", "console", "console or file path")

--- a/cmd/frpc/sub/xtcp.go
+++ b/cmd/frpc/sub/xtcp.go
@@ -27,7 +27,7 @@ import (
 func init() {
 	xtcpCmd.PersistentFlags().StringVarP(&serverAddr, "server_addr", "s", "127.0.0.1:7000", "frp server's address")
 	xtcpCmd.PersistentFlags().StringVarP(&user, "user", "u", "", "user")
-	xtcpCmd.PersistentFlags().StringVarP(&protocol, "protocol", "p", "tcp", "tcp or kcp or websocket")
+	xtcpCmd.PersistentFlags().StringVarP(&protocol, "protocol", "p", "tcp", "tcp or kcp or websocket or wss")
 	xtcpCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "auth token")
 	xtcpCmd.PersistentFlags().StringVarP(&logLevel, "log_level", "", "info", "log level")
 	xtcpCmd.PersistentFlags().StringVarP(&logFile, "log_file", "", "console", "console or file path")

--- a/conf/frpc_full.ini
+++ b/conf/frpc_full.ini
@@ -46,7 +46,7 @@ user = your_name
 login_fail_exit = true
 
 # communication protocol used to connect to server
-# now it supports tcp and kcp and websocket, default is tcp
+# now it supports tcp and kcp and websocket and wss, default is tcp
 protocol = tcp
 
 # if tls_enable is true, frpc will connect frps by tls

--- a/conf/frps_full.ini
+++ b/conf/frps_full.ini
@@ -71,3 +71,6 @@ tcp_mux = true
 
 # custom 404 page for HTTP requests
 # custom_404_page = /path/to/404.html
+
+wss_crt_path = ./wss.crt
+wss_key_path = ./wss.key

--- a/models/config/client_common.go
+++ b/models/config/client_common.go
@@ -264,7 +264,7 @@ func UnmarshalClientConfFromIni(content string) (cfg ClientCommonConf, err error
 
 	if tmpStr, ok = conf.Get("common", "protocol"); ok {
 		// Now it only support tcp and kcp and websocket.
-		if tmpStr != "tcp" && tmpStr != "kcp" && tmpStr != "websocket" {
+		if tmpStr != "tcp" && tmpStr != "kcp" && tmpStr != "websocket" && tmpStr != "wss" {
 			err = fmt.Errorf("Parse conf error: invalid protocol")
 			return
 		}

--- a/server/service.go
+++ b/server/service.go
@@ -161,10 +161,10 @@ func NewService(cfg config.ServerCommonConf) (svr *Service, err error) {
 	svr.websocketListener = frpNet.NewWebsocketListener(websocketLn)
 
 	// frp wss listener
-	wssListener := svr.muxer.Listen(1, 1, func(data []byte) bool {
+	wssLn := svr.muxer.Listen(1, 1, func(data []byte) bool {
 		return int(data[0]) == 0x16
 	})
-	svr.wssListener = frpNet.NewWssListener(wssListener)
+	svr.wssListener = frpNet.NewWssListener(wssLn)
 
 	// Create http vhost muxer.
 	if cfg.VhostHttpPort > 0 {

--- a/server/service.go
+++ b/server/service.go
@@ -67,6 +67,9 @@ type Service struct {
 	// Accept connections using websocket
 	websocketListener net.Listener
 
+	// Accept connections using wss
+	wssListener frpNet.Listener
+
 	// Accept frp tls connections
 	tlsListener net.Listener
 
@@ -156,6 +159,12 @@ func NewService(cfg config.ServerCommonConf) (svr *Service, err error) {
 		return bytes.Equal(data, websocketPrefix)
 	})
 	svr.websocketListener = frpNet.NewWebsocketListener(websocketLn)
+
+	// frp wss listener
+	wssListener := svr.muxer.Listen(1, 1, func(data []byte) bool {
+		return int(data[0]) == 0x16
+	})
+	svr.wssListener = frpNet.NewWssListener(wssListener)
 
 	// Create http vhost muxer.
 	if cfg.VhostHttpPort > 0 {

--- a/utils/net/conn.go
+++ b/utils/net/conn.go
@@ -223,7 +223,7 @@ func ConnectServerByProxy(proxyURL string, protocol string, addr string) (c net.
 	case "websocket":
 		return ConnectWebsocketServer(addr, "http", "ws")
 	case "wss":
-		return ConnectWebsocketServer(addr, "https", "wss")
+		return ConnectWssServer(addr, "https", "wss")
 	default:
 		return nil, fmt.Errorf("unsupport protocol: %s", protocol)
 	}

--- a/utils/net/conn.go
+++ b/utils/net/conn.go
@@ -221,7 +221,9 @@ func ConnectServerByProxy(proxyURL string, protocol string, addr string) (c net.
 		// http proxy is not supported for kcp
 		return ConnectServer(protocol, addr)
 	case "websocket":
-		return ConnectWebsocketServer(addr)
+		return ConnectWebsocketServer(addr, "http", "ws")
+	case "wss":
+		return ConnectWebsocketServer(addr, "https", "wss")
 	default:
 		return nil, fmt.Errorf("unsupport protocol: %s", protocol)
 	}

--- a/utils/net/websocket.go
+++ b/utils/net/websocket.go
@@ -79,14 +79,14 @@ func (p *WebsocketListener) Addr() net.Addr {
 }
 
 // addr: domain:port
-func ConnectWebsocketServer(addr string) (net.Conn, error) {
-	addr = "ws://" + addr + FrpWebsocketPath
+func ConnectWebsocketServer(addr string, httpProtocol string, wsProtocol string) (net.Conn, error) {
+	addr = wsProtocol + "://" + addr + FrpWebsocketPath
 	uri, err := url.Parse(addr)
 	if err != nil {
 		return nil, err
 	}
 
-	origin := "http://" + uri.Host
+	origin := httpProtocol + "://" + uri.Host
 	cfg, err := websocket.NewConfig(addr, origin)
 	if err != nil {
 		return nil, err

--- a/utils/net/wss.go
+++ b/utils/net/wss.go
@@ -1,6 +1,7 @@
 package net
 
 import (
+	// "crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -9,7 +10,7 @@ import (
 	"time"
 
 	"github.com/fatedier/frp/utils/log"
-
+	
 	"golang.org/x/net/websocket"
 )
 
@@ -50,9 +51,8 @@ func NewWssListener(ln net.Listener) (wl *WssListener) {
 		Addr:    ln.Addr().String(),
 		Handler: muxer,
 	}
-
-	certFile := "a.cert"
-	keyFile := "a.key"
+	certFile := "a_cert.pem"
+	keyFile := "a_key.pem"
 
 	go wl.server.ServeTLS(ln, certFile, keyFile)
 	return
@@ -95,6 +95,10 @@ func ConnectWssServer(addr string, httpProtocol string, wsProtocol string) (Conn
 	cfg.Dialer = &net.Dialer{
 		Timeout: 10 * time.Second,
 	}
+
+	// cfg.TlsConfig = &tls.Config{
+	// 	InsecureSkipVerify: true,
+	// }
 
 	conn, err := websocket.DialConfig(cfg)
 	if err != nil {

--- a/utils/net/wss.go
+++ b/utils/net/wss.go
@@ -1,0 +1,105 @@
+package net
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/fatedier/frp/utils/log"
+
+	"golang.org/x/net/websocket"
+)
+
+var (
+	ErrWssListenerClosed = errors.New("wss listener closed")
+)
+
+type WssListener struct {
+	net.Addr
+	ln     net.Listener
+	accept chan Conn
+	log.Logger
+
+	server    *http.Server
+	httpMutex *http.ServeMux
+}
+
+// NewWssListener to handle wss connections
+// ln: tcp listener for wss connections
+func NewWssListener(ln net.Listener) (wl *WssListener) {
+	wl = &WssListener{
+		Addr:   ln.Addr(),
+		accept: make(chan Conn),
+		Logger: log.NewPrefixLogger(""),
+	}
+
+	muxer := http.NewServeMux()
+	muxer.Handle(FrpWebsocketPath, websocket.Handler(func(c *websocket.Conn) {
+		notifyCh := make(chan struct{})
+		conn := WrapCloseNotifyConn(c, func() {
+			close(notifyCh)
+		})
+		wl.accept <- conn
+		<-notifyCh
+	}))
+
+	wl.server = &http.Server{
+		Addr:    ln.Addr().String(),
+		Handler: muxer,
+	}
+
+	certFile := "a.cert"
+	keyFile := "a.key"
+
+	go wl.server.ServeTLS(ln, certFile, keyFile)
+	return
+}
+
+func ListenWss(bindAddr string, bindPort int) (*WssListener, error) {
+	tcpLn, err := net.Listen("tcp", fmt.Sprintf("%s:%d", bindAddr, bindPort))
+	if err != nil {
+		return nil, err
+	}
+	l := NewWssListener(tcpLn)
+	return l, nil
+}
+
+func (p *WssListener) Accept() (Conn, error) {
+	c, ok := <-p.accept
+	if !ok {
+		return nil, ErrWssListenerClosed
+	}
+	return c, nil
+}
+
+func (p *WssListener) Close() error {
+	return p.server.Close()
+}
+
+// addr: domain:port
+func ConnectWssServer(addr string, httpProtocol string, wsProtocol string) (Conn, error) {
+	addr = wsProtocol + "://" + addr + FrpWebsocketPath
+	uri, err := url.Parse(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	origin := httpProtocol + "://" + uri.Host
+	cfg, err := websocket.NewConfig(addr, origin)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Dialer = &net.Dialer{
+		Timeout: 10 * time.Second,
+	}
+
+	conn, err := websocket.DialConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	c := WrapConn(conn)
+	return c, nil
+}


### PR DESCRIPTION
websocketsecure support in frpc

It should fix https://github.com/fatedier/frp/issues/1161

frpc.ini
[common]
server_addr =  经cloudflare中转的域名
server_port = 443
protocol = wss

frps.ini
[common]
bind_port = 80

or behind traefik with https valid certificate such as acme

https://support.cloudflare.com/hc/zh-cn/articles/200170416-SSL-%E9%80%89%E9%A1%B9%E6%98%AF%E6%89%80%E6%8C%87%E7%9A%84%E6%98%AF%E4%BB%80%E4%B9%88-

Flexible （灵活） SSL：访问者与 Cloudflare 之间使用安全连接，但 Cloudflare 与您的源服务器之间没有安全连接。您的 Web 服务器不需要拥有 SSL 证书，但访问者仍然会浏览该网站的 HTTPS版本。如果您的网站上有任何敏感信息，并不建议使用此选项。此设置仅适用于端口 443-> 80，而不适用于我们支持的其他端口，如 2053。
