### PR TITLE
support non-preemptive authentication

### DIFF
--- a/models/plugin/client/http_proxy.go
+++ b/models/plugin/client/http_proxy.go
@@ -231,6 +231,7 @@ func removeProxyHeaders(req *http.Request) {
 func getBadResponse() *http.Response {
 	header := make(map[string][]string)
 	header["Proxy-Authenticate"] = []string{"Basic"}
+	header["Connection"] = []string{"close"}
 	res := &http.Response{
 		Status:     "407 Not authorized",
 		StatusCode: 407,


### PR DESCRIPTION
Non-preemptive authentication means that the Proxy-Authorization will not be actively sent when the tunnel is established, and this authentication will be brought after receiving the 407 response.

The server will now directly close the connection when the proxy verification fails, and the client will still send a request on this connection without knowing it, causing the client to report an error.
Therefore, you should explicitly return close when closing the connection.

In [rfc7230#Connection](https://tools.ietf.org/html/rfc7230#section-6.1)

> A server that does not support persistent connections MUST send the
   "close" connection option in every response message that does not
   have a 1xx (Informational) status code.

![img](https://i.loli.net/2020/06/15/WVdSQg8ZncKbzMH.png)