### PR TITLE
Create autocloser.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: DOCS
-    url: https://github.com/fatedier/frp
+    url: https://github.com/fatedier/frp/blob/master/README.md
     about: Here you can find out how to configure frp.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,7 +9,7 @@ assignees: ''
 
 <!-- From Chinese to English by machine translation, welcome to revise and polish. -->
 
-**The solution you want**
+**[REQUIRED] The solution you want**
 <!--A clear and concise description of the solution you want. -->
 
 **Alternatives considered**
@@ -18,5 +18,10 @@ assignees: ''
 **How to implement this function**
 <!--Implementation steps for the solution you want. -->
 
-**Application scenarios of this function**
+**[REQUIRED] Application scenarios of this function**
 <!--Make a clear and concise description of the application scenario of the solution you want. -->
+
+**Checklist**:
+<!--- Make sure you've completed the following steps (put an "X" between of brackets): -->
+- [] I included all information required in the sections above
+- [] I made sure there are no duplicates of this report [(Use Search)](https://github.com/fatedier/frp/issues?q=is%3Aissue)

--- a/.github/workflows/autocloser.yml
+++ b/.github/workflows/autocloser.yml
@@ -1,0 +1,26 @@
+name: Autocloser
+on:
+  issues:
+    types: [opened]
+jobs:
+  autoclose:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Autoclose issues that did not follow issue template
+      uses: roots/issue-closer@v1.1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-close-message: >
+            Hello @${{ github.event.issue.user.login }}! :wave: 
+            Thank you very much for reporting it.
+
+
+            However, **your report doesn't follow the issue template**,
+            so it is being automatically closed. We are really sorry for that,
+            but we need all reports to follow the template, or else it won't be
+            possible to understand and help with all issues.
+
+
+            Please, create a new issue following the template, or reopen this
+            same issue to edit and provide all required information.
+        issue-pattern: 'I included all information required in the sections above'


### PR DESCRIPTION
This PR can use GitHub action to automatically close issues that do not follow the issue template.

Stability is not guaranteed, but it can be used normally after merging.

So in contrast, I still recommend [close-issue-app](https://github.com/apps/close-issue-app), which is more stable and faster, and can be used normally after installing and merging #2178.