### PR TITLE
add max_delay_time parameter to frpc

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -168,7 +168,7 @@ func (svr *Service) Run() error {
 
 func (svr *Service) keepControllerWorking() {
 	xl := xlog.FromContextSafe(svr.ctx)
-	maxDelayTime := 20 * time.Second
+	maxDelayTime := time.Duration(svr.cfg.MaxDelayTime) * time.Second
 	delayTime := time.Second
 
 	// if frpc reconnect frps, we need to limit retry times in 1min

--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -161,6 +161,8 @@ type ClientCommonConf struct {
 	// Enable golang pprof handlers in admin listener.
 	// Admin port must be set first.
 	PprofEnable bool `ini:"pprof_enable" json:"pprof_enable"`
+	// MaxDelayTime specifies the maximum waiting time for frpc to reconnect frps.
+	MaxDelayTime int64 `ini:"max_delay_time" json:"max_delay_time"`
 }
 
 // GetDefaultClientConf returns a client configuration with default values.
@@ -191,6 +193,7 @@ func GetDefaultClientConf() ClientCommonConf {
 		Metas:                   make(map[string]string),
 		UDPPacketSize:           1500,
 		IncludeConfigFiles:      make([]string, 0),
+		MaxDelayTime:            20,
 	}
 }
 

--- a/pkg/config/client_test.go
+++ b/pkg/config/client_test.go
@@ -296,6 +296,7 @@ func Test_LoadClientCommonConf(t *testing.T) {
 		},
 		UDPPacketSize:      1509,
 		IncludeConfigFiles: []string{},
+		MaxDelayTime:       60,
 	}
 
 	common, err := UnmarshalClientConfFromIni(testClientBytesWithFull)

--- a/pkg/config/client_test.go
+++ b/pkg/config/client_test.go
@@ -296,7 +296,7 @@ func Test_LoadClientCommonConf(t *testing.T) {
 		},
 		UDPPacketSize:      1509,
 		IncludeConfigFiles: []string{},
-		MaxDelayTime:       60,
+		MaxDelayTime:       20,
 	}
 
 	common, err := UnmarshalClientConfFromIni(testClientBytesWithFull)

--- a/pkg/config/client_test.go
+++ b/pkg/config/client_test.go
@@ -67,6 +67,7 @@ var testClientBytesWithFull = []byte(`
 		meta_var1 = 123
 		meta_var2 = 234
 		udp_packet_size = 1509
+		max_delay_time = 60
 		
 		# all proxy
 		[ssh]
@@ -296,7 +297,7 @@ func Test_LoadClientCommonConf(t *testing.T) {
 		},
 		UDPPacketSize:      1509,
 		IncludeConfigFiles: []string{},
-		MaxDelayTime:       20,
+		MaxDelayTime:       60,
 	}
 
 	common, err := UnmarshalClientConfFromIni(testClientBytesWithFull)


### PR DESCRIPTION
Add the `max_delay_time` parameter to frpc to avoid too frequent reconnection requests from frpc to frps and keep trying reconnection #3270 