### PR TITLE
Allow server plugin to talk to https services. Option for skipping tls verification

### DIFF
--- a/doc/server_plugin.md
+++ b/doc/server_plugin.md
@@ -209,9 +209,10 @@ path = /handler
 ops = NewProxy
 ```
 
-addr: the address where the external RPC service listens on.
-path: http request url path for the POST request.
-ops: operations plugin needs to handle (e.g. "Login", "NewProxy", ...).
+- addr: the address where the external RPC service listens. Defaults to http. For https, specify the schema: `addr = https://127.0.0.1:9001`.
+- path: http request url path for the POST request.
+- ops: operations plugin needs to handle (e.g. "Login", "NewProxy", ...).
+- tls_verify: When the schema is https, we verify by default. Set this value to false if you want to skip verification.
 
 ### Metadata
 

--- a/pkg/config/server_common.go
+++ b/pkg/config/server_common.go
@@ -458,11 +458,16 @@ func UnmarshalPluginsFromIni(sections ini.File, cfg *ServerCommonConf) {
 	for name, section := range sections {
 		if strings.HasPrefix(name, "plugin.") {
 			name = strings.TrimSpace(strings.TrimPrefix(name, "plugin."))
+			var tls_verify, err = strconv.ParseBool(section["tls_verify"])
+			if err != nil {
+				tls_verify = true
+			}
 			options := plugin.HTTPPluginOptions{
-				Name: name,
-				Addr: section["addr"],
-				Path: section["path"],
-				Ops:  strings.Split(section["ops"], ","),
+				Name:      name,
+				Addr:      section["addr"],
+				Path:      section["path"],
+				Ops:       strings.Split(section["ops"], ","),
+				TlsVerify: tls_verify,
 			}
 			for i := range options.Ops {
 				options.Ops[i] = strings.TrimSpace(options.Ops[i])

--- a/pkg/config/server_common.go
+++ b/pkg/config/server_common.go
@@ -467,7 +467,7 @@ func UnmarshalPluginsFromIni(sections ini.File, cfg *ServerCommonConf) {
 				Addr:      section["addr"],
 				Path:      section["path"],
 				Ops:       strings.Split(section["ops"], ","),
-				TlsVerify: tls_verify,
+				TLSVerify: tls_verify,
 			}
 			for i := range options.Ops {
 				options.Ops[i] = strings.TrimSpace(options.Ops[i])

--- a/pkg/plugin/server/http.go
+++ b/pkg/plugin/server/http.go
@@ -43,17 +43,18 @@ type httpPlugin struct {
 }
 
 func NewHTTPPluginOptions(options HTTPPluginOptions) Plugin {
+	var url = fmt.Sprintf("%s%s", options.Addr, options.Path)
+
 	var client *http.Client
-	if options.TLSVerify == false {
+	if strings.HasPrefix(url, "https://") {
 		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: options.TLSVerify == false},
 		}
 		client = &http.Client{Transport: tr}
 	} else {
 		client = &http.Client{}
 	}
 
-	var url = fmt.Sprintf("%s%s", options.Addr, options.Path)
 	if !strings.HasPrefix(url, "https://") && !strings.HasPrefix(url, "http://") {
 		url = "http://" + url
 	}

--- a/pkg/plugin/server/http.go
+++ b/pkg/plugin/server/http.go
@@ -32,7 +32,7 @@ type HTTPPluginOptions struct {
 	Addr      string
 	Path      string
 	Ops       []string
-	TlsVerify bool
+	TLSVerify bool
 }
 
 type httpPlugin struct {
@@ -44,7 +44,7 @@ type httpPlugin struct {
 
 func NewHTTPPluginOptions(options HTTPPluginOptions) Plugin {
 	var client *http.Client
-	if options.TlsVerify == false {
+	if options.TLSVerify == false {
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}


### PR DESCRIPTION
This is in relation to https://github.com/fatedier/frp/issues/2102. It allows me to use the following server plugin config to talk to a https service without tls verification:

```
[plugin.user-manager]
addr = https://localhost:8443
path = /login
ops  = Login
tls_verify = false
```

It is backwards compatible, so if you don't specify a schema, it will default to `http:` as before. If you don't specify `tls_verify` it will default to `true`.

I am not a golang programmer, so I apologise if the quality of my PR isn't good enough. I am happy to make changes if you need them.