### PR TITLE
frpc: fix that login_fail_exit invalid if `protocol=kcp`

### DIFF
--- a/cmd/frpc/sub/root.go
+++ b/cmd/frpc/sub/root.go
@@ -234,7 +234,7 @@ func startService(
 	}
 
 	err = svr.Run()
-	if cfg.Protocol == "kcp" {
+	if err == nil && cfg.Protocol == "kcp" {
 		<-kcpDoneCh
 	}
 	return


### PR DESCRIPTION
Fix #2360 