### PR TITLE
xtcp: when connection timeout occurs, support fallback to STCP

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -369,7 +369,8 @@ func (cm *ConnectionManager) OpenConnection() error {
 		}
 		tlsConfig.NextProtos = []string{"frp"}
 
-		conn, err := quic.DialAddr(
+		conn, err := quic.DialAddrContext(
+			cm.ctx,
 			net.JoinHostPort(cm.cfg.ServerAddr, strconv.Itoa(cm.cfg.ServerPort)),
 			tlsConfig, &quic.Config{
 				MaxIdleTimeout:     time.Duration(cm.cfg.QUICMaxIdleTimeout) * time.Second,
@@ -467,7 +468,8 @@ func (cm *ConnectionManager) realConnect() (net.Conn, error) {
 			Hook: utilnet.DialHookCustomTLSHeadByte(tlsConfig != nil, cm.cfg.DisableCustomTLSFirstByte),
 		}),
 	)
-	conn, err := libdial.Dial(
+	conn, err := libdial.DialContext(
+		cm.ctx,
 		net.JoinHostPort(cm.cfg.ServerAddr, strconv.Itoa(cm.cfg.ServerPort)),
 		dialOptions...,
 	)

--- a/client/visitor/sudp.go
+++ b/client/visitor/sudp.go
@@ -254,6 +254,7 @@ func (sv *SUDPVisitor) Close() {
 	default:
 		close(sv.checkCloseCh)
 	}
+	sv.BaseVisitor.Close()
 	if sv.udpConn != nil {
 		sv.udpConn.Close()
 	}

--- a/cmd/frpc/sub/root.go
+++ b/cmd/frpc/sub/root.go
@@ -117,7 +117,6 @@ var rootCmd = &cobra.Command{
 		// Do not show command usage here.
 		err := runClient(cfgFile)
 		if err != nil {
-			fmt.Println(err)
 			os.Exit(1)
 		}
 		return nil
@@ -199,6 +198,7 @@ func parseClientCommonCfgFromCmd() (cfg config.ClientCommonConf, err error) {
 func runClient(cfgFilePath string) error {
 	cfg, pxyCfgs, visitorCfgs, err := config.ParseClientConfig(cfgFilePath)
 	if err != nil {
+		fmt.Println(err)
 		return err
 	}
 	return startService(cfg, pxyCfgs, visitorCfgs, cfgFilePath)
@@ -214,8 +214,8 @@ func startService(
 		cfg.LogMaxDays, cfg.DisableLogColor)
 
 	if cfgFile != "" {
-		log.Trace("start frpc service for config file [%s]", cfgFile)
-		defer log.Trace("frpc service for config file [%s] stopped", cfgFile)
+		log.Info("start frpc service for config file [%s]", cfgFile)
+		defer log.Info("frpc service for config file [%s] stopped", cfgFile)
 	}
 	svr, errRet := client.NewService(cfg, pxyCfgs, visitorCfgs, cfgFile)
 	if errRet != nil {

--- a/conf/frpc_full.ini
+++ b/conf/frpc_full.ini
@@ -337,6 +337,8 @@ server_name = secret_tcp
 sk = abcdefg
 # connect this address to visitor stcp server
 bind_addr = 127.0.0.1
+# bind_port can be less than 0, it means don't bind to the port and only receive connections redirected from
+# other visitors. (This is not supported for SUDP now)
 bind_port = 9000
 use_encryption = false
 use_compression = false
@@ -355,6 +357,8 @@ type = xtcp
 server_name = p2p_tcp
 sk = abcdefg
 bind_addr = 127.0.0.1
+# bind_port can be less than 0, it means don't bind to the port and only receive connections redirected from
+# other visitors. (This is not supported for SUDP now)
 bind_port = 9001
 use_encryption = false
 use_compression = false
@@ -363,6 +367,8 @@ keep_tunnel_open = false
 # effective when keep_tunnel_open is set to true, the number of attempts to punch through per hour
 max_retries_an_hour = 8
 min_retry_interval = 90
+# fallback_to = stcp_visitor
+# fallback_timeout_ms = 500
 
 [tcpmuxhttpconnect]
 type = tcpmux

--- a/pkg/config/client_test.go
+++ b/pkg/config/client_test.go
@@ -661,9 +661,10 @@ func Test_LoadClientBasicConf(t *testing.T) {
 				BindAddr:   "127.0.0.1",
 				BindPort:   9001,
 			},
-			Protocol:         "quic",
-			MaxRetriesAnHour: 8,
-			MinRetryInterval: 90,
+			Protocol:          "quic",
+			MaxRetriesAnHour:  8,
+			MinRetryInterval:  90,
+			FallbackTimeoutMs: 1000,
 		},
 	}
 

--- a/pkg/config/visitor_test.go
+++ b/pkg/config/visitor_test.go
@@ -87,9 +87,10 @@ func Test_Visitor_UnmarshalFromIni(t *testing.T) {
 					BindAddr:   "127.0.0.1",
 					BindPort:   9001,
 				},
-				Protocol:         "quic",
-				MaxRetriesAnHour: 8,
-				MinRetryInterval: 90,
+				Protocol:          "quic",
+				MaxRetriesAnHour:  8,
+				MinRetryInterval:  90,
+				FallbackTimeoutMs: 1000,
 			},
 		},
 	}

--- a/pkg/nathole/analysis.go
+++ b/pkg/nathole/analysis.go
@@ -63,20 +63,20 @@ var (
 	}
 
 	// mode 2, HardNAT is receiver, EasyNAT is sender
-	// sender, portsRandomNumber 1000, sendDelayMs 2000 | receiver, listen 256 ports, ttl 7
-	// sender, portsRandomNumber 1000, sendDelayMs 2000 | receiver, listen 256 ports, ttl 4
-	// sender, portsRandomNumber 1000, sendDelayMs 2000 | receiver, listen 256 ports
+	// sender, portsRandomNumber 1000, sendDelayMs 3000 | receiver, listen 256 ports, ttl 7
+	// sender, portsRandomNumber 1000, sendDelayMs 3000 | receiver, listen 256 ports, ttl 4
+	// sender, portsRandomNumber 1000, sendDelayMs 3000 | receiver, listen 256 ports
 	mode2Behaviors = []lo.Tuple2[RecommandBehavior, RecommandBehavior]{
 		lo.T2(
-			RecommandBehavior{Role: DetectRoleSender, PortsRandomNumber: 1000, SendDelayMs: 2000},
+			RecommandBehavior{Role: DetectRoleSender, PortsRandomNumber: 1000, SendDelayMs: 3000},
 			RecommandBehavior{Role: DetectRoleReceiver, ListenRandomPorts: 256, TTL: 7},
 		),
 		lo.T2(
-			RecommandBehavior{Role: DetectRoleSender, PortsRandomNumber: 1000, SendDelayMs: 2000},
+			RecommandBehavior{Role: DetectRoleSender, PortsRandomNumber: 1000, SendDelayMs: 3000},
 			RecommandBehavior{Role: DetectRoleReceiver, ListenRandomPorts: 256, TTL: 4},
 		),
 		lo.T2(
-			RecommandBehavior{Role: DetectRoleSender, PortsRandomNumber: 1000, SendDelayMs: 2000},
+			RecommandBehavior{Role: DetectRoleSender, PortsRandomNumber: 1000, SendDelayMs: 3000},
 			RecommandBehavior{Role: DetectRoleReceiver, ListenRandomPorts: 256},
 		),
 	}
@@ -98,21 +98,21 @@ var (
 	}
 
 	// mode 4, Regular ports changes are usually the sender.
-	// sender, portsRandomNumber 1000, sendDelayMs: 2000 | receiver, listen 256 ports, ttl 7, portsRangeNumber 10
-	// sender, portsRandomNumber 1000, sendDelayMs: 2000 | receiver, listen 256 ports, ttl 4, portsRangeNumber 10
-	// sender, portsRandomNumber 1000, SendDelayMs: 2000 | receiver, listen 256 ports, portsRangeNumber 10
+	// sender, portsRandomNumber 1000, sendDelayMs: 2000 | receiver, listen 256 ports, ttl 7, portsRangeNumber 2
+	// sender, portsRandomNumber 1000, sendDelayMs: 2000 | receiver, listen 256 ports, ttl 4, portsRangeNumber 2
+	// sender, portsRandomNumber 1000, SendDelayMs: 2000 | receiver, listen 256 ports, portsRangeNumber 2
 	mode4Behaviors = []lo.Tuple2[RecommandBehavior, RecommandBehavior]{
 		lo.T2(
-			RecommandBehavior{Role: DetectRoleSender, PortsRandomNumber: 1000, SendDelayMs: 2000},
-			RecommandBehavior{Role: DetectRoleReceiver, ListenRandomPorts: 256, TTL: 7, PortsRangeNumber: 10},
+			RecommandBehavior{Role: DetectRoleSender, PortsRandomNumber: 1000, SendDelayMs: 3000},
+			RecommandBehavior{Role: DetectRoleReceiver, ListenRandomPorts: 256, TTL: 7, PortsRangeNumber: 2},
 		),
 		lo.T2(
-			RecommandBehavior{Role: DetectRoleSender, PortsRandomNumber: 1000, SendDelayMs: 2000},
-			RecommandBehavior{Role: DetectRoleReceiver, ListenRandomPorts: 256, TTL: 4, PortsRangeNumber: 10},
+			RecommandBehavior{Role: DetectRoleSender, PortsRandomNumber: 1000, SendDelayMs: 3000},
+			RecommandBehavior{Role: DetectRoleReceiver, ListenRandomPorts: 256, TTL: 4, PortsRangeNumber: 2},
 		),
 		lo.T2(
-			RecommandBehavior{Role: DetectRoleSender, PortsRandomNumber: 1000, SendDelayMs: 2000},
-			RecommandBehavior{Role: DetectRoleReceiver, ListenRandomPorts: 256, PortsRangeNumber: 10},
+			RecommandBehavior{Role: DetectRoleSender, PortsRandomNumber: 1000, SendDelayMs: 3000},
+			RecommandBehavior{Role: DetectRoleReceiver, ListenRandomPorts: 256, PortsRangeNumber: 2},
 		),
 	}
 )

