### PR TITLE
bugfix: Issue #2831 - Cant connect to frps behind ingress with tls

### DIFF
--- a/pkg/transport/tls.go
+++ b/pkg/transport/tls.go
@@ -100,6 +100,8 @@ func NewClientTLSConfig(certPath, keyPath, caPath, serverName string) (*tls.Conf
 		base.Certificates = []tls.Certificate{*cert}
 	}
 
+	base.ServerName = serverName
+
 	if caPath != "" {
 		pool, err := newCertPool(caPath)
 		if err != nil {
@@ -107,7 +109,6 @@ func NewClientTLSConfig(certPath, keyPath, caPath, serverName string) (*tls.Conf
 		}
 
 		base.RootCAs = pool
-		base.ServerName = serverName
 		base.InsecureSkipVerify = false
 	} else {
 		base.InsecureSkipVerify = true


### PR DESCRIPTION
Fix for issue #2831 

`ServerName` gets added to `TLSConfig` even if no ca has been added, so that SNI based routing works as intended.

<img width="860" alt="image" src="https://user-images.githubusercontent.com/3883897/157684597-8c65acd5-61a9-4df2-8bbf-128c3553545b.png">

