### PR TITLE
 Add an "assets_dir" option for frpc

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -96,7 +96,7 @@ func (svr *Service) Run() error {
 
 	if g.GlbClientCfg.AdminPort != 0 {
 		// Init admin server assets
-		err := assets.Load("")
+		err := assets.Load(g.GlbClientCfg.AssetsDir)
 		if err != nil {
 			return fmt.Errorf("Load assets error: %v", err)
 		}

--- a/client/service.go
+++ b/client/service.go
@@ -52,13 +52,6 @@ type Service struct {
 }
 
 func NewService(pxyCfgs map[string]config.ProxyConf, visitorCfgs map[string]config.VisitorConf) (svr *Service, err error) {
-	// Init assets
-	err = assets.Load("")
-	if err != nil {
-		err = fmt.Errorf("Load assets error: %v", err)
-		return
-	}
-
 	svr = &Service{
 		pxyCfgs:     pxyCfgs,
 		visitorCfgs: visitorCfgs,
@@ -102,7 +95,13 @@ func (svr *Service) Run() error {
 	go svr.keepControllerWorking()
 
 	if g.GlbClientCfg.AdminPort != 0 {
-		err := svr.RunAdminServer(g.GlbClientCfg.AdminAddr, g.GlbClientCfg.AdminPort)
+		// Init admin server assets
+		err := assets.Load("")
+		if err != nil {
+			return fmt.Errorf("Load assets error: %v", err)
+		}
+
+		err = svr.RunAdminServer(g.GlbClientCfg.AdminAddr, g.GlbClientCfg.AdminPort)
 		if err != nil {
 			log.Warn("run admin server error: %v", err)
 		}

--- a/conf/frpc_full.ini
+++ b/conf/frpc_full.ini
@@ -29,6 +29,8 @@ admin_addr = 127.0.0.1
 admin_port = 7400
 admin_user = admin
 admin_pwd = admin
+# Admin assets directory. By default, these assets are bundled with frpc.
+# assets_dir = ./static
 
 # connections will be established in advance, default value is zero
 pool_count = 5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatedier/beego v0.0.0-20171024143340-6c6a4f5bd5eb h1:wCrNShQidLmvVWn/0PikGmpdP0vtQmnvyRg3ZBEhczw=
 github.com/fatedier/beego v0.0.0-20171024143340-6c6a4f5bd5eb/go.mod h1:wx3gB6dbIfBRcucp94PI9Bt3I0F2c/MyNEWuhzpWiwk=
@@ -27,6 +28,7 @@ github.com/pires/go-proxyproto v0.0.0-20190111085350-4d51b51e3bfc h1:lNOt1SMsgHX
 github.com/pires/go-proxyproto v0.0.0-20190111085350-4d51b51e3bfc/go.mod h1:6/gX3+E/IYGa0wMORlSMla999awQFdbaeQCHjSMKIzY=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rakyll/statik v0.1.1 h1:fCLHsIMajHqD5RKigbFXpvX3dN7c80Pm12+NCrI3kvg=
 github.com/rakyll/statik v0.1.1/go.mod h1:OEi9wJV/fMUAGx1eNjq75DKDsJVuEv1U0oYdX6GX8Zs=

--- a/models/config/client_common.go
+++ b/models/config/client_common.go
@@ -38,6 +38,7 @@ type ClientCommonConf struct {
 	AdminPort         int                 `json:"admin_port"`
 	AdminUser         string              `json:"admin_user"`
 	AdminPwd          string              `json:"admin_pwd"`
+	AssetsDir         string              `json:"assets_dir"`
 	PoolCount         int                 `json:"pool_count"`
 	TcpMux            bool                `json:"tcp_mux"`
 	User              string              `json:"user"`
@@ -65,6 +66,7 @@ func GetDefaultClientConf() *ClientCommonConf {
 		AdminPort:         0,
 		AdminUser:         "",
 		AdminPwd:          "",
+		AssetsDir:         "",
 		PoolCount:         1,
 		TcpMux:            true,
 		User:              "",
@@ -158,6 +160,10 @@ func UnmarshalClientConfFromIni(defaultCfg *ClientCommonConf, content string) (c
 
 	if tmpStr, ok = conf.Get("common", "admin_pwd"); ok {
 		cfg.AdminPwd = tmpStr
+	}
+
+	if tmpStr, ok = conf.Get("common", "assets_dir"); ok {
+		cfg.AssetsDir = tmpStr
 	}
 
 	if tmpStr, ok = conf.Get("common", "pool_count"); ok {

--- a/server/service.go
+++ b/server/service.go
@@ -108,13 +108,6 @@ func NewService() (svr *Service, err error) {
 	// Init HTTP group controller
 	svr.rc.HTTPGroupCtl = group.NewHTTPGroupController(svr.httpVhostRouter)
 
-	// Init assets
-	err = assets.Load(cfg.AssetsDir)
-	if err != nil {
-		err = fmt.Errorf("Load assets error: %v", err)
-		return
-	}
-
 	// Init 404 not found page
 	vhost.NotFoundPagePath = cfg.Custom404Page
 
@@ -231,6 +224,13 @@ func NewService() (svr *Service, err error) {
 	var statsEnable bool
 	// Create dashboard web server.
 	if cfg.DashboardPort > 0 {
+		// Init dashboard assets
+		err = assets.Load(cfg.AssetsDir)
+		if err != nil {
+			err = fmt.Errorf("Load assets error: %v", err)
+			return
+		}
+
 		err = svr.RunDashboardServer(cfg.DashboardAddr, cfg.DashboardPort)
 		if err != nil {
 			err = fmt.Errorf("Create dashboard web server error, %v", err)


### PR DESCRIPTION
This option allows users to specify where they want assets to be loaded from, like the "assets_dir" option that already exists for frps. This allows library users to use the admin panel without having to bundle assets with statik.

This PR is based off of the branch from #1395, so that PR should be reviewed first.

Related: #1387 