### PR TITLE
Support Windows services

### DIFF
--- a/cmd/frpc/main.go
+++ b/cmd/frpc/main.go
@@ -22,11 +22,40 @@ import (
 	"github.com/fatedier/frp/cmd/frpc/sub"
 
 	"github.com/fatedier/golib/crypto"
+	"github.com/kardianos/service"
+	"os"
+	"path/filepath"
 )
 
 func main() {
 	crypto.DefaultSalt = "frp"
 	rand.Seed(time.Now().UnixNano())
 
-	sub.Execute()
+	svcConfig := &service.Config{
+		Name:	"FRPC",
+	}
+	prg := &FRPC{}
+	s, err := service.New(prg, svcConfig)
+	if err != nil {
+		sub.Execute()
+		return
+	}
+	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	err = os.Chdir(dir)
+	_ = s.Run()
+}
+
+type FRPC struct {}
+
+func (p *FRPC) Start(s service.Service) error {
+	_, _ = s.Status()
+	go sub.Execute()
+	return nil
+}
+func (p *FRPC) Stop(s service.Service) error {
+	_, _ = s.Status()
+	if service.Interactive() {
+		os.Exit(0)
+	}
+	return nil
 }

--- a/cmd/frps/main.go
+++ b/cmd/frps/main.go
@@ -22,11 +22,42 @@ import (
 
 	_ "github.com/fatedier/frp/assets/frps/statik"
 	_ "github.com/fatedier/frp/models/metrics"
+	"github.com/kardianos/service"
+	"os"
+	"path/filepath"
 )
 
 func main() {
 	crypto.DefaultSalt = "frp"
 	rand.Seed(time.Now().UnixNano())
 
-	Execute()
+		svcConfig := &service.Config{
+		Name:	"FRPS",
+	}
+	prg := &FRPS{}
+	s, err := service.New(prg, svcConfig)
+	if err != nil {
+		Execute()
+		return
+	}
+
+	dir, err := filepath.Abs(filepath.Dir(os.Args[0])) //chang workdir
+	err = os.Chdir(dir)
+	_ = s.Run()
+}
+
+type FRPS struct {}
+
+func (p *FRPS) Start(s service.Service) error {
+	_, _ = s.Status()
+	go Execute()
+	return nil
+}
+
+func (p *FRPS) Stop(s service.Service) error {
+	_, _ = s.Status()
+	if service.Interactive() {
+		os.Exit(0)
+	}
+	return nil
 }


### PR DESCRIPTION
对于not Windows系统的部署可以使用额外的脚本，但是对于windows服务来说确实有些许不一样。
即使使用sc工具添加到系统服务，也需要frp本身支持，稍微改了一下，默认工作路径为当前程序所在目录

安装到系统服务可以使用类似于
sc create FRPS binPath= "%CD%\FRPS.exe -c frps.ini" start= demand

#1745