### PR TITLE
Added OpExit

### DIFF
--- a/doc/server_plugin.md
+++ b/doc/server_plugin.md
@@ -94,6 +94,29 @@ Client login operation
 }
 ```
 
+#### Exit
+
+Client exit operation. When client cannot connect to server that will notify to admin.
+Can use a new version (OpExit supported at: https://github.com/lowk3v/frp-notify/releases/tag/OpExitSupported)
+
+```
+{
+    "content": {
+        "version": <string>,
+        "hostname": <string>,
+        "os": <string>,
+        "arch": <string>,
+        "user": <string>,
+        "timestamp": <int64>,
+        "privilege_key": <string>,
+        "run_id": <string>,
+        "pool_count": <int>,
+        "metas": map<string>string,
+        "client_address": <string>
+    }
+}
+```
+
 #### NewProxy
 
 Create new proxy

--- a/pkg/msg/msg.go
+++ b/pkg/msg/msg.go
@@ -83,6 +83,19 @@ type LoginResp struct {
 	Error         string `json:"error,omitempty"`
 }
 
+// When frpc exit success, send this message to exit plugin server
+type Exit struct {
+	Version      string            `json:"version,omitempty"`
+	Hostname     string            `json:"hostname,omitempty"`
+	Os           string            `json:"os,omitempty"`
+	Arch         string            `json:"arch,omitempty"`
+	User         string            `json:"user,omitempty"`
+	PrivilegeKey string            `json:"privilege_key,omitempty"`
+	Timestamp    int64             `json:"timestamp,omitempty"`
+	RunID        string            `json:"run_id,omitempty"`
+	Metas        map[string]string `json:"metas,omitempty"`
+}
+
 // When frpc login success, send this message to frps for running a new proxy.
 type NewProxy struct {
 	ProxyName      string            `json:"proxy_name,omitempty"`

--- a/pkg/plugin/server/plugin.go
+++ b/pkg/plugin/server/plugin.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	APIVersion = "0.1.0"
+	APIVersion = "0.1.1"
 
 	OpLogin       = "Login"
+	OpExit        = "Exit"
 	OpNewProxy    = "NewProxy"
 	OpCloseProxy  = "CloseProxy"
 	OpPing        = "Ping"

--- a/pkg/plugin/server/types.go
+++ b/pkg/plugin/server/types.go
@@ -37,6 +37,11 @@ type LoginContent struct {
 	ClientAddress string `json:"client_address,omitempty"`
 }
 
+type ExitContent struct {
+	ClientAddress string `json:"client_address,omitempty"`
+	msg.Exit
+}
+
 type UserInfo struct {
 	User  string            `json:"user"`
 	Metas map[string]string `json:"metas"`

--- a/server/control.go
+++ b/server/control.go
@@ -394,6 +394,25 @@ func (ctl *Control) stoper() {
 
 	ctl.allShutdown.Done()
 	xl.Info("client exit success")
+
+	notifyContent := &plugin.ExitContent{
+		ClientAddress: ctl.conn.RemoteAddr().String(),
+		Exit: msg.Exit{
+			Version:      ctl.loginMsg.Version,
+			Hostname:     ctl.loginMsg.Hostname,
+			Os:           ctl.loginMsg.Os,
+			Arch:         ctl.loginMsg.Arch,
+			User:         ctl.loginMsg.User,
+			PrivilegeKey: ctl.loginMsg.PrivilegeKey,
+			Timestamp:    ctl.loginMsg.Timestamp,
+			RunID:        ctl.loginMsg.RunID,
+			Metas:        ctl.loginMsg.Metas,
+		},
+	}
+	go func() {
+		_ = ctl.pluginManager.Exit(notifyContent)
+	}()
+
 	metrics.Server.CloseClient()
 }
 


### PR DESCRIPTION
I added an option that supported the server plugin with the op is Exit. When the FRP client cannot connect to a server then the server will push a message to the FRP-notify plugin (version OpExit supported at https://github.com/lowk3v/frp-notify/releases/tag/OpExitSupported)
I would like to help someone