### PR TITLE
Notify server plugins when a proxy is closed

### DIFF
--- a/doc/server_plugin.md
+++ b/doc/server_plugin.md
@@ -138,7 +138,10 @@ Create new proxy
 
 #### CloseProxy
 
-A previously created proxy is closed
+A previously created proxy is closed.
+
+Please note that one request will be sent for every proxy that is closed, do **NOT** use this
+if you have too many proxies bound to a single client, as this may exhaust the server's resources.
 
 ```
 {

--- a/doc/server_plugin.md
+++ b/doc/server_plugin.md
@@ -70,7 +70,7 @@ The response can look like any of the following:
 
 ### Operation
 
-Currently `Login`, `NewProxy`, `Ping`, `NewWorkConn` and `NewUserConn` operations are supported.
+Currently `Login`, `NewProxy`, `CloseProxy`, `Ping`, `NewWorkConn` and `NewUserConn` operations are supported.
 
 #### Login
 
@@ -132,6 +132,23 @@ Create new proxy
         "multiplexer": <string>
 
         "metas": map<string>string
+    }
+}
+```
+
+#### CloseProxy
+
+A previously created proxy is closed
+
+```
+{
+    "content": {
+        "user": {
+            "user": <string>,
+            "metas": map<string>string
+            "run_id": <string>
+        },
+        "proxy_name": <string>
     }
 }
 ```

