### PR TITLE
Update frpc_full.ini

### DIFF
--- a/conf/frpc_full.ini
+++ b/conf/frpc_full.ini
@@ -258,7 +258,7 @@ local_ip = 127.0.0.1
 local_port = 8000
 use_encryption = false
 use_compression = false
-subdomain = web01
+subdomain = web02
 custom_domains = web02.yourdomain.com
 # if not empty, frpc will use proxy protocol to transfer connection info to your local service
 # v1 or v2 or empty


### PR DESCRIPTION
Fix typos.

### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5bc325e</samp>

Update `frpc_full.ini` example file to use the same subdomain as `frps_full.ini`. This makes the web service accessible at `web02.[your_domain].com` instead of `web01.[your_domain].com`.

### WHY
<!-- author to complete -->

Fix typos.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5bc325e</samp>

* Change the subdomain for the web service from web01 to web02 in the frpc_full.ini example file ([link](https://github.com/fatedier/frp/pull/3399/files?diff=unified&w=0#diff-12bf97fbdf713937ce234cefa7dd9244ac8f86ca1c32e8b5af7aa8232bef5983L261-R261))
