### PR TITLE
[client] Remove redundant function parameters in HandleEvent

### DIFF
--- a/client/event/event.go
+++ b/client/event/event.go
@@ -6,18 +6,11 @@ import (
 	"github.com/fatedier/frp/pkg/msg"
 )
 
-type Type int
-
-const (
-	EvStartProxy Type = iota
-	EvCloseProxy
-)
-
 var (
 	ErrPayloadType = errors.New("error payload type")
 )
 
-type Handler func(evType Type, payload interface{}) error
+type Handler func(payload interface{}) error
 
 type StartProxyPayload struct {
 	NewProxyMsg *msg.NewProxy

--- a/client/proxy/proxy_manager.go
+++ b/client/proxy/proxy_manager.go
@@ -75,7 +75,7 @@ func (pm *Manager) HandleWorkConn(name string, workConn net.Conn, m *msg.StartWo
 	}
 }
 
-func (pm *Manager) HandleEvent(evType event.Type, payload interface{}) error {
+func (pm *Manager) HandleEvent(payload interface{}) error {
 	var m msg.Message
 	switch e := payload.(type) {
 	case *event.StartProxyPayload:

--- a/client/proxy/proxy_wrapper.go
+++ b/client/proxy/proxy_wrapper.go
@@ -145,7 +145,7 @@ func (pw *Wrapper) Stop() {
 }
 
 func (pw *Wrapper) close() {
-	pw.handler(event.EvCloseProxy, &event.CloseProxyPayload{
+	pw.handler(&event.CloseProxyPayload{
 		CloseProxyMsg: &msg.CloseProxy{
 			ProxyName: pw.Name,
 		},
@@ -174,7 +174,7 @@ func (pw *Wrapper) checkWorker() {
 				var newProxyMsg msg.NewProxy
 				pw.Cfg.MarshalToMsg(&newProxyMsg)
 				pw.lastSendStartMsg = now
-				pw.handler(event.EvStartProxy, &event.StartProxyPayload{
+				pw.handler(&event.StartProxyPayload{
 					NewProxyMsg: &newProxyMsg,
 				})
 			}


### PR DESCRIPTION
The type parameter of the HandleEvent function seems to be useless, can we remove this parameter?