### PR TITLE
tweak logs: show what config frps uses (config file / command line)

### DIFF
--- a/cmd/frps/root.go
+++ b/cmd/frps/root.go
@@ -105,6 +105,7 @@ var rootCmd = &cobra.Command{
 		var cfg config.ServerCommonConf
 		var err error
 		if cfgFile != "" {
+			log.Info("frps uses config file: %s", cfgFile)
 			var content string
 			content, err = config.GetRenderedConfFromFile(cfgFile)
 			if err != nil {
@@ -112,6 +113,7 @@ var rootCmd = &cobra.Command{
 			}
 			cfg, err = parseServerCommonCfg(CfgFileTypeIni, content)
 		} else {
+			log.Info("frps uses command line arguments for config")
 			cfg, err = parseServerCommonCfg(CfgFileTypeCmd, "")
 		}
 		if err != nil {
@@ -212,7 +214,7 @@ func runServer(cfg config.ServerCommonConf) (err error) {
 	if err != nil {
 		return err
 	}
-	log.Info("start frps success")
+	log.Info("frps started successfully")
 	svr.Run()
 	return
 }


### PR DESCRIPTION
* show what config frps uses (config file / command line)
* optimize the "start successfully" log message

To make the behavior more clear (#2099)

Now the logs look like this:

```
2020/11/23 16:45:32 [I] [root.go:116] frps uses command line arguments for config
2020/11/23 16:45:32 [I] [service.go:190] frps tcp listen on 0.0.0.0:7000
2020/11/23 16:45:32 [I] [root.go:217] frps started successfully
```