### PR TITLE
fix: typo tot => to

### DIFF
--- a/client/visitor.go
+++ b/client/visitor.go
@@ -37,7 +37,7 @@ import (
 	"github.com/fatedier/frp/pkg/util/xlog"
 )
 
-// Visitor is used for forward traffics from local port tot remote service.
+// Visitor is used for forward traffics from local port to remote service.
 type Visitor interface {
 	Run() error
 	Close()


### PR DESCRIPTION
### Summary

fixed trivial typo

### WHY

### Walkthrough
