### PR TITLE
use constant time comparison

### DIFF
--- a/client/admin.go
+++ b/client/admin.go
@@ -48,7 +48,7 @@ func (svr *Service) RunAdminServer(address string) (err error) {
 
 	subRouter := router.NewRoute().Subrouter()
 	user, passwd := svr.cfg.AdminUser, svr.cfg.AdminPwd
-	subRouter.Use(frpNet.NewHTTPAuthMiddleware(user, passwd).Middleware)
+	subRouter.Use(frpNet.NewHTTPAuthMiddleware(user, passwd).SetAuthFailDelay(200 * time.Millisecond).Middleware)
 
 	// api, see admin_api.go
 	subRouter.HandleFunc("/api/reload", svr.apiReload).Methods("GET")

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -73,30 +73,30 @@ func (auth *TokenAuthSetterVerifier) SetNewWorkConn(newWorkConnMsg *msg.NewWorkC
 	return nil
 }
 
-func (auth *TokenAuthSetterVerifier) VerifyLogin(loginMsg *msg.Login) error {
-	if util.GetAuthKey(auth.token, loginMsg.Timestamp) != loginMsg.PrivilegeKey {
+func (auth *TokenAuthSetterVerifier) VerifyLogin(m *msg.Login) error {
+	if !util.ConstantTimeEqString(util.GetAuthKey(auth.token, m.Timestamp), m.PrivilegeKey) {
 		return fmt.Errorf("token in login doesn't match token from configuration")
 	}
 	return nil
 }
 
-func (auth *TokenAuthSetterVerifier) VerifyPing(pingMsg *msg.Ping) error {
+func (auth *TokenAuthSetterVerifier) VerifyPing(m *msg.Ping) error {
 	if !auth.AuthenticateHeartBeats {
 		return nil
 	}
 
-	if util.GetAuthKey(auth.token, pingMsg.Timestamp) != pingMsg.PrivilegeKey {
+	if !util.ConstantTimeEqString(util.GetAuthKey(auth.token, m.Timestamp), m.PrivilegeKey) {
 		return fmt.Errorf("token in heartbeat doesn't match token from configuration")
 	}
 	return nil
 }
 
-func (auth *TokenAuthSetterVerifier) VerifyNewWorkConn(newWorkConnMsg *msg.NewWorkConn) error {
+func (auth *TokenAuthSetterVerifier) VerifyNewWorkConn(m *msg.NewWorkConn) error {
 	if !auth.AuthenticateNewWorkConns {
 		return nil
 	}
 
-	if util.GetAuthKey(auth.token, newWorkConnMsg.Timestamp) != newWorkConnMsg.PrivilegeKey {
+	if !util.ConstantTimeEqString(util.GetAuthKey(auth.token, m.Timestamp), m.PrivilegeKey) {
 		return fmt.Errorf("token in NewWorkConn doesn't match token from configuration")
 	}
 	return nil

--- a/pkg/nathole/controller.go
+++ b/pkg/nathole/controller.go
@@ -174,7 +174,7 @@ func (c *Controller) HandleVisitor(m *msg.NatHoleVisitor, transporter transport.
 		if !ok {
 			return fmt.Errorf("xtcp server for [%s] doesn't exist", m.ProxyName)
 		}
-		if m.SignKey != util.GetAuthKey(clientCfg.sk, m.Timestamp) {
+		if !util.ConstantTimeEqString(m.SignKey, util.GetAuthKey(clientCfg.sk, m.Timestamp)) {
 			return fmt.Errorf("xtcp connection of [%s] auth failed", m.ProxyName)
 		}
 		c.sessions[sid] = session

--- a/pkg/plugin/client/http_proxy.go
+++ b/pkg/plugin/client/http_proxy.go
@@ -21,11 +21,13 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	frpIo "github.com/fatedier/golib/io"
 	gnet "github.com/fatedier/golib/net"
 
 	frpNet "github.com/fatedier/frp/pkg/util/net"
+	"github.com/fatedier/frp/pkg/util/util"
 )
 
 const PluginHTTPProxy = "http_proxy"
@@ -179,7 +181,9 @@ func (hp *HTTPProxy) Auth(req *http.Request) bool {
 		return false
 	}
 
-	if pair[0] != hp.AuthUser || pair[1] != hp.AuthPasswd {
+	if !util.ConstantTimeEqString(pair[0], hp.AuthUser) ||
+		!util.ConstantTimeEqString(pair[1], hp.AuthPasswd) {
+		time.Sleep(200 * time.Millisecond)
 		return false
 	}
 	return true

--- a/pkg/plugin/client/static_file.go
+++ b/pkg/plugin/client/static_file.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 
@@ -64,7 +65,7 @@ func NewStaticFilePlugin(params map[string]string) (Plugin, error) {
 	}
 
 	router := mux.NewRouter()
-	router.Use(frpNet.NewHTTPAuthMiddleware(httpUser, httpPasswd).Middleware)
+	router.Use(frpNet.NewHTTPAuthMiddleware(httpUser, httpPasswd).SetAuthFailDelay(200 * time.Millisecond).Middleware)
 	router.PathPrefix(prefix).Handler(frpNet.MakeHTTPGzipHandler(http.StripPrefix(prefix, http.FileServer(http.Dir(localPath))))).Methods("GET")
 	sp.s = &http.Server{
 		Handler: router,

--- a/pkg/util/util/util.go
+++ b/pkg/util/util/util.go
@@ -17,6 +17,7 @@ package util
 import (
 	"crypto/md5"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
 	mathrand "math/rand"
@@ -138,4 +139,8 @@ func RandomSleep(duration time.Duration, minRatio, maxRatio float64) time.Durati
 	d := duration * time.Duration(n) / time.Duration(1000)
 	time.Sleep(d)
 	return d
+}
+
+func ConstantTimeEqString(a, b string) bool {
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }

--- a/server/dashboard.go
+++ b/server/dashboard.go
@@ -50,7 +50,7 @@ func (svr *Service) RunDashboardServer(address string) (err error) {
 	subRouter := router.NewRoute().Subrouter()
 
 	user, passwd := svr.cfg.DashboardUser, svr.cfg.DashboardPwd
-	subRouter.Use(frpNet.NewHTTPAuthMiddleware(user, passwd).Middleware)
+	subRouter.Use(frpNet.NewHTTPAuthMiddleware(user, passwd).SetAuthFailDelay(200 * time.Millisecond).Middleware)
 
 	// metrics
 	if svr.cfg.EnablePrometheus {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -66,8 +66,8 @@ func NewDefaultFramework() *Framework {
 	options := Options{
 		TotalParallelNode: suiteConfig.ParallelTotal,
 		CurrentNodeIndex:  suiteConfig.ParallelProcess,
-		FromPortIndex:     20000,
-		ToPortIndex:       50000,
+		FromPortIndex:     10000,
+		ToPortIndex:       60000,
 	}
 	return NewFramework(options)
 }
@@ -118,14 +118,14 @@ func (f *Framework) AfterEach() {
 	// stop processor
 	for _, p := range f.serverProcesses {
 		_ = p.Stop()
-		if TestContext.Debug {
+		if TestContext.Debug || ginkgo.CurrentSpecReport().Failed() {
 			fmt.Println(p.ErrorOutput())
 			fmt.Println(p.StdOutput())
 		}
 	}
 	for _, p := range f.clientProcesses {
 		_ = p.Stop()
-		if TestContext.Debug {
+		if TestContext.Debug || ginkgo.CurrentSpecReport().Failed() {
 			fmt.Println(p.ErrorOutput())
 			fmt.Println(p.StdOutput())
 		}

--- a/test/e2e/framework/process.go
+++ b/test/e2e/framework/process.go
@@ -38,7 +38,7 @@ func (f *Framework) RunProcesses(serverTemplates []string, clientTemplates []str
 		err = p.Start()
 		ExpectNoError(err)
 	}
-	time.Sleep(2 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	currentClientProcesses := make([]*process.Process, 0, len(clientTemplates))
 	for i := range clientTemplates {
@@ -56,7 +56,7 @@ func (f *Framework) RunProcesses(serverTemplates []string, clientTemplates []str
 		ExpectNoError(err)
 		time.Sleep(500 * time.Millisecond)
 	}
-	time.Sleep(5 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	return currentServerProcesses, currentClientProcesses
 }

--- a/test/e2e/pkg/port/port.go
+++ b/test/e2e/pkg/port/port.go
@@ -58,7 +58,7 @@ func (pa *Allocator) GetByName(portName string) int {
 			return 0
 		}
 
-		l, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+		l, err := net.Listen("tcp", net.JoinHostPort("0.0.0.0", strconv.Itoa(port)))
 		if err != nil {
 			// Maybe not controlled by us, mark it used.
 			pa.used.Insert(port)
@@ -66,7 +66,7 @@ func (pa *Allocator) GetByName(portName string) int {
 		}
 		l.Close()
 
-		udpAddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+		udpAddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort("0.0.0.0", strconv.Itoa(port)))
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 920ea05</samp>

This pull request enhances the security of frp by using constant time string comparisons and adding delays for authentication failures in various components. It also improves the error logging and test execution time for the e2e tests. The affected components include the token auth setter verifier, the http_proxy and static_file plugins, the HTTPAuthMiddleware, the admin and dashboard servers, and the xtcp controller.

### WHY
<!-- author to complete -->

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 920ea05</samp>

*  Prevent timing attacks and brute force attacks on authentication by using constant time string comparison and adding delays for invalid credentials ([link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-59287927a544069422a5f28382e81bb40ace0d744675513cb7a61edf9c580032L51-R51), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-d310d7e9bbd41ac7a0cf3116a8c3c8726aae2a76591c96d002eaa454678ff544L76-R77), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-d310d7e9bbd41ac7a0cf3116a8c3c8726aae2a76591c96d002eaa454678ff544L83-R88), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-d310d7e9bbd41ac7a0cf3116a8c3c8726aae2a76591c96d002eaa454678ff544L94-R99), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-2f15ef36bc925196e99eb8971b235db30a64a9c44c6ac37215abdaaac812777fL177-R177), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-97bc97cc16f9ba8e279612e411a2cee0403c5ed2af7be924ed66854f419b6964R24), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-97bc97cc16f9ba8e279612e411a2cee0403c5ed2af7be924ed66854f419b6964R30), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-97bc97cc16f9ba8e279612e411a2cee0403c5ed2af7be924ed66854f419b6964L182-R186), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-c8767c89d4dc441b090b7667cb8971a9df6a576eba3bbbc54ff54d77c280394cR21), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-c8767c89d4dc441b090b7667cb8971a9df6a576eba3bbbc54ff54d77c280394cL67-R68), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-3a844d843eca1bc9bd56950dc0d638bc09f566f9854102d04b22793506327b56R22-R24), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-3a844d843eca1bc9bd56950dc0d638bc09f566f9854102d04b22793506327b56L49-R54), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-3a844d843eca1bc9bd56950dc0d638bc09f566f9854102d04b22793506327b56L60-R79), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-3a844d843eca1bc9bd56950dc0d638bc09f566f9854102d04b22793506327b56L73-L85), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-220bfdeeeeaabb744e23da69fbada64e73aa59078dac6fa8894a64ddcd8eec08R20), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-220bfdeeeeaabb744e23da69fbada64e73aa59078dac6fa8894a64ddcd8eec08R143-R146), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-784df5374a58c17eb8c55b7253a3354d5035ec70687e9d48fcbabc889ba9c389L53-R53))
  * Add a delay of 200 milliseconds to the HTTP authentication middleware for the `admin.go`, `static_file.go`, and `dashboard.go` files ([link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-59287927a544069422a5f28382e81bb40ace0d744675513cb7a61edf9c580032L51-R51), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-c8767c89d4dc441b090b7667cb8971a9df6a576eba3bbbc54ff54d77c280394cR21), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-c8767c89d4dc441b090b7667cb8971a9df6a576eba3bbbc54ff54d77c280394cL67-R68), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-784df5374a58c17eb8c55b7253a3354d5035ec70687e9d48fcbabc889ba9c389L53-R53))
  * Add the time and util packages to the imports for the `http_proxy.go`, `static_file.go`, and `net/http.go` files ([link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-97bc97cc16f9ba8e279612e411a2cee0403c5ed2af7be924ed66854f419b6964R24), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-c8767c89d4dc441b090b7667cb8971a9df6a576eba3bbbc54ff54d77c280394cR21), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-3a844d843eca1bc9bd56950dc0d638bc09f566f9854102d04b22793506327b56R22-R24))
  * Add a field and a method for setting the authentication failure delay to the HTTP authentication middleware struct in `net/http.go` ([link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-3a844d843eca1bc9bd56950dc0d638bc09f566f9854102d04b22793506327b56L49-R54), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-3a844d843eca1bc9bd56950dc0d638bc09f566f9854102d04b22793506327b56L60-R79))
  * Replace the string comparison with a constant time string comparison for verifying the basic authentication credentials in the `http_proxy.go` and `net/http.go` files ([link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-97bc97cc16f9ba8e279612e411a2cee0403c5ed2af7be924ed66854f419b6964R30), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-97bc97cc16f9ba8e279612e411a2cee0403c5ed2af7be924ed66854f419b6964L182-R186), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-3a844d843eca1bc9bd56950dc0d638bc09f566f9854102d04b22793506327b56R22-R24), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-3a844d843eca1bc9bd56950dc0d638bc09f566f9854102d04b22793506327b56L73-L85))
  * Add the subtle package to the imports and a function for constant time string comparison to the `util/util.go` file ([link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-220bfdeeeeaabb744e23da69fbada64e73aa59078dac6fa8894a64ddcd8eec08R20), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-220bfdeeeeaabb744e23da69fbada64e73aa59078dac6fa8894a64ddcd8eec08R143-R146))
  * Replace the string comparison with a constant time string comparison for verifying the token in the `token.go` file and the sign key in the `controller.go` file ([link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-d310d7e9bbd41ac7a0cf3116a8c3c8726aae2a76591c96d002eaa454678ff544L76-R77), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-d310d7e9bbd41ac7a0cf3116a8c3c8726aae2a76591c96d002eaa454678ff544L83-R88), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-d310d7e9bbd41ac7a0cf3116a8c3c8726aae2a76591c96d002eaa454678ff544L94-R99), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-2f15ef36bc925196e99eb8971b235db30a64a9c44c6ac37215abdaaac812777fL177-R177))
* Reduce the sleep time after starting the server and client processes for the tests in `process.go` ([link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-2ce7cd299067ef6a56dda8fc78be4f7471ddf92a4ff6df1b5390358eba3ee42dL59-R59))
* Print the error and standard output of the server and client processes after each test in `framework.go` ([link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-c354587e36151f73f4a4da62c22d612510bee633ada8a52ed16b89c7185f0283L121-R121), [link](https://github.com/fatedier/frp/pull/3452/files?diff=unified&w=0#diff-c354587e36151f73f4a4da62c22d612510bee633ada8a52ed16b89c7185f0283L128-R128))
