### PR TITLE
feat: support aead encryption

### DIFF
--- a/client/control.go
+++ b/client/control.go
@@ -284,7 +284,7 @@ func (ctl *Control) reader() {
 	defer ctl.readerShutdown.Done()
 	defer close(ctl.closedCh)
 
-	encReader := crypto.NewReader(ctl.conn, []byte(ctl.clientCfg.Token))
+	encReader := crypto.NewReader(ctl.conn, []byte(ctl.clientCfg.Token), ctl.clientCfg.Aead)
 	for {
 		m, err := msg.ReadMsg(encReader)
 		if err != nil {
@@ -304,7 +304,7 @@ func (ctl *Control) reader() {
 func (ctl *Control) writer() {
 	xl := ctl.xl
 	defer ctl.writerShutdown.Done()
-	encWriter, err := crypto.NewWriter(ctl.conn, []byte(ctl.clientCfg.Token))
+	encWriter, err := crypto.NewWriter(ctl.conn, []byte(ctl.clientCfg.Token), ctl.clientCfg.Aead)
 	if err != nil {
 		xl.Error("crypto new writer error: %v", err)
 		ctl.conn.Close()

--- a/client/proxy/proxy.go
+++ b/client/proxy/proxy.go
@@ -487,7 +487,7 @@ func (pxy *UDPProxy) InWorkConn(conn net.Conn, m *msg.StartWorkConn) {
 		})
 	}
 	if pxy.cfg.UseEncryption {
-		rwc, err = frpIo.WithEncryption(rwc, []byte(pxy.clientCfg.Token))
+		rwc, err = frpIo.WithEncryption(rwc, []byte(pxy.clientCfg.Token), pxy.cfg.UseAead)
 		if err != nil {
 			conn.Close()
 			xl.Error("create encryption stream error: %v", err)
@@ -600,7 +600,7 @@ func (pxy *SUDPProxy) InWorkConn(conn net.Conn, m *msg.StartWorkConn) {
 		})
 	}
 	if pxy.cfg.UseEncryption {
-		rwc, err = frpIo.WithEncryption(rwc, []byte(pxy.clientCfg.Token))
+		rwc, err = frpIo.WithEncryption(rwc, []byte(pxy.clientCfg.Token), pxy.cfg.UseAead)
 		if err != nil {
 			conn.Close()
 			xl.Error("create encryption stream error: %v", err)
@@ -732,10 +732,10 @@ func HandleTCPWorkConnection(ctx context.Context, localInfo *config.LocalSvrConf
 		})
 	}
 
-	xl.Trace("handle tcp work connection, use_encryption: %t, use_compression: %t",
-		baseInfo.UseEncryption, baseInfo.UseCompression)
+	xl.Trace("handle tcp work connection, use_encryption: %t,  use_aead: %t, use_compression: %t",
+		baseInfo.UseEncryption, baseInfo.UseAead, baseInfo.UseCompression)
 	if baseInfo.UseEncryption {
-		remote, err = frpIo.WithEncryption(remote, encKey)
+		remote, err = frpIo.WithEncryption(remote, encKey, baseInfo.UseAead)
 		if err != nil {
 			workConn.Close()
 			xl.Error("create encryption stream error: %v", err)

--- a/client/visitor.go
+++ b/client/visitor.go
@@ -154,7 +154,7 @@ func (sv *STCPVisitor) handleConn(userConn net.Conn) {
 	var remote io.ReadWriteCloser
 	remote = visitorConn
 	if sv.cfg.UseEncryption {
-		remote, err = frpIo.WithEncryption(remote, []byte(sv.cfg.Sk))
+		remote, err = frpIo.WithEncryption(remote, []byte(sv.cfg.Sk), sv.cfg.UseAead)
 		if err != nil {
 			xl.Error("create encryption stream error: %v", err)
 			return
@@ -323,7 +323,7 @@ func (sv *XTCPVisitor) handleConn(userConn net.Conn) {
 
 	var muxConnRWCloser io.ReadWriteCloser = muxConn
 	if sv.cfg.UseEncryption {
-		muxConnRWCloser, err = frpIo.WithEncryption(muxConnRWCloser, []byte(sv.cfg.Sk))
+		muxConnRWCloser, err = frpIo.WithEncryption(muxConnRWCloser, []byte(sv.cfg.Sk), sv.cfg.UseAead)
 		if err != nil {
 			xl.Error("create encryption stream error: %v", err)
 			return
@@ -515,6 +515,7 @@ func (sv *SUDPVisitor) getNewVisitorConn() (net.Conn, error) {
 		SignKey:        util.GetAuthKey(sv.cfg.Sk, now),
 		Timestamp:      now,
 		UseEncryption:  sv.cfg.UseEncryption,
+		UseAead:        sv.cfg.UseAead,
 		UseCompression: sv.cfg.UseCompression,
 	}
 	err = msg.WriteMsg(visitorConn, newVisitorConnMsg)
@@ -537,7 +538,7 @@ func (sv *SUDPVisitor) getNewVisitorConn() (net.Conn, error) {
 	var remote io.ReadWriteCloser
 	remote = visitorConn
 	if sv.cfg.UseEncryption {
-		remote, err = frpIo.WithEncryption(remote, []byte(sv.cfg.Sk))
+		remote, err = frpIo.WithEncryption(remote, []byte(sv.cfg.Sk), sv.cfg.UseAead)
 		if err != nil {
 			xl.Error("create encryption stream error: %v", err)
 			return nil, err

--- a/cmd/frpc/sub/http.go
+++ b/cmd/frpc/sub/http.go
@@ -38,6 +38,7 @@ func init() {
 	httpCmd.PersistentFlags().StringVarP(&httpPwd, "http_pwd", "", "", "http auth password")
 	httpCmd.PersistentFlags().StringVarP(&hostHeaderRewrite, "host_header_rewrite", "", "", "host header rewrite")
 	httpCmd.PersistentFlags().BoolVarP(&useEncryption, "ue", "", false, "use encryption")
+	httpCmd.PersistentFlags().BoolVarP(&useAead, "ua", "", false, "use aead")
 	httpCmd.PersistentFlags().BoolVarP(&useCompression, "uc", "", false, "use compression")
 
 	rootCmd.AddCommand(httpCmd)
@@ -69,6 +70,7 @@ var httpCmd = &cobra.Command{
 		cfg.HTTPPwd = httpPwd
 		cfg.HostHeaderRewrite = hostHeaderRewrite
 		cfg.UseEncryption = useEncryption
+		cfg.UseAead = useAead
 		cfg.UseCompression = useCompression
 
 		err = cfg.CheckForCli()

--- a/cmd/frpc/sub/https.go
+++ b/cmd/frpc/sub/https.go
@@ -34,6 +34,7 @@ func init() {
 	httpsCmd.PersistentFlags().StringVarP(&customDomains, "custom_domain", "d", "", "custom domain")
 	httpsCmd.PersistentFlags().StringVarP(&subDomain, "sd", "", "", "sub domain")
 	httpsCmd.PersistentFlags().BoolVarP(&useEncryption, "ue", "", false, "use encryption")
+	httpsCmd.PersistentFlags().BoolVarP(&useAead, "ua", "", false, "use aead")
 	httpsCmd.PersistentFlags().BoolVarP(&useCompression, "uc", "", false, "use compression")
 
 	rootCmd.AddCommand(httpsCmd)
@@ -61,6 +62,7 @@ var httpsCmd = &cobra.Command{
 		cfg.CustomDomains = strings.Split(customDomains, ",")
 		cfg.SubDomain = subDomain
 		cfg.UseEncryption = useEncryption
+		cfg.UseAead = useAead
 		cfg.UseCompression = useCompression
 
 		err = cfg.CheckForCli()

--- a/cmd/frpc/sub/root.go
+++ b/cmd/frpc/sub/root.go
@@ -59,6 +59,7 @@ var (
 	localPort         int
 	remotePort        int
 	useEncryption     bool
+	useAead           bool
 	useCompression    bool
 	customDomains     string
 	subDomain         string

--- a/cmd/frpc/sub/stcp.go
+++ b/cmd/frpc/sub/stcp.go
@@ -36,6 +36,7 @@ func init() {
 	stcpCmd.PersistentFlags().StringVarP(&bindAddr, "bind_addr", "", "", "bind addr")
 	stcpCmd.PersistentFlags().IntVarP(&bindPort, "bind_port", "", 0, "bind port")
 	stcpCmd.PersistentFlags().BoolVarP(&useEncryption, "ue", "", false, "use encryption")
+	stcpCmd.PersistentFlags().BoolVarP(&useAead, "ua", "", false, "use aead")
 	stcpCmd.PersistentFlags().BoolVarP(&useCompression, "uc", "", false, "use compression")
 
 	rootCmd.AddCommand(stcpCmd)
@@ -64,6 +65,7 @@ var stcpCmd = &cobra.Command{
 			cfg.ProxyName = prefix + proxyName
 			cfg.ProxyType = consts.STCPProxy
 			cfg.UseEncryption = useEncryption
+			cfg.UseAead = useAead
 			cfg.UseCompression = useCompression
 			cfg.Role = role
 			cfg.Sk = sk
@@ -80,6 +82,7 @@ var stcpCmd = &cobra.Command{
 			cfg.ProxyName = prefix + proxyName
 			cfg.ProxyType = consts.STCPProxy
 			cfg.UseEncryption = useEncryption
+			cfg.UseAead = useAead
 			cfg.UseCompression = useCompression
 			cfg.Role = role
 			cfg.Sk = sk

--- a/cmd/frpc/sub/sudp.go
+++ b/cmd/frpc/sub/sudp.go
@@ -36,6 +36,7 @@ func init() {
 	sudpCmd.PersistentFlags().StringVarP(&bindAddr, "bind_addr", "", "", "bind addr")
 	sudpCmd.PersistentFlags().IntVarP(&bindPort, "bind_port", "", 0, "bind port")
 	sudpCmd.PersistentFlags().BoolVarP(&useEncryption, "ue", "", false, "use encryption")
+	sudpCmd.PersistentFlags().BoolVarP(&useAead, "ua", "", false, "use aead")
 	sudpCmd.PersistentFlags().BoolVarP(&useCompression, "uc", "", false, "use compression")
 
 	rootCmd.AddCommand(sudpCmd)
@@ -64,6 +65,7 @@ var sudpCmd = &cobra.Command{
 			cfg.ProxyName = prefix + proxyName
 			cfg.ProxyType = consts.SUDPProxy
 			cfg.UseEncryption = useEncryption
+			cfg.UseAead = useAead
 			cfg.UseCompression = useCompression
 			cfg.Role = role
 			cfg.Sk = sk
@@ -80,6 +82,7 @@ var sudpCmd = &cobra.Command{
 			cfg.ProxyName = prefix + proxyName
 			cfg.ProxyType = consts.SUDPProxy
 			cfg.UseEncryption = useEncryption
+			cfg.UseAead = useAead
 			cfg.UseCompression = useCompression
 			cfg.Role = role
 			cfg.Sk = sk

--- a/cmd/frpc/sub/tcp.go
+++ b/cmd/frpc/sub/tcp.go
@@ -32,6 +32,7 @@ func init() {
 	tcpCmd.PersistentFlags().IntVarP(&localPort, "local_port", "l", 0, "local port")
 	tcpCmd.PersistentFlags().IntVarP(&remotePort, "remote_port", "r", 0, "remote port")
 	tcpCmd.PersistentFlags().BoolVarP(&useEncryption, "ue", "", false, "use encryption")
+	tcpCmd.PersistentFlags().BoolVarP(&useAead, "ua", "", false, "use aead")
 	tcpCmd.PersistentFlags().BoolVarP(&useCompression, "uc", "", false, "use compression")
 
 	rootCmd.AddCommand(tcpCmd)
@@ -58,6 +59,7 @@ var tcpCmd = &cobra.Command{
 		cfg.LocalPort = localPort
 		cfg.RemotePort = remotePort
 		cfg.UseEncryption = useEncryption
+		cfg.UseAead = useAead
 		cfg.UseCompression = useCompression
 
 		err = cfg.CheckForCli()

--- a/cmd/frpc/sub/tcpmux.go
+++ b/cmd/frpc/sub/tcpmux.go
@@ -35,6 +35,7 @@ func init() {
 	tcpMuxCmd.PersistentFlags().StringVarP(&subDomain, "sd", "", "", "sub domain")
 	tcpMuxCmd.PersistentFlags().StringVarP(&multiplexer, "mux", "", "", "multiplexer")
 	tcpMuxCmd.PersistentFlags().BoolVarP(&useEncryption, "ue", "", false, "use encryption")
+	tcpMuxCmd.PersistentFlags().BoolVarP(&useAead, "ua", "", false, "use aead")
 	tcpMuxCmd.PersistentFlags().BoolVarP(&useCompression, "uc", "", false, "use compression")
 
 	rootCmd.AddCommand(tcpMuxCmd)
@@ -63,6 +64,7 @@ var tcpMuxCmd = &cobra.Command{
 		cfg.SubDomain = subDomain
 		cfg.Multiplexer = multiplexer
 		cfg.UseEncryption = useEncryption
+		cfg.UseAead = useAead
 		cfg.UseCompression = useCompression
 
 		err = cfg.CheckForCli()

--- a/cmd/frpc/sub/udp.go
+++ b/cmd/frpc/sub/udp.go
@@ -32,6 +32,7 @@ func init() {
 	udpCmd.PersistentFlags().IntVarP(&localPort, "local_port", "l", 0, "local port")
 	udpCmd.PersistentFlags().IntVarP(&remotePort, "remote_port", "r", 0, "remote port")
 	udpCmd.PersistentFlags().BoolVarP(&useEncryption, "ue", "", false, "use encryption")
+	udpCmd.PersistentFlags().BoolVarP(&useAead, "ua", "", false, "use aead")
 	udpCmd.PersistentFlags().BoolVarP(&useCompression, "uc", "", false, "use compression")
 
 	rootCmd.AddCommand(udpCmd)
@@ -58,6 +59,7 @@ var udpCmd = &cobra.Command{
 		cfg.LocalPort = localPort
 		cfg.RemotePort = remotePort
 		cfg.UseEncryption = useEncryption
+		cfg.UseAead = useAead
 		cfg.UseCompression = useCompression
 
 		err = cfg.CheckForCli()

--- a/cmd/frpc/sub/xtcp.go
+++ b/cmd/frpc/sub/xtcp.go
@@ -36,6 +36,7 @@ func init() {
 	xtcpCmd.PersistentFlags().StringVarP(&bindAddr, "bind_addr", "", "", "bind addr")
 	xtcpCmd.PersistentFlags().IntVarP(&bindPort, "bind_port", "", 0, "bind port")
 	xtcpCmd.PersistentFlags().BoolVarP(&useEncryption, "ue", "", false, "use encryption")
+	xtcpCmd.PersistentFlags().BoolVarP(&useAead, "ua", "", false, "use aead")
 	xtcpCmd.PersistentFlags().BoolVarP(&useCompression, "uc", "", false, "use compression")
 
 	rootCmd.AddCommand(xtcpCmd)
@@ -64,6 +65,7 @@ var xtcpCmd = &cobra.Command{
 			cfg.ProxyName = prefix + proxyName
 			cfg.ProxyType = consts.XTCPProxy
 			cfg.UseEncryption = useEncryption
+			cfg.UseAead = useAead
 			cfg.UseCompression = useCompression
 			cfg.Role = role
 			cfg.Sk = sk
@@ -80,6 +82,7 @@ var xtcpCmd = &cobra.Command{
 			cfg.ProxyName = prefix + proxyName
 			cfg.ProxyType = consts.XTCPProxy
 			cfg.UseEncryption = useEncryption
+			cfg.UseAead = useAead
 			cfg.UseCompression = useCompression
 			cfg.Role = role
 			cfg.Sk = sk

--- a/go.mod
+++ b/go.mod
@@ -31,3 +31,5 @@ require (
 	k8s.io/apimachinery v0.21.2
 	k8s.io/client-go v0.21.2
 )
+
+replace github.com/fatedier/golib => ../golib

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,6 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatedier/beego v0.0.0-20171024143340-6c6a4f5bd5eb h1:wCrNShQidLmvVWn/0PikGmpdP0vtQmnvyRg3ZBEhczw=
 github.com/fatedier/beego v0.0.0-20171024143340-6c6a4f5bd5eb/go.mod h1:wx3gB6dbIfBRcucp94PI9Bt3I0F2c/MyNEWuhzpWiwk=
-github.com/fatedier/golib v0.1.1-0.20220321042308-c306138b83ac h1:td1FJwN/oz8+9GldeEm3YdBX0Husc0FSPywLesZxi4w=
-github.com/fatedier/golib v0.1.1-0.20220321042308-c306138b83ac/go.mod h1:fLV0TLwHqrnB/L3jbNl67Gn6PCLggDGHniX1wLrA2Qo=
 github.com/fatedier/kcp-go v2.0.4-0.20190803094908-fe8645b0a904+incompatible h1:ssXat9YXFvigNge/IkkZvFMn8yeYKFX+uI6wn2mLJ74=
 github.com/fatedier/kcp-go v2.0.4-0.20190803094908-fe8645b0a904+incompatible/go.mod h1:YpCOaxj7vvMThhIQ9AfTOPW2sfztQR5WDfs7AflSy4s=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -27,6 +27,7 @@ type TokenConfig struct {
 	// to the server. The server must have a matching token for authorization
 	// to succeed.  By default, this value is "".
 	Token string `ini:"token" json:"token"`
+	Aead  bool   `ini:"aead" json:"aead"`
 }
 
 func getDefaultTokenConf() TokenConfig {

--- a/pkg/config/client_test.go
+++ b/pkg/config/client_test.go
@@ -312,6 +312,7 @@ func Test_LoadClientBasicConf(t *testing.T) {
 				ProxyType:      consts.TCPProxy,
 				UseCompression: true,
 				UseEncryption:  true,
+				UseAead:        true,
 				Group:          "test_group",
 				GroupKey:       "123456",
 				BandwidthLimit: MustBandwidthQuantity("19MB"),
@@ -382,6 +383,7 @@ func Test_LoadClientBasicConf(t *testing.T) {
 				ProxyName:      testUser + ".dns",
 				ProxyType:      consts.UDPProxy,
 				UseEncryption:  true,
+				UseAead:        true,
 				UseCompression: true,
 				LocalSvrConf: LocalSvrConf{
 					LocalIP:   "114.114.114.114",
@@ -395,6 +397,7 @@ func Test_LoadClientBasicConf(t *testing.T) {
 				ProxyName:      testUser + ".udp_port_0",
 				ProxyType:      consts.UDPProxy,
 				UseEncryption:  true,
+				UseAead:        true,
 				UseCompression: true,
 				LocalSvrConf: LocalSvrConf{
 					LocalIP:   "114.114.114.114",
@@ -408,6 +411,7 @@ func Test_LoadClientBasicConf(t *testing.T) {
 				ProxyName:      testUser + ".udp_port_1",
 				ProxyType:      consts.UDPProxy,
 				UseEncryption:  true,
+				UseAead:        true,
 				UseCompression: true,
 				LocalSvrConf: LocalSvrConf{
 					LocalIP:   "114.114.114.114",
@@ -421,6 +425,7 @@ func Test_LoadClientBasicConf(t *testing.T) {
 				ProxyName:      testUser + ".udp_port_2",
 				ProxyType:      consts.UDPProxy,
 				UseEncryption:  true,
+				UseAead:        true,
 				UseCompression: true,
 				LocalSvrConf: LocalSvrConf{
 					LocalIP:   "114.114.114.114",
@@ -435,6 +440,7 @@ func Test_LoadClientBasicConf(t *testing.T) {
 				ProxyType:      consts.HTTPProxy,
 				UseCompression: true,
 				UseEncryption:  true,
+				UseAead:        true,
 				LocalSvrConf: LocalSvrConf{
 					LocalIP:   "127.0.0.9",
 					LocalPort: 89,
@@ -465,6 +471,7 @@ func Test_LoadClientBasicConf(t *testing.T) {
 				ProxyType:      consts.HTTPSProxy,
 				UseCompression: true,
 				UseEncryption:  true,
+				UseAead:        true,
 				LocalSvrConf: LocalSvrConf{
 					LocalIP:   "127.0.0.9",
 					LocalPort: 8009,

--- a/pkg/config/proxy.go
+++ b/pkg/config/proxy.go
@@ -120,6 +120,10 @@ type BaseProxyConf struct {
 	// be encrypted. Encryption is done using the tokens supplied in the server
 	// and client configuration. By default, this value is false.
 	UseEncryption bool `ini:"use_encryption" json:"use_encryption"`
+	// UseAead controls whether or not the encryption uses AEAD cipher or unsafe
+	// stream cipher. It is valid only when UseEncryption is true. By default,
+	// this value is false.
+	UseAead       bool `ini:"use_aead" json:"use_aead"`
 	// UseCompression controls whether or not communication with the server
 	// will be compressed. By default, this value is false.
 	UseCompression bool `ini:"use_compression" json:"use_compression"`
@@ -328,6 +332,7 @@ func (cfg *BaseProxyConf) compare(cmp *BaseProxyConf) bool {
 	if cfg.ProxyName != cmp.ProxyName ||
 		cfg.ProxyType != cmp.ProxyType ||
 		cfg.UseEncryption != cmp.UseEncryption ||
+		cfg.UseAead != cmp.UseAead ||
 		cfg.UseCompression != cmp.UseCompression ||
 		cfg.Group != cmp.Group ||
 		cfg.GroupKey != cmp.GroupKey ||
@@ -386,6 +391,7 @@ func (cfg *BaseProxyConf) marshalToMsg(pMsg *msg.NewProxy) {
 	pMsg.ProxyName = cfg.ProxyName
 	pMsg.ProxyType = cfg.ProxyType
 	pMsg.UseEncryption = cfg.UseEncryption
+	pMsg.UseAead = cfg.UseAead
 	pMsg.UseCompression = cfg.UseCompression
 	pMsg.Group = cfg.Group
 	pMsg.GroupKey = cfg.GroupKey
@@ -396,6 +402,7 @@ func (cfg *BaseProxyConf) unmarshalFromMsg(pMsg *msg.NewProxy) {
 	cfg.ProxyName = pMsg.ProxyName
 	cfg.ProxyType = pMsg.ProxyType
 	cfg.UseEncryption = pMsg.UseEncryption
+	cfg.UseAead = pMsg.UseAead
 	cfg.UseCompression = pMsg.UseCompression
 	cfg.Group = pMsg.Group
 	cfg.GroupKey = pMsg.GroupKey

--- a/pkg/config/proxy_test.go
+++ b/pkg/config/proxy_test.go
@@ -76,6 +76,7 @@ func Test_Proxy_UnmarshalFromIni(t *testing.T) {
 					ProxyType:      consts.TCPProxy,
 					UseCompression: true,
 					UseEncryption:  true,
+					UseAead:        true,
 					Group:          "test_group",
 					GroupKey:       "123456",
 					BandwidthLimit: MustBandwidthQuantity("19MB"),
@@ -135,6 +136,7 @@ func Test_Proxy_UnmarshalFromIni(t *testing.T) {
 					ProxyName:      testProxyPrefix + "dns",
 					ProxyType:      consts.UDPProxy,
 					UseEncryption:  true,
+					UseAead:        true,
 					UseCompression: true,
 					LocalSvrConf: LocalSvrConf{
 						LocalIP:   "114.114.114.114",
@@ -172,6 +174,7 @@ func Test_Proxy_UnmarshalFromIni(t *testing.T) {
 					ProxyType:      consts.HTTPProxy,
 					UseCompression: true,
 					UseEncryption:  true,
+					UseAead:        true,
 					LocalSvrConf: LocalSvrConf{
 						LocalIP:   "127.0.0.9",
 						LocalPort: 89,
@@ -216,6 +219,7 @@ func Test_Proxy_UnmarshalFromIni(t *testing.T) {
 					ProxyType:      consts.HTTPSProxy,
 					UseCompression: true,
 					UseEncryption:  true,
+					UseAead:        true,
 					LocalSvrConf: LocalSvrConf{
 						LocalIP:   "127.0.0.9",
 						LocalPort: 8009,
@@ -392,6 +396,7 @@ func Test_RangeProxy_UnmarshalFromIni(t *testing.T) {
 						ProxyName:      testProxyPrefix + "udp_port_0",
 						ProxyType:      consts.UDPProxy,
 						UseEncryption:  true,
+						UseAead:        true,
 						UseCompression: true,
 						LocalSvrConf: LocalSvrConf{
 							LocalIP:   "114.114.114.114",
@@ -405,6 +410,7 @@ func Test_RangeProxy_UnmarshalFromIni(t *testing.T) {
 						ProxyName:      testProxyPrefix + "udp_port_1",
 						ProxyType:      consts.UDPProxy,
 						UseEncryption:  true,
+						UseAead:        true,
 						UseCompression: true,
 						LocalSvrConf: LocalSvrConf{
 							LocalIP:   "114.114.114.114",
@@ -418,6 +424,7 @@ func Test_RangeProxy_UnmarshalFromIni(t *testing.T) {
 						ProxyName:      testProxyPrefix + "udp_port_2",
 						ProxyType:      consts.UDPProxy,
 						UseEncryption:  true,
+						UseAead:        true,
 						UseCompression: true,
 						LocalSvrConf: LocalSvrConf{
 							LocalIP:   "114.114.114.114",

--- a/pkg/config/visitor.go
+++ b/pkg/config/visitor.go
@@ -43,6 +43,7 @@ type BaseVisitorConf struct {
 	ProxyName      string `ini:"name" json:"name"`
 	ProxyType      string `ini:"type" json:"type"`
 	UseEncryption  bool   `ini:"use_encryption" json:"use_encryption"`
+	UseAead        bool   `ini:"use_aead" json:"use_aead"`
 	UseCompression bool   `ini:"use_compression" json:"use_compression"`
 	Role           string `ini:"role" json:"role"`
 	Sk             string `ini:"sk" json:"sk"`
@@ -108,6 +109,7 @@ func (cfg *BaseVisitorConf) compare(cmp *BaseVisitorConf) bool {
 	if cfg.ProxyName != cmp.ProxyName ||
 		cfg.ProxyType != cmp.ProxyType ||
 		cfg.UseEncryption != cmp.UseEncryption ||
+		cfg.UseAead != cmp.UseAead ||
 		cfg.UseCompression != cmp.UseCompression ||
 		cfg.Role != cmp.Role ||
 		cfg.Sk != cmp.Sk ||

--- a/pkg/msg/msg.go
+++ b/pkg/msg/msg.go
@@ -88,6 +88,7 @@ type NewProxy struct {
 	ProxyName      string            `json:"proxy_name,omitempty"`
 	ProxyType      string            `json:"proxy_type,omitempty"`
 	UseEncryption  bool              `json:"use_encryption,omitempty"`
+	UseAead        bool              `json:"use_aead,omitempty"`
 	UseCompression bool              `json:"use_compression,omitempty"`
 	Group          string            `json:"group,omitempty"`
 	GroupKey       string            `json:"group_key,omitempty"`
@@ -146,6 +147,7 @@ type NewVisitorConn struct {
 	SignKey        string `json:"sign_key,omitempty"`
 	Timestamp      int64  `json:"timestamp,omitempty"`
 	UseEncryption  bool   `json:"use_encryption,omitempty"`
+	UseAead        bool   `json:"use_aead,omitempty"`
 	UseCompression bool   `json:"use_compression,omitempty"`
 }
 

--- a/server/control.go
+++ b/server/control.go
@@ -295,7 +295,7 @@ func (ctl *Control) writer() {
 	defer ctl.allShutdown.Start()
 	defer ctl.writerShutdown.Done()
 
-	encWriter, err := crypto.NewWriter(ctl.conn, []byte(ctl.serverCfg.Token))
+	encWriter, err := crypto.NewWriter(ctl.conn, []byte(ctl.serverCfg.Token), ctl.serverCfg.Aead)
 	if err != nil {
 		xl.Error("crypto new writer error: %v", err)
 		ctl.allShutdown.Start()
@@ -327,7 +327,7 @@ func (ctl *Control) reader() {
 	defer ctl.allShutdown.Start()
 	defer ctl.readerShutdown.Done()
 
-	encReader := crypto.NewReader(ctl.conn, []byte(ctl.serverCfg.Token))
+	encReader := crypto.NewReader(ctl.conn, []byte(ctl.serverCfg.Token), ctl.serverCfg.Aead)
 	for {
 		m, err := msg.ReadMsg(encReader)
 		if err != nil {

--- a/server/proxy/http.go
+++ b/server/proxy/http.go
@@ -151,7 +151,7 @@ func (pxy *HTTPProxy) GetRealConn(remoteAddr string) (workConn net.Conn, err err
 
 	var rwc io.ReadWriteCloser = tmpConn
 	if pxy.cfg.UseEncryption {
-		rwc, err = frpIo.WithEncryption(rwc, []byte(pxy.serverCfg.Token))
+		rwc, err = frpIo.WithEncryption(rwc, []byte(pxy.serverCfg.Token), pxy.cfg.UseAead)
 		if err != nil {
 			xl.Error("create encryption stream error: %v", err)
 			return

--- a/server/proxy/proxy.go
+++ b/server/proxy/proxy.go
@@ -276,9 +276,9 @@ func HandleUserTCPConnection(pxy Proxy, userConn net.Conn, serverCfg config.Serv
 
 	var local io.ReadWriteCloser = workConn
 	cfg := pxy.GetConf().GetBaseInfo()
-	xl.Trace("handler user tcp connection, use_encryption: %t, use_compression: %t", cfg.UseEncryption, cfg.UseCompression)
+	xl.Trace("handler user tcp connection, use_encryption: %t, use_aead: %t, use_compression: %t", cfg.UseEncryption, cfg.UseAead, cfg.UseCompression)
 	if cfg.UseEncryption {
-		local, err = frpIo.WithEncryption(local, []byte(serverCfg.Token))
+		local, err = frpIo.WithEncryption(local, []byte(serverCfg.Token), cfg.UseAead)
 		if err != nil {
 			xl.Error("create encryption stream error: %v", err)
 			return

--- a/server/proxy/udp.go
+++ b/server/proxy/udp.go
@@ -185,7 +185,7 @@ func (pxy *UDPProxy) Run() (remoteAddr string, err error) {
 
 			var rwc io.ReadWriteCloser = workConn
 			if pxy.cfg.UseEncryption {
-				rwc, err = frpIo.WithEncryption(rwc, []byte(pxy.serverCfg.Token))
+				rwc, err = frpIo.WithEncryption(rwc, []byte(pxy.serverCfg.Token), pxy.cfg.UseAead)
 				if err != nil {
 					xl.Error("create encryption stream error: %v", err)
 					workConn.Close()

--- a/server/service.go
+++ b/server/service.go
@@ -514,5 +514,5 @@ func (svr *Service) RegisterWorkConn(workConn net.Conn, newMsg *msg.NewWorkConn)
 
 func (svr *Service) RegisterVisitorConn(visitorConn net.Conn, newMsg *msg.NewVisitorConn) error {
 	return svr.rc.VisitorManager.NewConn(newMsg.ProxyName, visitorConn, newMsg.Timestamp, newMsg.SignKey,
-		newMsg.UseEncryption, newMsg.UseCompression)
+		newMsg.UseEncryption, newMsg.UseAead, newMsg.UseCompression)
 }

--- a/server/visitor/visitor.go
+++ b/server/visitor/visitor.go
@@ -57,7 +57,7 @@ func (vm *Manager) Listen(name string, sk string) (l *frpNet.CustomListener, err
 }
 
 func (vm *Manager) NewConn(name string, conn net.Conn, timestamp int64, signKey string,
-	useEncryption bool, useCompression bool) (err error) {
+	useEncryption bool, useAead bool, useCompression bool) (err error) {
 
 	vm.mu.RLock()
 	defer vm.mu.RUnlock()
@@ -71,7 +71,7 @@ func (vm *Manager) NewConn(name string, conn net.Conn, timestamp int64, signKey 
 
 		var rwc io.ReadWriteCloser = conn
 		if useEncryption {
-			if rwc, err = frpIo.WithEncryption(rwc, []byte(sk)); err != nil {
+			if rwc, err = frpIo.WithEncryption(rwc, []byte(sk), useAead); err != nil {
 				err = fmt.Errorf("create encryption connection failed: %v", err)
 				return
 			}


### PR DESCRIPTION
As we all know, stream encryption is vulnerable and recognizable. Compared with that, AEAD is more difficult to break and is a mainstream encryption method.

Related PR: https://github.com/fatedier/golib/pull/16

We enables frp to support the AEAD method (currently only aes-gcm).

Notice: we should remove the `replace` instruction in `go.mod` before merging. It should be only for our test.

Example configs:

Server side:
```ini
[common]
bind_port = 7000
token = my_token
aead = true
log_level = info
```

Client side:
```ini
[common]
server_addr = 127.0.0.1
server_port = 7000
token = my_token
aead = true

[iperf3]
type = tcp
local_ip = 127.0.0.1
local_port = 5201
remote_port = 5202
use_encryption = true
use_aead = true
```
Then we can use following commands to test:
```bash
iperf3 -s -p 5201
go run ./cmd/frps -c /tmp/frps.ini
go run ./cmd/frps -c /tmp/frpc.ini
iperf3 -c localhost -p 5202
```