### PR TITLE
feat: wss support (#2194)

### DIFF
--- a/pkg/util/net/websocket.go
+++ b/pkg/util/net/websocket.go
@@ -78,9 +78,8 @@ func (p *WebsocketListener) Addr() net.Addr {
 	return p.ln.Addr()
 }
 
-// addr: domain:port
+// addr: url
 func ConnectWebsocketServer(addr string) (net.Conn, error) {
-	addr = "ws://" + addr + FrpWebsocketPath
 	uri, err := url.Parse(addr)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Among the supported protocol in FRP, **WebSocket** is more special(located at layer 7 in the OSI model) than TCP and KCP. 

We should support `URL format` configuration to connect to server instead of hard-code `domain:port format`. 

And then obtain the **WSS support** feature gracefully.
  
- BEFORE use `domain:port` to connect server

`frpc.ini`:
```frpc.ini
[common]
server_addr = frps.server.host
server_port = 7007
token = SECRET
tls_enable = true
protocol = websocket
```

- AFTER extra support `URL` to connect server

`frpc.ini`:
```frpc.ini
[common]
server_addr = wss://frps.server.host/frps/
token = SECRET
tls_enable = true
protocol = websocket
```

`nginx.conf`:

```nginx.conf
... 
# frps websocket proxy
location /frps/ {
    proxy_redirect off;
    proxy_pass http://127.0.0.1:7007/;
    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "upgrade";
    proxy_set_header Host $http_host;
    proxy_read_timeout 600s;
}
...
```