### PR TITLE
optimize: GetAuthKey

### DIFF
--- a/pkg/util/util/util.go
+++ b/pkg/util/util/util.go
@@ -44,9 +44,9 @@ func RandIDWithLen(idLen int) (id string, err error) {
 }
 
 func GetAuthKey(token string, timestamp int64) (key string) {
-	token += fmt.Sprintf("%d", timestamp)
 	md5Ctx := md5.New()
 	md5Ctx.Write([]byte(token))
+	md5Ctx.Write([]byte(strconv.FormatInt(timestamp, 10)))
 	data := md5Ctx.Sum(nil)
 	return hex.EncodeToString(data)
 }


### PR DESCRIPTION
could be ~30% faster, it's a hot function that deserves an optimization

```
goos: windows
goarch: amd64
pkg: github.com/fatedier/frp/pkg/util/util
cpu: AMD Ryzen 9 5950X 16-Core Processor
BenchmarkGetAuthKey
BenchmarkGetAuthKey-32           6673195               179.0 ns/op            96 B/op          4 allocs/op
BenchmarkGetAuthKeyOld
BenchmarkGetAuthKeyOld-32        4884744               244.7 ns/op           128 B/op          6 allocs/op
```

Use this patch for benchmark: [patch.txt](https://github.com/fatedier/frp/files/10415430/patch.txt)