--- a/pkg/nathole/classify.go
+++ b/pkg/nathole/classify.go
@@ -85,11 +85,6 @@ func ClassifyNATFeature(addresses []string, localIPs []string) (*NatFeature, err
 		}
 	}
 
-	natFeature.PortsDifference = portMax - portMin
-	if natFeature.PortsDifference <= 10 && natFeature.PortsDifference >= 1 {
-		natFeature.RegularPortsChange = true
-	}
-
 	switch {
 	case ipChanged && portChanged:
 		natFeature.NatType = HardNAT
@@ -103,6 +98,12 @@ func ClassifyNATFeature(addresses []string, localIPs []string) (*NatFeature, err
 	default:
 		natFeature.NatType = EasyNAT
 		natFeature.Behavior = BehaviorNoChange
+	}
+	if natFeature.Behavior == BehaviorPortChanged {
+		natFeature.PortsDifference = portMax - portMin
+		if natFeature.PortsDifference <= 5 && natFeature.PortsDifference >= 1 {
+			natFeature.RegularPortsChange = true
+		}
 	}
 	return natFeature, nil
 }

--- a/pkg/nathole/nathole.go
+++ b/pkg/nathole/nathole.go
@@ -384,7 +384,7 @@ func sendSidMessageToRangePorts(
 				if err := sendFunc(conn, detectAddr); err != nil {
 					xl.Trace("send sid message from %s to %s error: %v", conn.LocalAddr(), detectAddr, err)
 				}
-				time.Sleep(5 * time.Millisecond)
+				time.Sleep(2 * time.Millisecond)
 			}
 		}
 	}

