### PR TITLE
Documentation: Update CLI Command Flags in OpenSSL Certificate Issuance Example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ openssl req -new -sha256 -key server.key \
     -config <(cat my-openssl.cnf <(printf "\n[SAN]\nsubjectAltName=DNS:localhost,IP:127.0.0.1,DNS:example.server.com")) \
     -out server.csr
 
-openssl x509 -req -days 365 \
+openssl x509 -req -days 365 -sha256 \
 	-in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
 	-extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1,DNS:example.server.com") \
 	-out server.crt
@@ -671,7 +671,7 @@ openssl req -new -sha256 -key client.key \
     -config <(cat my-openssl.cnf <(printf "\n[SAN]\nsubjectAltName=DNS:client.com,DNS:example.client.com")) \
     -out client.csr
 
-openssl x509 -req -days 365 \
+openssl x509 -req -days 365 -sha256 \
     -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
 	-extfile <(printf "subjectAltName=DNS:client.com,DNS:example.client.com") \
 	-out client.crt


### PR DESCRIPTION
# What

* Update OpenSSL command flags in README

# Why

In some cases (on some versions of OpenSSL?) following the OpenSSL certificate issuance example outlined in the README leads to the following error in `frpc`:

```
x509: certificate signed by unknown authority (possibly because of "x509: cannot verify signature: insecure algorithm SHA1-RSA (temporarily override with GODEBUG=x509sha1=1)" while trying to verify candidate authority certificate "example.ca.com")
```

This is resolved by the following comment:

https://github.com/fatedier/frp/issues/2957#issuecomment-1159350315|

# Notes

#2957 