### PR TITLE
Fix server-side proxy inappropriate quit when met `accept: too many open files` error

### DIFF
--- a/conf/systemd/frpc.service
+++ b/conf/systemd/frpc.service
@@ -9,9 +9,6 @@ Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/frpc -c /etc/frp/frpc.ini
 ExecReload=/usr/bin/frpc reload -c /etc/frp/frpc.ini
-# see:
-#   https://github.com/containerd/containerd/issues/3201
-#   https://github.com/containerd/containerd/pull/3202
 LimitNOFILE=1048576
 
 [Install]

--- a/conf/systemd/frpc.service
+++ b/conf/systemd/frpc.service
@@ -9,6 +9,10 @@ Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/frpc -c /etc/frp/frpc.ini
 ExecReload=/usr/bin/frpc reload -c /etc/frp/frpc.ini
+# see:
+#   https://github.com/containerd/containerd/issues/3201
+#   https://github.com/containerd/containerd/pull/3202
+LimitNOFILE=1048576
 
 [Install]
 WantedBy=multi-user.target

--- a/conf/systemd/frpc@.service
+++ b/conf/systemd/frpc@.service
@@ -3,7 +3,7 @@ Description=Frp Client Service
 After=network.target
 
 [Service]
-Type=idle
+Type=simple
 User=nobody
 Restart=on-failure
 RestartSec=5s

--- a/conf/systemd/frpc@.service
+++ b/conf/systemd/frpc@.service
@@ -9,6 +9,7 @@ Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/frpc -c /etc/frp/%i.ini
 ExecReload=/usr/bin/frpc reload -c /etc/frp/%i.ini
+LimitNOFILE=1048576
 
 [Install]
 WantedBy=multi-user.target

--- a/conf/systemd/frps.service
+++ b/conf/systemd/frps.service
@@ -8,6 +8,10 @@ User=nobody
 Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/frps -c /etc/frp/frps.ini
+# see:
+#   https://github.com/containerd/containerd/issues/3201
+#   https://github.com/containerd/containerd/pull/3202
+LimitNOFILE=1048576
 
 [Install]
 WantedBy=multi-user.target

--- a/conf/systemd/frps.service
+++ b/conf/systemd/frps.service
@@ -8,9 +8,6 @@ User=nobody
 Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/frps -c /etc/frp/frps.ini
-# see:
-#   https://github.com/containerd/containerd/issues/3201
-#   https://github.com/containerd/containerd/pull/3202
 LimitNOFILE=1048576
 
 [Install]

--- a/conf/systemd/frps@.service
+++ b/conf/systemd/frps@.service
@@ -8,6 +8,7 @@ User=nobody
 Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/frps -c /etc/frp/%i.ini
+LimitNOFILE=1048576
 
 [Install]
 WantedBy=multi-user.target

