### PR TITLE
fix: websocket on http

### DIFF
--- a/pkg/util/vhost/reverseproxy.go
+++ b/pkg/util/vhost/reverseproxy.go
@@ -276,6 +276,7 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if reqUpType != "" {
 		outreq.Header.Set("Connection", "Upgrade")
 		outreq.Header.Set("Upgrade", reqUpType)
+		p.Transport.(*http.Transport).DisableKeepAlives = false
 	}
 
 	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {


### PR DESCRIPTION
sending websocket request on http port with `http` type, frps will forward request and add the header that including `Connection: close`, then ws service can't response normally.

issue is #2195 

set DisableKeepAlives=false
