### PR TITLE
更新 Systemd 服务配置

### DIFF
--- a/conf/systemd/frpc.service
+++ b/conf/systemd/frpc.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=Frp Client Service
 After=network.target
+StartLimitIntervalSec=3
 
 [Service]
-Type=simple
+Type=idle
 User=nobody
 Restart=on-failure
 RestartSec=5s

--- a/conf/systemd/frpc@.service
+++ b/conf/systemd/frpc@.service
@@ -1,12 +1,14 @@
 [Unit]
-Description=Frp Client Service
+Description=Frp Client Service (%i)
 After=network.target
+StartLimitIntervalSec=3
 
 [Service]
 Type=idle
 User=nobody
 Restart=on-failure
 RestartSec=5s
+ExecStartPre=/bin/test -s /etc/frp/%i.ini
 ExecStart=/usr/bin/frpc -c /etc/frp/%i.ini
 ExecReload=/usr/bin/frpc reload -c /etc/frp/%i.ini
 

--- a/conf/systemd/frps.service
+++ b/conf/systemd/frps.service
@@ -1,12 +1,14 @@
 [Unit]
 Description=Frp Server Service
 After=network.target
+StartLimitIntervalSec=3
 
 [Service]
 Type=simple
 User=nobody
 Restart=on-failure
 RestartSec=5s
+ExecStartPre=/bin/test -s /etc/frp/frps.ini
 ExecStart=/usr/bin/frps -c /etc/frp/frps.ini
 
 [Install]

--- a/conf/systemd/frps@.service
+++ b/conf/systemd/frps@.service
@@ -1,12 +1,14 @@
 [Unit]
-Description=Frp Server Service
+Description=Frp Server Service (%i)
 After=network.target
+StartLimitIntervalSec=3
 
 [Service]
 Type=simple
 User=nobody
 Restart=on-failure
 RestartSec=5s
+ExecStartPre=/bin/test -s /etc/frp/%i.ini
 ExecStart=/usr/bin/frps -c /etc/frp/%i.ini
 
 [Install]


### PR DESCRIPTION
修改：

- 对于模板化实例 (`frpc@` 和 `frps@`)，在 Description 中显示实例名
- 将 `frpc` 的服务类型改为 idle，防止卡启动等
- 在启动 frpc 和 frps 实例之前检查配置文件存在且非空（要是能提供一个 test-config 之类的命令就好了，例如 `nginx -t` 和 `sshd -t` 这样）