### PR TITLE
reduce docker image size

### DIFF
--- a/dockerfiles/Dockerfile-for-frpc
+++ b/dockerfiles/Dockerfile-for-frpc
@@ -1,9 +1,14 @@
+FROM alpine:3.12.0 AS temp
+
+ADD bin/frpc /tmp
+
+RUN chmod -R 777 /tmp/frpc
+
+
 FROM alpine:3.12.0
 
 WORKDIR /app
 
-ADD bin/frpc /usr/bin
-
-RUN chmod -R 777 /usr/bin/frpc
+COPY --from=temp /tmp/frpc /usr/bin
 
 ENTRYPOINT ["/usr/bin/frpc"]

--- a/dockerfiles/Dockerfile-for-frpc
+++ b/dockerfiles/Dockerfile-for-frpc
@@ -1,6 +1,6 @@
 FROM alpine:3.12.0 AS temp
 
-ADD bin/frpc /tmp
+COPY bin/frpc /tmp
 
 RUN chmod -R 777 /tmp/frpc
 

--- a/dockerfiles/Dockerfile-for-frps
+++ b/dockerfiles/Dockerfile-for-frps
@@ -1,6 +1,6 @@
 FROM alpine:3.12.0 AS temp
 
-ADD bin/frps /tmp
+COPY bin/frps /tmp
 
 RUN chmod -R 777 /tmp/frps
 

--- a/dockerfiles/Dockerfile-for-frps
+++ b/dockerfiles/Dockerfile-for-frps
@@ -1,9 +1,14 @@
+FROM alpine:3.12.0 AS temp
+
+ADD bin/frps /tmp
+
+RUN chmod -R 777 /tmp/frps
+
+
 FROM alpine:3.12.0
 
 WORKDIR /app
 
-ADD bin/frps /usr/bin
-
-RUN chmod -R 777 /usr/bin/frps
+COPY --from=temp /tmp/frps /usr/bin
 
 ENTRYPOINT ["/usr/bin/frps"]


### PR DESCRIPTION
缩小docker镜像体积
实际上`ADD`和`RUN chmod`会添加两层重复的数据

### 优化前
```
$ docker images | grep fatedier/frp
fatedier/frps                          v0.34.0                          b9f2e995389b        5 days ago          34.3MB
fatedier/frpc                          v0.34.0                          dcad2637a36e        5 days ago          27.8MB
```
### 优化后
```
$ docker images | grep new/frp
new/frps                          v0.34.0                          9d35ba17f07d        8 minutes ago       18.8MB
new/frpc                          v0.34.0                          dea6506a0e30        8 minutes ago       15.5MB
```