### PR TITLE
Add audience to token generator

### DIFF
--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -93,6 +93,9 @@ func NewOidcAuthSetter(baseCfg BaseConfig, cfg OidcClientConfig) *OidcAuthProvid
 		ClientSecret: cfg.OidcClientSecret,
 		Scopes:       []string{cfg.OidcAudience},
 		TokenURL:     cfg.OidcTokenEndpointURL,
+		EndpointParams: map[string][]string{
+			"audience": {cfg.OidcAudience},
+		},
 	}
 
 	return &OidcAuthProvider{


### PR DESCRIPTION
Certain implementations of oauth2, such as auth0, require the audience
parameter to be send to the token generation endpoint.

This commit adds an additional parameter to, by default, send the
audience parameter.

This should be be broadly compatible and ignored by other
implementations. Otherwise, we can consider an additional configuration
option