### PR TITLE
fix: send server plugin request as json

### DIFF
--- a/models/plugin/server/http.go
+++ b/models/plugin/server/http.go
@@ -84,6 +84,7 @@ func (p *httpPlugin) do(ctx context.Context, r *Request, res *Response) error {
 	}
 	req = req.WithContext(ctx)
 	req.Header.Set("X-Frp-Reqid", GetReqidFromContext(ctx))
+	req.Header.Set("Content-Type", "application/json")
 	resp, err := p.client.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
Currently the request is being sent as Content-Type: `application/octet-stream` which is identified by web servers as a binary upload.