### PR TITLE
client: support websocket over TLS (wss://).

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -455,7 +455,12 @@ func (cm *ConnectionManager) realConnect() (net.Conn, error) {
 	protocol := cm.cfg.Protocol
 	if protocol == "websocket" {
 		protocol = "tcp"
-		dialOptions = append(dialOptions, libdial.WithAfterHook(libdial.AfterHook{Hook: frpNet.DialHookWebsocket()}))
+		dialOptions = append(dialOptions, libdial.WithAfterHook(libdial.AfterHook{
+			// make sure to do the websocket handshake after the TLS handshake,
+			// to support websocket over TLS.
+			Priority: libdial.WithTLSConfigPriority + 1,
+			Hook:     frpNet.DialHookWebsocket(),
+		}))
 	}
 	if cm.cfg.ConnectServerLocalIP != "" {
 		dialOptions = append(dialOptions, libdial.WithLocalAddr(cm.cfg.ConnectServerLocalIP))


### PR DESCRIPTION
This adds support for using `protocol=websocket` and TLS at the same time in `frpc`.

The issue was the TLS handshake has to run before the websocket handshake. This required a small patch in golib: https://github.com/fatedier/golib/pull/20

Tested working with this config. The server is running `frps` behind an NGINX reverse proxy that terminates TLS.

```ini
[common]
server_addr = frp.example.com
server_port = 443
protocol = websocket
tls_enable = true
disable_custom_tls_first_byte = true
```