### PR TITLE
Fixed go vet warnings

### DIFF
--- a/cmd/frpc/sub/root.go
+++ b/cmd/frpc/sub/root.go
@@ -121,7 +121,7 @@ func Execute() {
 }
 
 func handleSignal(svr *client.Service) {
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	<-ch
 	svr.GracefulClose(500 * time.Millisecond)

--- a/test/e2e/plugin/server.go
+++ b/test/e2e/plugin/server.go
@@ -149,7 +149,7 @@ var _ = Describe("[Feature: Server-Plugins]", func() {
 			[tcp]
 			type = tcp
 			local_port = {{ .%s }}
-			remote_port = 0
+			remote_port = %d
 			`, framework.TCPEchoServerPort, remotePort)
 
 			f.RunProcesses([]string{serverConf}, []string{clientConf})


### PR DESCRIPTION
Fixed go vet warnings:
```bash
$ go vet ./...
# github.com/fatedier/frp/test/e2e/plugin
test/e2e/plugin/server.go:148:18: Sprintf call needs 1 arg but has 2 args
# github.com/fatedier/frp/cmd/frpc/sub
cmd/frpc/sub/root.go:125:2: misuse of unbuffered os.Signal channel as argument to signal.Notify
```