### PR TITLE
nathole: support discover without configuration file

### DIFF
--- a/cmd/frpc/sub/nathole.go
+++ b/cmd/frpc/sub/nathole.go
@@ -26,7 +26,10 @@ import (
 	"github.com/fatedier/frp/pkg/nathole"
 )
 
-var natHoleSTUNServer string
+var (
+	natHoleSTUNServer string
+	serverUDPPort     int
+)
 
 func init() {
 	RegisterCommonFlags(natholeCmd)
@@ -34,7 +37,8 @@ func init() {
 	rootCmd.AddCommand(natholeCmd)
 	natholeCmd.AddCommand(natholeDiscoveryCmd)
 
-	natholeCmd.PersistentFlags().StringVarP(&natHoleSTUNServer, "nat_hole_stun_server", "", "", "STUN server address for nathole")
+	natholeCmd.PersistentFlags().StringVarP(&natHoleSTUNServer, "nat_hole_stun_server", "", "stun.easyvoip.com:3478", "STUN server address for nathole")
+	natholeCmd.PersistentFlags().IntVarP(&serverUDPPort, "server_udp_port", "", 0, "UDP port of frps for nathole")
 }
 
 var natholeCmd = &cobra.Command{
@@ -46,13 +50,13 @@ var natholeDiscoveryCmd = &cobra.Command{
 	Use:   "discover",
 	Short: "Discover nathole information by frps and stun server",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, _, _, err := config.ParseClientConfig(cfgFile)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		// ignore error here, because we can use command line pameters
+		cfg, _, _, _ := config.ParseClientConfig(cfgFile)
 		if natHoleSTUNServer != "" {
 			cfg.NatHoleSTUNServer = natHoleSTUNServer
+		}
+		if serverUDPPort != 0 {
+			cfg.ServerUDPPort = serverUDPPort
 		}
 
 		if err := validateForNatHoleDiscovery(cfg); err != nil {


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5fa1026</samp>

Added a new option and a default value for nathole feature in `frpc`. This improves the usability and reliability of UDP hole punching for frp clients.

### WHY
<!-- author to complete -->

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5fa1026</samp>

* Add a new flag `--server_udp_port` to specify the UDP port of frps for nathole ([link](https://github.com/fatedier/frp/pull/3395/files?diff=unified&w=0#diff-5ac4ee81516dfc6b3f0a0abd3e447ee4a2d03d59a7a62be497d7dbf208c3da0dL37-R41))
* Change the default value of `natHoleSTUNServer` to "stun.easyvoip.com:3478" to provide a public STUN server for nathole ([link](https://github.com/fatedier/frp/pull/3395/files?diff=unified&w=0#diff-5ac4ee81516dfc6b3f0a0abd3e447ee4a2d03d59a7a62be497d7dbf208c3da0dL37-R41))
* Override the values of `natHoleSTUNServer` and `serverUDPPort` in the `cfg` object with the flag values if they are not empty or zero ([link](https://github.com/fatedier/frp/pull/3395/files?diff=unified&w=0#diff-5ac4ee81516dfc6b3f0a0abd3e447ee4a2d03d59a7a62be497d7dbf208c3da0dL49-R60))
* Remove the error handling of `config.ParseClientConfig` in `nathole.go` as the flags can override the config file or the environment variables ([link](https://github.com/fatedier/frp/pull/3395/files?diff=unified&w=0#diff-5ac4ee81516dfc6b3f0a0abd3e447ee4a2d03d59a7a62be497d7dbf208c3da0dL49-R60))
* Add a new variable `serverUDPPort` to store the UDP port of frps for nathole ([link](https://github.com/fatedier/frp/pull/3395/files?diff=unified&w=0#diff-5ac4ee81516dfc6b3f0a0abd3e447ee4a2d03d59a7a62be497d7dbf208c3da0dL29-R32))
