### PR TITLE
Fix basic example server to join in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Note that `local_port` (listened on client) and `remote_port` (exposed on server
 
   `./frpc -c ./frpc.ini`
 
-5. From another machine, SSH to server A like this (assuming that username is `test`):
+5. From another machine, SSH to server B via server A  like this (assuming that username is `test`):
 
   `ssh -oPort=6000 test@x.x.x.x`
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Note that `local_port` (listened on client) and `remote_port` (exposed on server
 
   `./frpc -c ./frpc.ini`
 
-5. From another machine, SSH to server B like this (assuming that username is `test`):
+5. From another machine, SSH to server A like this (assuming that username is `test`):
 
   `ssh -oPort=6000 test@x.x.x.x`
 


### PR DESCRIPTION
As i understand `frps` creates the proxy on `remote_port` of `frpc`. In that case port `6000` would be open on server A. Architecture diagram tells the same.