--- a/pkg/plugin/server/plugin.go
+++ b/pkg/plugin/server/plugin.go
@@ -23,6 +23,7 @@ const (
 
 	OpLogin       = "Login"
 	OpNewProxy    = "NewProxy"
+	OpCloseProxy  = "CloseProxy"
 	OpPing        = "Ping"
 	OpNewWorkConn = "NewWorkConn"
 	OpNewUserConn = "NewUserConn"

--- a/pkg/plugin/server/types.go
+++ b/pkg/plugin/server/types.go
@@ -48,6 +48,11 @@ type NewProxyContent struct {
 	msg.NewProxy
 }
 
+type CloseProxyContent struct {
+	User UserInfo `json:"user"`
+	msg.CloseProxy
+}
+
 type PingContent struct {
 	User UserInfo `json:"user"`
 	msg.Ping

--- a/server/control.go
+++ b/server/control.go
@@ -453,6 +453,17 @@ func (ctl *Control) manager() {
 				}
 				ctl.sendCh <- resp
 			case *msg.CloseProxy:
+				content := &plugin.CloseProxyContent{
+					User: plugin.UserInfo{
+						User:  ctl.loginMsg.User,
+						Metas: ctl.loginMsg.Metas,
+						RunID: ctl.loginMsg.RunID,
+					},
+					CloseProxy: *m,
+				}
+
+				ctl.pluginManager.CloseProxy(content)
+
 				ctl.CloseProxy(m)
 				xl.Info("close proxy [%s] success", m.ProxyName)
 			case *msg.Ping:

--- a/server/control.go
+++ b/server/control.go
@@ -578,5 +578,20 @@ func (ctl *Control) CloseProxy(closeMsg *msg.CloseProxy) (err error) {
 	ctl.mu.Unlock()
 
 	metrics.Server.CloseProxy(pxy.GetName(), pxy.GetConf().GetBaseInfo().ProxyType)
+
+	notifyContent := &plugin.CloseProxyContent{
+		User: plugin.UserInfo{
+			User:  ctl.loginMsg.User,
+			Metas: ctl.loginMsg.Metas,
+			RunID: ctl.loginMsg.RunID,
+		},
+		CloseProxy: msg.CloseProxy{
+			ProxyName: pxy.GetName(),
+		},
+	}
+	go func() {
+		ctl.pluginManager.CloseProxy(notifyContent)
+	}()
+
 	return
 }

--- a/test/e2e/framework/process.go
+++ b/test/e2e/framework/process.go
@@ -12,7 +12,7 @@ import (
 
 // RunProcesses run multiple processes from templates.
 // The first template should always be frps.
-func (f *Framework) RunProcesses(serverTemplates []string, clientTemplates []string) {
+func (f *Framework) RunProcesses(serverTemplates []string, clientTemplates []string) ([]*process.Process, []*process.Process) {
 	templates := make([]string, 0, len(serverTemplates)+len(clientTemplates))
 	for _, t := range serverTemplates {
 		templates = append(templates, t)
@@ -28,6 +28,7 @@ func (f *Framework) RunProcesses(serverTemplates []string, clientTemplates []str
 		f.usedPorts[name] = port
 	}
 
+	currentServerProcesses := make([]*process.Process, 0, len(serverTemplates))
 	for i := range serverTemplates {
 		path := filepath.Join(f.TempDirectory, fmt.Sprintf("frp-e2e-server-%d", i))
 		err = os.WriteFile(path, []byte(outs[i]), 0666)
@@ -37,11 +38,13 @@ func (f *Framework) RunProcesses(serverTemplates []string, clientTemplates []str
 		p := process.NewWithEnvs(TestContext.FRPServerPath, []string{"-c", path}, f.osEnvs)
 		f.serverConfPaths = append(f.serverConfPaths, path)
 		f.serverProcesses = append(f.serverProcesses, p)
+		currentServerProcesses = append(currentServerProcesses, p)
 		err = p.Start()
 		ExpectNoError(err)
 	}
 	time.Sleep(time.Second)
 
+	currentClientProcesses := make([]*process.Process, 0, len(clientTemplates))
 	for i := range clientTemplates {
 		index := i + len(serverTemplates)
 		path := filepath.Join(f.TempDirectory, fmt.Sprintf("frp-e2e-client-%d", i))
@@ -52,11 +55,14 @@ func (f *Framework) RunProcesses(serverTemplates []string, clientTemplates []str
 		p := process.NewWithEnvs(TestContext.FRPClientPath, []string{"-c", path}, f.osEnvs)
 		f.clientConfPaths = append(f.clientConfPaths, path)
 		f.clientProcesses = append(f.clientProcesses, p)
+		currentClientProcesses = append(currentClientProcesses, p)
 		err = p.Start()
 		ExpectNoError(err)
 		time.Sleep(500 * time.Millisecond)
 	}
 	time.Sleep(500 * time.Millisecond)
+
+	return currentServerProcesses, currentClientProcesses
 }
 
 func (f *Framework) RunFrps(args ...string) (*process.Process, string, error) {

--- a/test/e2e/plugin/server.go
+++ b/test/e2e/plugin/server.go
@@ -158,6 +158,53 @@ var _ = Describe("[Feature: Server-Plugins]", func() {
 		})
 	})
 
+	Describe("CloseProxy", func() {
+		newFunc := func() *plugin.Request {
+			var r plugin.Request
+			r.Content = &plugin.CloseProxyContent{}
+			return &r
+		}
+
+		It("Validate Info", func() {
+			localPort := f.AllocPort()
+			handler := func(req *plugin.Request) *plugin.Response {
+				var ret plugin.Response
+				content := req.Content.(*plugin.CloseProxyContent)
+				if content.ProxyName == "tcp" {
+					ret.Unchange = true
+				} else {
+					ret.Reject = true
+				}
+				return &ret
+			}
+			pluginServer := NewHTTPPluginServer(localPort, newFunc, handler, nil)
+
+			f.RunServer("", pluginServer)
+
+			serverConf := consts.DefaultServerConfig + fmt.Sprintf(`
+			[plugin.test]
+			addr = 127.0.0.1:%d
+			path = /handler
+			ops = CloseProxy
+			`, localPort)
+			clientConf := consts.DefaultClientConfig
+
+			remotePort := f.AllocPort()
+			clientConf += fmt.Sprintf(`
+			[tcp]
+			type = tcp
+			local_port = {{ .%s }}
+			remote_port = %d
+			`, framework.TCPEchoServerPort, remotePort)
+
+			f.RunProcesses([]string{serverConf}, []string{clientConf})
+
+			time.Sleep(5 * time.Second)
+
+			framework.NewRequestExpect(f).Port(remotePort).Ensure()
+		})
+	})
+
 	Describe("Ping", func() {
 		newFunc := func() *plugin.Request {
 			var r plugin.Request


### PR DESCRIPTION
This is an implementation of #2821 ,but currently does not work.

It seems that similar types of plugin requests are dispatched here, but after adding a `fmt.Printf("%+v\n", m)`, no message is sent to this channel when I press `Ctrl-C` in `frpc`, am I missing something?
https://github.com/fatedier/frp/blob/19739ed31a26994e1e68346324f83b9544f7a4b0/server/control.go#L455-L457

![image](https://user-images.githubusercontent.com/1381736/156321004-a64bb546-33ad-4bf2-9fcc-e2bde931ed37.png)
![image](https://user-images.githubusercontent.com/1381736/156321015-33dff9cf-feb0-48f4-8d8d-486fb9cc9e36.png)


I have chosen to ignore any response from the plugin since there is nothing to modify in this operation (we can't prevent a proxy from closing).

Help is needed also for end-to-end tests, since it is passing when really should not.