### PR TITLE
add e2e case for xtcp

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -17,4 +17,4 @@ if [ x${LOG_LEVEL} != x"" ]; then
     logLevel=${LOG_LEVEL}
 fi
 
-ginkgo -nodes=8 --poll-progress-after=20s ${ROOT}/test/e2e -- -frpc-path=${ROOT}/bin/frpc -frps-path=${ROOT}/bin/frps -log-level=${logLevel} -debug=${debug}
+ginkgo -nodes=8 --poll-progress-after=30s ${ROOT}/test/e2e -- -frpc-path=${ROOT}/bin/frpc -frps-path=${ROOT}/bin/frps -log-level=${logLevel} -debug=${debug}

--- a/test/e2e/basic/basic.go
+++ b/test/e2e/basic/basic.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 
@@ -275,8 +276,8 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 		})
 	})
 
-	ginkgo.Describe("STCP && SUDP", func() {
-		types := []string{"stcp", "sudp"}
+	ginkgo.Describe("STCP && SUDP && XTCP", func() {
+		types := []string{"stcp", "sudp", "xtcp"}
 		for _, t := range types {
 			proxyType := t
 			ginkgo.It(fmt.Sprintf("Expose echo server with %s", strings.ToUpper(proxyType)), func() {
@@ -293,6 +294,9 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 				case "sudp":
 					localPortName = framework.UDPEchoServerPort
 					protocol = "udp"
+				case "xtcp":
+					localPortName = framework.TCPEchoServerPort
+					protocol = "tcp"
 				}
 
 				correctSK := "abc"
@@ -371,6 +375,9 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 
 				for _, test := range tests {
 					framework.NewRequestExpect(f).
+						RequestModify(func(r *request.Request) {
+							r.Timeout(5 * time.Second)
+						}).
 						Protocol(protocol).
 						PortName(test.bindPortName).
 						Explain(test.proxyName).


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f152b97</samp>

Added `xtcp` tests to the `test/e2e/basic` package and increased the test progress report interval in `hack/run-e2e.sh`. These changes improve the test coverage and readability of the end-to-end tests.

### WHY
<!-- author to complete -->

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f152b97</samp>

* Increase the test progress report interval to 30s to reduce log noise and size ([link](https://github.com/fatedier/frp/pull/3451/files?diff=unified&w=0#diff-0913e7b61c925dbdbf31c36ad24131da81c64f8ec9c3477662eec4cca73dba07L20-R20))
* Import the `time` package to use timeouts and delays in some test cases ([link](https://github.com/fatedier/frp/pull/3451/files?diff=unified&w=0#diff-198c426913c63e51585ac1793ca15e8e195cf8a0a72ba93e9b12d2f6acd9fa44R7))
  - Add `"xtcp"` to the proxy types slice in the `STCP && SUDP` describe block ([link](https://github.com/fatedier/frp/pull/3451/files?diff=unified&w=0#diff-198c426913c63e51585ac1793ca15e8e195cf8a0a72ba93e9b12d2f6acd9fa44L278-R280))
  - Add a case block for the `xtcp` proxy type in the `BeforeEach` block, setting the local port name and protocol to TCP ([link](https://github.com/fatedier/frp/pull/3451/files?diff=unified&w=0#diff-198c426913c63e51585ac1793ca15e8e195cf8a0a72ba93e9b12d2f6acd9fa44R297-R299))
  - Add a `RequestModify` function to the `ExpectConnectServer` function call in the `It` block, setting a timeout of 5 seconds for the request ([link](https://github.com/fatedier/frp/pull/3451/files?diff=unified&w=0#diff-198c426913c63e51585ac1793ca15e8e195cf8a0a72ba93e9b12d2f6acd9fa44R378-R380))
