### PR TITLE
fix create tls work connection

### DIFF
--- a/client/control.go
+++ b/client/control.go
@@ -211,10 +211,11 @@ func (ctl *Control) connectServer() (conn net.Conn, err error) {
 		var tlsConfig *tls.Config
 
 		if ctl.clientCfg.TLSEnable {
-			tlsConfig, err = transport.NewServerTLSConfig(
+			tlsConfig, err = transport.NewClientTLSConfig(
 				ctl.clientCfg.TLSCertFile,
 				ctl.clientCfg.TLSKeyFile,
-				ctl.clientCfg.TLSTrustedCaFile)
+				ctl.clientCfg.TLSTrustedCaFile,
+				ctl.clientCfg.ServerAddr)
 
 			if err != nil {
 				xl.Warn("fail to build tls configuration when connecting to server, err: %v", err)


### PR DESCRIPTION
Resolve #2007

0.34.0创建tls工作连接有问题，重现步骤：

### frps.ini
```
[common]
bind_port = 7000
log_level = trace
token = xxx
tcp_mux = false
tls_only = true
tls_cert_file = tls.crt
tls_key_file = tls.key
```

### frpc.ini
```
[common]
server_addr = some.domain.com
server_port = 7000
token = xxx
log_level = trace
tcp_mux = false
tls_enable = true
tls_trusted_ca_file = ca.crt

[web]
type = tcp
local_ip = 127.0.0.1
local_port = 8080
remote_port = 28080

```

### frpc logs
```
2020/09/29 14:00:00 [I] [service.go:288] [20a8b38f554e9ef0] login to server success, get run id [20a8b38f554e9ef0], server udp port [0]
2020/09/29 14:00:00 [I] [proxy_manager.go:144] [20a8b38f554e9ef0] proxy added: [web]
2020/09/29 14:00:00 [T] [proxy_wrapper.go:171] [20a8b38f554e9ef0] [web] change status from [new] to [wait start]
2020/09/29 14:00:00 [I] [control.go:180] [20a8b38f554e9ef0] [web] start proxy success
2020/09/29 14:00:00 [W] [control.go:151] [20a8b38f554e9ef0] work connection write to server error: tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config
```