### PR TITLE
Adjust package structure of frps

### DIFF
--- a/cmd/frps/main.go
+++ b/cmd/frps/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"github.com/fatedier/frp/cmd/frps/sub"
 	"math/rand"
 	"time"
 
@@ -28,5 +29,5 @@ func main() {
 	crypto.DefaultSalt = "frp"
 	rand.Seed(time.Now().UnixNano())
 
-	Execute()
+	sub.Execute()
 }

--- a/cmd/frps/sub/root.go
+++ b/cmd/frps/sub/root.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package sub
 
 import (
 	"fmt"

--- a/cmd/frps/sub/verify.go
+++ b/cmd/frps/sub/verify.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package sub
 
 import (
 	"fmt"


### PR DESCRIPTION
We can make `cmd/frps/sub` an importable package (same as `frpc`), so it can be accessed from other package.