--- a/test/e2e/basic/basic.go
+++ b/test/e2e/basic/basic.go
@@ -376,7 +376,7 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 				for _, test := range tests {
 					framework.NewRequestExpect(f).
 						RequestModify(func(r *request.Request) {
-							r.Timeout(5 * time.Second)
+							r.Timeout(10 * time.Second)
 						}).
 						Protocol(protocol).
 						PortName(test.bindPortName).

--- a/test/e2e/basic/xtcp.go
+++ b/test/e2e/basic/xtcp.go
@@ -1,0 +1,52 @@
+package basic
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+
+	"github.com/fatedier/frp/test/e2e/framework"
+	"github.com/fatedier/frp/test/e2e/framework/consts"
+	"github.com/fatedier/frp/test/e2e/pkg/port"
+	"github.com/fatedier/frp/test/e2e/pkg/request"
+)
+
+var _ = ginkgo.Describe("[Feature: XTCP]", func() {
+	f := framework.NewDefaultFramework()
+
+	ginkgo.It("Fallback To STCP", func() {
+		serverConf := consts.DefaultServerConfig
+		clientConf := consts.DefaultClientConfig
+
+		bindPortName := port.GenName("XTCP")
+		clientConf += fmt.Sprintf(`
+			[foo]
+			type = stcp
+			local_port = {{ .%s }}
+
+			[foo-visitor]
+			type = stcp
+			role = visitor
+			server_name = foo
+			bind_port = -1
+
+			[bar-visitor]
+			type = xtcp
+			role = visitor
+			server_name = bar
+			bind_port = {{ .%s }}
+			keep_tunnel_open = true
+			fallback_to = foo-visitor
+			fallback_timeout_ms = 200
+			`, framework.TCPEchoServerPort, bindPortName)
+
+		f.RunProcesses([]string{serverConf}, []string{clientConf})
+		framework.NewRequestExpect(f).
+			RequestModify(func(r *request.Request) {
+				r.Timeout(time.Second)
+			}).
+			PortName(bindPortName).
+			Ensure()
+	})
+})


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0d7862a</samp>

