### PR TITLE
Load assets for dashboard/admin panel on demand

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -52,13 +52,6 @@ type Service struct {
 }
 
 func NewService(pxyCfgs map[string]config.ProxyConf, visitorCfgs map[string]config.VisitorConf) (svr *Service, err error) {
-	// Init assets
-	err = assets.Load("")
-	if err != nil {
-		err = fmt.Errorf("Load assets error: %v", err)
-		return
-	}
-
 	svr = &Service{
 		pxyCfgs:     pxyCfgs,
 		visitorCfgs: visitorCfgs,
@@ -102,7 +95,13 @@ func (svr *Service) Run() error {
 	go svr.keepControllerWorking()
 
 	if g.GlbClientCfg.AdminPort != 0 {
-		err := svr.RunAdminServer(g.GlbClientCfg.AdminAddr, g.GlbClientCfg.AdminPort)
+		// Init admin server assets
+		err := assets.Load("")
+		if err != nil {
+			return fmt.Errorf("Load assets error: %v", err)
+		}
+
+		err = svr.RunAdminServer(g.GlbClientCfg.AdminAddr, g.GlbClientCfg.AdminPort)
 		if err != nil {
 			log.Warn("run admin server error: %v", err)
 		}

--- a/server/service.go
+++ b/server/service.go
@@ -108,13 +108,6 @@ func NewService() (svr *Service, err error) {
 	// Init HTTP group controller
 	svr.rc.HTTPGroupCtl = group.NewHTTPGroupController(svr.httpVhostRouter)
 
-	// Init assets
-	err = assets.Load(cfg.AssetsDir)
-	if err != nil {
-		err = fmt.Errorf("Load assets error: %v", err)
-		return
-	}
-
 	// Init 404 not found page
 	vhost.NotFoundPagePath = cfg.Custom404Page
 
@@ -231,6 +224,13 @@ func NewService() (svr *Service, err error) {
 	var statsEnable bool
 	// Create dashboard web server.
 	if cfg.DashboardPort > 0 {
+		// Init dashboard assets
+		err = assets.Load(cfg.AssetsDir)
+		if err != nil {
+			err = fmt.Errorf("Load assets error: %v", err)
+			return
+		}
+
 		err = svr.RunDashboardServer(cfg.DashboardAddr, cfg.DashboardPort)
 		if err != nil {
 			err = fmt.Errorf("Create dashboard web server error, %v", err)


### PR DESCRIPTION
(This PR contains the same changes as #1391, but now is based off the dev branch instead of master)

The client and server services now only attempt to load assets if the dashboard or admin panel are enabled. This change makes it possible to use FRP as a library without having to manage assets.

If a library user wants to start a server with the dashboard enabled, they will need to set the DashboardPort and AssetsDir fields of ServerCommonConf.

If a library use wants to start a client with the admin panel enabled, that isn't currently possible because there's no way to customize the admin panel's assets directory. I can send a PR for that as well if there's interest.

Related: #1387