### PR TITLE
Fixed a bug where service loops reconnection after disconnection. service is shut down and can not exit goroutine

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -198,6 +198,10 @@ func (svr *Service) keepControllerWorking() {
 		}
 
 		for {
+			if atomic.LoadUint32(&svr.exit) != 0 {
+				return
+			}
+
 			xl.Info("try to reconnect to server...")
 			conn, session, err := svr.login()
 			if err != nil {


### PR DESCRIPTION
About:
Fixed a bug where service loops reconnection after disconnection. If service is shut down ,it can not exit goroutine.

Description:
After the connection is disconnected, the service begins to reconnect. At this point, the service is externally shut down, and the reconnected coroutine cannot exit.