This pull request adds a new feature of visitor-to-visitor connection redirection and fallback for STCP and XTCP proxies. It also fixes some bugs and improves the performance and reliability of the NAT hole punching process. It refactors some code, adds comments and documentation, and updates the configuration and test files accordingly.

### WHY
<!-- author to complete -->

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0d7862a</samp>

*  Add a feature of not binding to the port and only receiving connections redirected from other visitors for stcp and xtcp visitors ([link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-47736b3efa64378c562de79bf84ff718399cdc5e41d69f3986661c57262695bfL38-R51), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-ab3060623fd2bc094ac0766bc594d8ab3b4de37fb944ad03c80bb25af0c9e486L62-R70), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-12bf97fbdf713937ce234cefa7dd9244ac8f86ca1c32e8b5af7aa8232bef5983R340-R341), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-12bf97fbdf713937ce234cefa7dd9244ac8f86ca1c32e8b5af7aa8232bef5983R360-R361), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-6ee1be2917f26b793160747c763b3b1600cee8faf4985e9147810f2e085428ebL52-R55), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-6ee1be2917f26b793160747c763b3b1600cee8faf4985e9147810f2e085428ebL137-R144))
*  Add a feature of falling back to another visitor if the tunnel opening fails within a timeout for xtcp visitors ([link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-ab3060623fd2bc094ac0766bc594d8ab3b4de37fb944ad03c80bb25af0c9e486L142-R165), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-ab3060623fd2bc094ac0766bc594d8ab3b4de37fb944ad03c80bb25af0c9e486L148-R190), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-ab3060623fd2bc094ac0766bc594d8ab3b4de37fb944ad03c80bb25af0c9e486L174-R214), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-ab3060623fd2bc094ac0766bc594d8ab3b4de37fb944ad03c80bb25af0c9e486R228-R229), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-12bf97fbdf713937ce234cefa7dd9244ac8f86ca1c32e8b5af7aa8232bef5983R370-R371), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-b1a1396357f897f16a777d4b67e3b5e0b84766e9cf8a6a8d978df2cc72ca115cL664-R667), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-6ee1be2917f26b793160747c763b3b1600cee8faf4985e9147810f2e085428ebL66-R74), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-6ee1be2917f26b793160747c763b3b1600cee8faf4985e9147810f2e085428ebL271-R278), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-6ee1be2917f26b793160747c763b3b1600cee8faf4985e9147810f2e085428ebR300-R302), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-a8c5c4f05278dbcedb060efa40217e0412e893822a53cfe6fd144cc81a0be764R1-R52))
*  Add a feature of transferring connections from other visitors to the visitor and a function to do so in the visitor manager ([link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-47736b3efa64378c562de79bf84ff718399cdc5e41d69f3986661c57262695bfL59-R73), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-abbc6c05d8cef7aefa7cbc0547129ce17a8fbdbc91fb00ee62c7b87a10f4ace3R31), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-abbc6c05d8cef7aefa7cbc0547129ce17a8fbdbc91fb00ee62c7b87a10f4ace3R40), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-abbc6c05d8cef7aefa7cbc0547129ce17a8fbdbc91fb00ee62c7b87a10f4ace3L44-R50), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-abbc6c05d8cef7aefa7cbc0547129ce17a8fbdbc91fb00ee62c7b87a10f4ace3L72-R97), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-85182a35b298e78d303ed36cccd8234812f942d76792932999d640e1948fc696R19), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-85182a35b298e78d303ed36cccd8234812f942d76792932999d640e1948fc696L37-R38), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-85182a35b298e78d303ed36cccd8234812f942d76792932999d640e1948fc696L86-R104), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-85182a35b298e78d303ed36cccd8234812f942d76792932999d640e1948fc696L142-R164), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-ab3060623fd2bc094ac0766bc594d8ab3b4de37fb944ad03c80bb25af0c9e486L92-R110))
*  Fix a bug that causes false positive detection of regular ports change and affects the hole punching process for xtcp visitors ([link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-60e3e39f57fb49d2af363f6207f5364964bef106e4c8c1fc71718d947a813941L88-L92), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-60e3e39f57fb49d2af363f6207f5364964bef106e4c8c1fc71718d947a813941R102-R107))
*  Improve the success rate and performance of the hole punching process for xtcp visitors by changing the send delays and ports range numbers ([link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-9edd9ae649401607046f55d682d6afb7fc0d915dc2d2d306bd6dc5f1d2c7d52dL66-R79), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-9edd9ae649401607046f55d682d6afb7fc0d915dc2d2d306bd6dc5f1d2c7d52dL101-R115), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-93ecd74b16624b460b1da47b7e21f0fa2fd4c7ed6098412049beaa66760c0627L387-R387))
*  Avoid resource leaks and ensure graceful shutdown by closing the internal listener and the base listener for sudp and stcp visitors and closing all the visitors and the stop channel in the visitor manager ([link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-d02ddc4b655b53c915b7f4fb430bd05a97df1799ac1d281e654cb457373b5f58R257), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-85182a35b298e78d303ed36cccd8234812f942d76792932999d640e1948fc696L142-R164))
*  Avoid concurrent access and nil pointer errors by adding a mutex lock and a condition to check if the cancel function is not nil before calling it in the xtcp visitor ([link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-ab3060623fd2bc094ac0766bc594d8ab3b4de37fb944ad03c80bb25af0c9e486L77-R85))
*  Avoid timeout errors and flaky tests by changing the request timeout from 5 to 10 seconds in the basic test case ([link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-198c426913c63e51585ac1793ca15e8e195cf8a0a72ba93e9b12d2f6acd9fa44L379-R379))
*  Add a new test case for the feature of falling back to another visitor if the tunnel opening fails within a timeout in the `test/e2e/basic/xtcp.go` file ([link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-a8c5c4f05278dbcedb060efa40217e0412e893822a53cfe6fd144cc81a0be764R1-R52))
*  Improve the code style and readability by removing empty lines in the `pkg/config/visitor.go` file ([link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-6ee1be2917f26b793160747c763b3b1600cee8faf4985e9147810f2e085428ebL158), [link](https://github.com/fatedier/frp/pull/3460/files?diff=unified&w=0#diff-6ee1be2917f26b793160747c763b3b1600cee8faf4985e9147810f2e085428ebL172))
