### PR TITLE
fix: kcp protocol cause delay release resource

### DIFF
--- a/client/control.go
+++ b/client/control.go
@@ -182,9 +182,16 @@ func (ctl *Control) HandleNewProxyResp(inMsg *msg.NewProxyResp) {
 }
 
 func (ctl *Control) Close() error {
+	return ctl.GracefulClose(0)
+}
+
+func (ctl *Control) GracefulClose(t time.Duration) error {
 	ctl.pm.Close()
-	ctl.conn.Close()
 	ctl.vm.Close()
+
+	time.Sleep(t)
+
+	ctl.conn.Close()
 	if ctl.session != nil {
 		ctl.session.Close()
 	}

--- a/client/service.go
+++ b/client/service.go
@@ -311,10 +311,14 @@ func (svr *Service) ReloadConf(pxyCfgs map[string]config.ProxyConf, visitorCfgs 
 	return svr.ctl.ReloadConf(pxyCfgs, visitorCfgs)
 }
 
-func (svr *Service) Close() {
+func (svr *Service) Close(t time.Duration) {
 	atomic.StoreUint32(&svr.exit, 1)
 	if svr.ctl != nil {
-		svr.ctl.Close()
+		if t > 0 {
+			svr.ctl.GracefulClose(t)
+		} else {
+			svr.ctl.Close()
+		}
 	}
 	svr.cancel()
 }

--- a/cmd/frpc/sub/root.go
+++ b/cmd/frpc/sub/root.go
@@ -124,8 +124,7 @@ func handleSignal(svr *client.Service) {
 	ch := make(chan os.Signal)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	<-ch
-	svr.Close()
-	time.Sleep(250 * time.Millisecond)
+	svr.Close(time.Millisecond * 250)
 	close(kcpDoneCh)
 }
 


### PR DESCRIPTION
#2620 

### 复现问题

frpc
```
[common]
server_addr = 0.0.0.0
server_port = 7000
log_level = debug
protocol = kcp
tls_enable = true

[http_web]
type = tcp
local_ip = 127.0.0.1
local_port = 8890
remote_port = 8891
```

frps
```
[common]
bind_addr = 0.0.0.0
bind_port = 7000
kcp_bind_port = 7000
vhost_http_port = 80
vhost_https_port = 443
dashboard_addr = 0.0.0.0
dashboard_port = 7500
log_level = debug
```
---

- [ ] 启动  frps，frpc
- [ ] 杀掉 frpc，立刻启动 frpc，出现 conflict，frps 没有释放资源


### 解决思路
等待一段时间，等 sendch 的释放消息发出去，等待 frps 释放。




