### PR TITLE
config: inline is NOT SUPPORTED in encoding/json

### DIFF
--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -29,7 +29,7 @@ import (
 // recommended to use GetDefaultClientConf instead of creating this object
 // directly, so that all unspecified fields have reasonable default values.
 type ClientCommonConf struct {
-	auth.ClientConfig `ini:",extends" json:"inline"`
+	auth.ClientConfig `ini:",extends"`
 
 	// ServerAddr specifies the address of the server to connect to. By
 	// default, this value is "0.0.0.0".

--- a/pkg/config/proxy.go
+++ b/pkg/config/proxy.go
@@ -144,8 +144,8 @@ type BaseProxyConf struct {
 	Metas map[string]string `ini:"-" json:"metas"`
 
 	// TODO: LocalSvrConf => LocalAppConf
-	LocalSvrConf    `ini:",extends" json:"inline"`
-	HealthCheckConf `ini:",extends" json:"inline"`
+	LocalSvrConf    `ini:",extends"`
+	HealthCheckConf `ini:",extends"`
 }
 
 type DomainConf struct {
@@ -155,8 +155,8 @@ type DomainConf struct {
 
 // HTTP
 type HTTPProxyConf struct {
-	BaseProxyConf `ini:",extends" json:"inline"`
-	DomainConf    `ini:",extends" json:"inline"`
+	BaseProxyConf `ini:",extends"`
+	DomainConf    `ini:",extends"`
 
 	Locations         []string          `ini:"locations" json:"locations"`
 	HTTPUser          string            `ini:"http_user" json:"http_user"`
@@ -167,27 +167,27 @@ type HTTPProxyConf struct {
 
 // HTTPS
 type HTTPSProxyConf struct {
-	BaseProxyConf `ini:",extends" json:"inline"`
-	DomainConf    `ini:",extends" json:"inline"`
+	BaseProxyConf `ini:",extends"`
+	DomainConf    `ini:",extends"`
 }
 
 // TCP
 type TCPProxyConf struct {
-	BaseProxyConf `ini:",extends" json:"inline"`
+	BaseProxyConf `ini:",extends"`
 	RemotePort    int `ini:"remote_port" json:"remote_port"`
 }
 
 // TCPMux
 type TCPMuxProxyConf struct {
-	BaseProxyConf `ini:",extends" json:"inline"`
-	DomainConf    `ini:",extends" json:"inline"`
+	BaseProxyConf `ini:",extends"`
+	DomainConf    `ini:",extends"`
 
 	Multiplexer string `ini:"multiplexer"`
 }
 
 // STCP
 type STCPProxyConf struct {
-	BaseProxyConf `ini:",extends" json:"inline"`
+	BaseProxyConf `ini:",extends"`
 
 	Role string `ini:"role" json:"role"`
 	Sk   string `ini:"sk" json:"sk"`
@@ -195,7 +195,7 @@ type STCPProxyConf struct {
 
 // XTCP
 type XTCPProxyConf struct {
-	BaseProxyConf `ini:",extends" json:"inline"`
+	BaseProxyConf `ini:",extends"`
 
 	Role string `ini:"role" json:"role"`
 	Sk   string `ini:"sk" json:"sk"`
@@ -203,14 +203,14 @@ type XTCPProxyConf struct {
 
 // UDP
 type UDPProxyConf struct {
-	BaseProxyConf `ini:",extends" json:"inline"`
+	BaseProxyConf `ini:",extends"`
 
 	RemotePort int `ini:"remote_port" json:"remote_port"`
 }
 
 // SUDP
 type SUDPProxyConf struct {
-	BaseProxyConf `ini:",extends" json:"inline"`
+	BaseProxyConf `ini:",extends"`
 
 	Role string `ini:"role" json:"role"`
 	Sk   string `ini:"sk" json:"sk"`

--- a/pkg/config/server.go
+++ b/pkg/config/server.go
@@ -29,7 +29,7 @@ import (
 // recommended to use GetDefaultServerConf instead of creating this object
 // directly, so that all unspecified fields have reasonable default values.
 type ServerCommonConf struct {
-	auth.ServerConfig `ini:",extends" json:"inline"`
+	auth.ServerConfig `ini:",extends"`
 
 	// BindAddr specifies the address that the server binds to. By default,
 	// this value is "0.0.0.0".

--- a/pkg/config/visitor.go
+++ b/pkg/config/visitor.go
@@ -52,15 +52,15 @@ type BaseVisitorConf struct {
 }
 
 type SUDPVisitorConf struct {
-	BaseVisitorConf `ini:",extends" json:"inline"`
+	BaseVisitorConf `ini:",extends"`
 }
 
 type STCPVisitorConf struct {
-	BaseVisitorConf `ini:",extends" json:"inline"`
+	BaseVisitorConf `ini:",extends"`
 }
 
 type XTCPVisitorConf struct {
-	BaseVisitorConf `ini:",extends" json:"inline"`
+	BaseVisitorConf `ini:",extends"`
 }
 
 // DefaultVisitorConf creates a empty VisitorConf object by visitorType.


### PR DESCRIPTION
and why use it as the field name?