### PR TITLE
Support OIDC scope parameter

### DIFF
--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -104,7 +104,7 @@ func NewOidcAuthSetter(baseCfg BaseConfig, cfg OidcClientConfig) *OidcAuthProvid
 	}
 
 	// Previous versions hardcoded the scope to audience,
-	// so for backwards compatability, use that if no scope is set
+	// so for backwards compatibility, use that if no scope is set
 	scope := cfg.OidcAudience
 	if cfg.OidcScope != "" {
 		scope = cfg.OidcScope

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -36,6 +36,9 @@ type OidcClientConfig struct {
 	// OidcAudience specifies the audience of the token in OIDC authentication
 	// if AuthenticationMethod == "oidc". By default, this value is "".
 	OidcAudience string `ini:"oidc_audience" json:"oidc_audience"`
+	// OidcScope specifies the scope of the token in OIDC authentication
+	// if AuthenticationMethod == "oidc". By default, this value is "".
+	OidcScope string `ini:"oidc_scope" json:"oidc_scope"`
 	// OidcTokenEndpointURL specifies the URL which implements OIDC Token Endpoint.
 	// It will be used to get an OIDC token if AuthenticationMethod == "oidc".
 	// By default, this value is "".
@@ -52,6 +55,7 @@ func getDefaultOidcClientConf() OidcClientConfig {
 		OidcClientID:                 "",
 		OidcClientSecret:             "",
 		OidcAudience:                 "",
+		OidcScope:                    "",
 		OidcTokenEndpointURL:         "",
 		OidcAdditionalEndpointParams: make(map[string]string),
 	}
@@ -102,7 +106,7 @@ func NewOidcAuthSetter(baseCfg BaseConfig, cfg OidcClientConfig) *OidcAuthProvid
 	tokenGenerator := &clientcredentials.Config{
 		ClientID:       cfg.OidcClientID,
 		ClientSecret:   cfg.OidcClientSecret,
-		Scopes:         []string{cfg.OidcAudience},
+		Scopes:         []string{cfg.OidcScope},
 		TokenURL:       cfg.OidcTokenEndpointURL,
 		EndpointParams: eps,
 	}

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -103,10 +103,17 @@ func NewOidcAuthSetter(baseCfg BaseConfig, cfg OidcClientConfig) *OidcAuthProvid
 		eps[k] = []string{v}
 	}
 
+	// Previous versions hardcoded the scope to audience,
+	// so for backwards compatability, use that if no scope is set
+	scope := cfg.OidcAudience
+	if cfg.OidcScope != "" {
+		scope = cfg.OidcScope
+	}
+
 	tokenGenerator := &clientcredentials.Config{
 		ClientID:       cfg.OidcClientID,
 		ClientSecret:   cfg.OidcClientSecret,
-		Scopes:         []string{cfg.OidcScope},
+		Scopes:         []string{scope},
 		TokenURL:       cfg.OidcTokenEndpointURL,
 		EndpointParams: eps,
 	}


### PR DESCRIPTION
allow scope to be passed in for oidc credentials, maintaining backwards compatibility. this was discussed in #3177 