--- a/server/proxy/proxy.go
+++ b/server/proxy/proxy.go
@@ -159,9 +159,6 @@ func (pxy *BaseProxy) startListenHandler(p Proxy, handler func(Proxy, net.Conn, 
 				// if listener is closed, err returned
 				c, err := l.Accept()
 				if err != nil {
-					xl.Warn("listener is closed: %s", err)
-
-					// see: net/mux/mux.go#Serve()
 					if err, ok := err.(interface{ Temporary() bool }); ok && err.Temporary() {
 						if tempDelay == 0 {
 							tempDelay = 5 * time.Millisecond
@@ -171,11 +168,12 @@ func (pxy *BaseProxy) startListenHandler(p Proxy, handler func(Proxy, net.Conn, 
 						if max := 1 * time.Second; tempDelay > max {
 							tempDelay = max
 						}
-						xl.Info("met temporary error when accepting, sleep for %s ...", tempDelay)
+						xl.Info("met temporary error: %s, sleep for %s ...", err, tempDelay)
 						time.Sleep(tempDelay)
 						continue
 					}
 
+					xl.Warn("listener is closed: %s", err)
 					return
 				}
 				xl.Info("get a user connection [%s]", c.RemoteAddr().String())

--- a/server/proxy/proxy.go
+++ b/server/proxy/proxy.go
@@ -156,7 +156,11 @@ func (pxy *BaseProxy) startListenHandler(p Proxy, handler func(Proxy, net.Conn, 
 				// if listener is closed, err returned
 				c, err := l.Accept()
 				if err != nil {
-					xl.Info("listener is closed")
+					xl.Warn("listener is closed: %s", err)
+					if err2, ok := err.(*net.OpError); ok && err2.Temporary() {
+						xl.Info("met temporary error when accepting, continue ...")
+						continue
+					}
 					return
 				}
 				xl.Info("get a user connection [%s]", c.RemoteAddr().String())


### PR DESCRIPTION
# How this happen

When the `frps` have massive concurrent connection establishments(especially for long-lived connections, e.g. http2, WebSocket), `frps` will use many file descriptors(expected behaviours), and eventually reach the `ulimit -n` limit.

After that the `frps` proxy listener simply log and quit, and the whole `frps` is refused to accepting any further connections.

Which is prone to DDOS attacks.

# How to reproduce this bug

## `frps`
No config file required, just use the defaults.

## `frpc`

### `client.ini`

```ini
[common]
server_addr = 127.0.0.1
server_port = 7000

[too-many-open-files-test]
type = tcp
remote_port = 1053
# Change to yours
local_ip = 192.168.200.1
local_port = 53
```

Why use DNS for test: simply because it's relative long-lived, anything else would be ok.

## `concurrent-conn.sh`

```bash
#!/bin/bash

while :; do
    # Fire and forget(reach `ulimit -n` quickly)
    dig @127.0.0.1 -p1053 dns.google +tcp +short > /dev/null &
done
```
# Reproduce procedures

Env: Ubuntu 20.04.2 LTS x86_64

* `./frps`
* `./frpc -c client.ini`
* `prlimit --pid $(pidof frps) --nofile=128:128`
Explicitly decrease nofile limit of `frps` to reach `ulimit -n` quickly
* `prlimit --pid $(pidof frpc) --nofile=102400:102400`
Explicitly increase nofile limit of `frpc` so `frpc` won't be the bottleneck
* `./concurrent-conn.sh`

# `frps` output

```
2021/07/02 20:25:05 [I] [proxy.go:165] [fad8fd4213b57280] [too-many-open-files-test] get a user connection [127.0.0.1:46129]
2021/07/02 20:25:05 [I] [proxy.go:165] [fad8fd4213b57280] [too-many-open-files-test] get a user connection [127.0.0.1:50013]
2021/07/02 20:25:05 [I] [proxy.go:165] [fad8fd4213b57280] [too-many-open-files-test] get a user connection [127.0.0.1:40547]
2021/07/02 20:25:05 [I] [proxy.go:165] [fad8fd4213b57280] [too-many-open-files-test] get a user connection [127.0.0.1:42587]
2021/07/02 20:25:05 [I] [proxy.go:165] [fad8fd4213b57280] [too-many-open-files-test] get a user connection [127.0.0.1:54785]
2021/07/02 20:25:05 [I] [proxy.go:165] [fad8fd4213b57280] [too-many-open-files-test] get a user connection [127.0.0.1:49519]
2021/07/02 20:25:05 [I] [proxy.go:165] [fad8fd4213b57280] [too-many-open-files-test] get a user connection [127.0.0.1:60873]
2021/07/02 20:25:05 [I] [proxy.go:165] [fad8fd4213b57280] [too-many-open-files-test] get a user connection [127.0.0.1:42663]
2021/07/02 20:25:05 [I] [proxy.go:165] [fad8fd4213b57280] [too-many-open-files-test] get a user connection [127.0.0.1:51231]
2021/07/02 20:25:05 [I] [proxy.go:165] [fad8fd4213b57280] [too-many-open-files-test] get a user connection [127.0.0.1:58995]
2021/07/02 20:25:05 [I] [proxy.go:165] [fad8fd4213b57280] [too-many-open-files-test] get a user connection [127.0.0.1:48041]
2021/07/02 20:25:05 [I] [proxy.go:165] [fad8fd4213b57280] [too-many-open-files-test] get a user connection [127.0.0.1:43217]
2021/07/02 20:25:05 [W] [proxy.go:158] [fad8fd4213b57280] [too-many-open-files-test] listener is closed: *net.OpError accept tcp [::]:1053: accept4: too many open files

```

# Verification taken from `concurrent-conn.sh`

> After that the `frps` proxy listener simply log and quit, and the whole `frps` is refused to accepting any further connections.

```
# Check after we met 'accept: too many open files'
$ dig @127.0.0.1 -p1053 dns.google +tcp +short

; <<>> DiG 9.16.1-Ubuntu <<>> @127.0.0.1 -p1053 dns.google +tcp +short
; (1 server found)
;; global options: +cmd
;; connection timed out; no servers could be reached

```