### PR TITLE
Set least privileged token permission for GitHub Actions

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -9,6 +9,9 @@ on:
         description: 'Image tag'
         required: true
         default: 'test'
+permissions:
+  contents: read
+
 jobs:
   image:
     name: Build Image from Dockerfile and binaries

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -3,6 +3,9 @@ name: goreleaser
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,8 +8,14 @@ on:
         description: 'In debug mod'
         required: false
         default: 'false'
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v6


### PR DESCRIPTION
Other than `golangci-lint.yml`, all other GitHub Actions workflow files have elevated token permissions as demonstrated by the following workflow execution logs.
https://github.com/fatedier/frp/actions/runs/3334432128/jobs/5517384845#step:1:19

This PR mitigates this issue. In addition to this PR, you should consider setting the following permission so that new workflow files will default to read-only permissions
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>