### PR TITLE
doc: no X-Real-IP in http proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -884,7 +884,7 @@ In this example, it will set header `X-From-Where: frp` in the HTTP request.
 
 This feature is for http proxy only.
 
-You can get user's real IP from HTTP request headers `X-Forwarded-For` and `X-Real-IP`.
+You can get user's real IP from HTTP request headers `X-Forwarded-For`.
 
 #### Proxy Protocol
 


### PR DESCRIPTION
Since there's no `X-Real-IP` header set for the HTTP proxy, the doc seems wrong.

https://github.com/fatedier/frp/blob/ff7b8b0b62d553b614e5cfc597f38991a8447bd3/pkg/util/vhost/reverseproxy.go#L281-L293