### PR TITLE
readme: fix toc hyperlinx

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ frp also has a P2P connect mode.
     * [Forward DNS query request](#forward-dns-query-request)
     * [Forward Unix domain socket](#forward-unix-domain-socket)
     * [Expose a simple HTTP file server](#expose-a-simple-http-file-server)
-    * [Enable HTTPS for local HTTP service](#enable-https-for-local-http-service)
+    * [Enable HTTPS for local HTTP(s) service](#enable-https-for-local-https-service)
     * [Expose your service privately](#expose-your-service-privately)
     * [P2P Mode](#p2p-mode)
 * [Features](#features)


### PR DESCRIPTION
Hi,

The hyperlink in the toc can not be accessed, perhaps due to the parenthesis.

![image](https://user-images.githubusercontent.com/15157070/118464012-4b83b700-b6f8-11eb-9691-a7b3955dccc6.png)


Han