### PR TITLE
stcp, xtcp, sudp: support allow_users and specified server user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ packages/
 release/
 test/bin/
 vendor/
+lastversion/
 dist/
 .idea/
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,23 @@ e2e:
 e2e-trace:
 	DEBUG=true LOG_LEVEL=trace ./hack/run-e2e.sh
 
+e2e-compatibility-last-frpc:
+	if [ ! -d "./lastversion" ]; then \
+		TARGET_DIRNAME=lastversion ./hack/download.sh; \
+	fi
+	FRPC_PATH="`pwd`/lastversion/frpc" ./hack/run-e2e.sh
+	rm -r ./lastversion
+
+e2e-compatibility-last-frps:
+	if [ ! -d "./lastversion" ]; then \
+		TARGET_DIRNAME=lastversion ./hack/download.sh; \
+	fi
+	FRPS_PATH="`pwd`/lastversion/frps" ./hack/run-e2e.sh
+	rm -r ./lastversion
+
 alltest: vet gotest e2e
 	
 clean:
 	rm -f ./bin/frpc
 	rm -f ./bin/frps
+	rm -rf ./lastversion

--- a/hack/download.sh
+++ b/hack/download.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+OS="$(go env GOOS)"
+ARCH="$(go env GOARCH)"
+
+if [ "${TARGET_OS}" ]; then
+  OS="${TARGET_OS}"
+fi
+if [ "${TARGET_ARCH}" ]; then
+  ARCH="${TARGET_ARCH}"
+fi
+
+# Determine the latest version by version number ignoring alpha, beta, and rc versions.
+if [ "${FRP_VERSION}" = "" ] ; then
+  FRP_VERSION="$(curl -sL https://github.com/fatedier/frp/releases | \
+                  grep -o 'releases/tag/v[0-9]*.[0-9]*.[0-9]*"' | sort -V | \
+                  tail -1 | awk -F'/' '{ print $3}')"
+  FRP_VERSION="${FRP_VERSION%?}"
+  FRP_VERSION="${FRP_VERSION#?}"
+fi
+
+if [ "${FRP_VERSION}" = "" ] ; then
+  printf "Unable to get latest frp version. Set FRP_VERSION env var and re-run. For example: export FRP_VERSION=1.0.0"
+  exit 1;
+fi
+
+SUFFIX=".tar.gz"
+if [ "${OS}" = "windows" ] ; then
+  SUFFIX=".zip"
+fi
+NAME="frp_${FRP_VERSION}_${OS}_${ARCH}${SUFFIX}"
+DIR_NAME="frp_${FRP_VERSION}_${OS}_${ARCH}"
+URL="https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/${NAME}"
+
+download_and_extract() {
+  printf "Downloading %s from %s ...\n" "$NAME" "${URL}"
+  if ! curl -o /dev/null -sIf "${URL}"; then
+    printf "\n%s is not found, please specify a valid FRP_VERSION\n" "${URL}"
+    exit 1
+  fi
+  curl -fsLO "${URL}"
+  filename=$NAME
+
+  if [ "${OS}" = "windows" ]; then
+    unzip "${filename}"
+  else
+    tar -xzf "${filename}"
+  fi
+  rm "${filename}"
+
+  if [ "${TARGET_DIRNAME}" ]; then
+    mv "${DIR_NAME}" "${TARGET_DIRNAME}"
+    DIR_NAME="${TARGET_DIRNAME}"
+  fi
+}
+
+download_and_extract
+
+printf ""
+printf "\nfrp %s Download Complete!\n" "$FRP_VERSION"
+printf "\n"
+printf "frp has been successfully downloaded into the %s folder on your system.\n" "$DIR_NAME"
+printf "\n"

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -1,20 +1,30 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-ROOT=$(unset CDPATH && cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
+SCRIPT=$(readlink -f "$0")
+ROOT=$(unset CDPATH && cd "$(dirname "$SCRIPT")/.." && pwd)
 
-which ginkgo &> /dev/null
-if [ $? -ne 0 ]; then
+ginkgo_command=$(which ginkgo 2>/dev/null)
+if [ -z "$ginkgo_command" ]; then
     echo "ginkgo not found, try to install..."
     go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.3
 fi
 
 debug=false
-if [ x${DEBUG} == x"true" ]; then
+if [ "x${DEBUG}" = "xtrue" ]; then
     debug=true
 fi
 logLevel=debug
-if [ x${LOG_LEVEL} != x"" ]; then
-    logLevel=${LOG_LEVEL}
+if [ "${LOG_LEVEL}" ]; then
+    logLevel="${LOG_LEVEL}"
 fi
 
-ginkgo -nodes=8 --poll-progress-after=30s ${ROOT}/test/e2e -- -frpc-path=${ROOT}/bin/frpc -frps-path=${ROOT}/bin/frps -log-level=${logLevel} -debug=${debug}
+frpcPath=${ROOT}/bin/frpc
+if [ "${FRPC_PATH}" ]; then
+    frpcPath="${FRPC_PATH}"
+fi
+frpsPath=${ROOT}/bin/frps
+if [ "${FRPS_PATH}" ]; then
+    frpsPath="${FRPS_PATH}"
+fi
+
+ginkgo -nodes=8 --poll-progress-after=60s ${ROOT}/test/e2e -- -frpc-path=${frpcPath} -frps-path=${frpsPath} -log-level=${logLevel} -debug=${debug}

--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -352,7 +352,7 @@ func LoadAllProxyConfsFromIni(
 		case "visitor":
 			newConf, newErr := NewVisitorConfFromIni(prefix, name, section)
 			if newErr != nil {
-				return nil, nil, newErr
+				return nil, nil, fmt.Errorf("failed to parse visitor %s, err: %v", name, newErr)
 			}
 			visitorConfs[prefix+name] = newConf
 		default:

--- a/pkg/config/visitor.go
+++ b/pkg/config/visitor.go
@@ -94,16 +94,16 @@ func NewVisitorConfFromIni(prefix string, name string, section *ini.Section) (Vi
 	visitorType := section.Key("type").String()
 
 	if visitorType == "" {
-		return nil, fmt.Errorf("visitor [%s] type shouldn't be empty", name)
+		return nil, fmt.Errorf("type shouldn't be empty")
 	}
 
 	conf := DefaultVisitorConf(visitorType)
 	if conf == nil {
-		return nil, fmt.Errorf("visitor [%s] type [%s] error", name, visitorType)
+		return nil, fmt.Errorf("type [%s] error", visitorType)
 	}
 
 	if err := conf.UnmarshalFromIni(prefix, name, section); err != nil {
-		return nil, fmt.Errorf("visitor [%s] type [%s] error", name, visitorType)
+		return nil, fmt.Errorf("type [%s] error", visitorType)
 	}
 
 	if err := conf.Validate(); err != nil {

--- a/pkg/msg/msg.go
+++ b/pkg/msg/msg.go
@@ -110,8 +110,9 @@ type NewProxy struct {
 	Headers           map[string]string `json:"headers,omitempty"`
 	RouteByHTTPUser   string            `json:"route_by_http_user,omitempty"`
 
-	// stcp
-	Sk string `json:"sk,omitempty"`
+	// stcp, sudp, xtcp
+	Sk         string   `json:"sk,omitempty"`
+	AllowUsers []string `json:"allow_users,omitempty"`
 
 	// tcpmux
 	Multiplexer string `json:"multiplexer,omitempty"`

--- a/server/control.go
+++ b/server/control.go
@@ -524,7 +524,7 @@ func (ctl *Control) manager() {
 }
 
 func (ctl *Control) HandleNatHoleVisitor(m *msg.NatHoleVisitor) {
-	ctl.rc.NatHoleController.HandleVisitor(m, ctl.msgTransporter)
+	ctl.rc.NatHoleController.HandleVisitor(m, ctl.msgTransporter, ctl.loginMsg.User)
 }
 
 func (ctl *Control) HandleNatHoleClient(m *msg.NatHoleClient) {
@@ -537,7 +537,7 @@ func (ctl *Control) HandleNatHoleReport(m *msg.NatHoleReport) {
 
 func (ctl *Control) RegisterProxy(pxyMsg *msg.NewProxy) (remoteAddr string, err error) {
 	var pxyConf config.ProxyConf
-	// Load configures from NewProxy message and check.
+	// Load configures from NewProxy message and validate.
 	pxyConf, err = config.NewProxyConfFromMsg(pxyMsg, ctl.serverCfg)
 	if err != nil {
 		return
@@ -550,8 +550,8 @@ func (ctl *Control) RegisterProxy(pxyMsg *msg.NewProxy) (remoteAddr string, err 
 		RunID: ctl.runID,
 	}
 
-	// NewProxy will return a interface Proxy.
-	// In fact it create different proxies by different proxy type, we just call run() here.
+	// NewProxy will return an interface Proxy.
+	// In fact, it creates different proxies based on the proxy type. We just call run() here.
 	pxy, err := proxy.NewProxy(ctl.ctx, userInfo, ctl.rc, ctl.poolCount, ctl.GetWorkConn, pxyConf, ctl.serverCfg, ctl.loginMsg)
 	if err != nil {
 		return remoteAddr, err

--- a/server/proxy/stcp.go
+++ b/server/proxy/stcp.go
@@ -27,7 +27,12 @@ type STCPProxy struct {
 
 func (pxy *STCPProxy) Run() (remoteAddr string, err error) {
 	xl := pxy.xl
-	listener, errRet := pxy.rc.VisitorManager.Listen(pxy.GetName(), pxy.cfg.Sk)
+	allowUsers := pxy.cfg.AllowUsers
+	// if allowUsers is empty, only allow same user from proxy
+	if len(allowUsers) == 0 {
+		allowUsers = []string{pxy.GetUserInfo().User}
+	}
+	listener, errRet := pxy.rc.VisitorManager.Listen(pxy.GetName(), pxy.cfg.Sk, allowUsers)
 	if errRet != nil {
 		err = errRet
 		return

--- a/server/proxy/sudp.go
+++ b/server/proxy/sudp.go
@@ -27,8 +27,12 @@ type SUDPProxy struct {
 
 func (pxy *SUDPProxy) Run() (remoteAddr string, err error) {
 	xl := pxy.xl
-
-	listener, errRet := pxy.rc.VisitorManager.Listen(pxy.GetName(), pxy.cfg.Sk)
+	allowUsers := pxy.cfg.AllowUsers
+	// if allowUsers is empty, only allow same user from proxy
+	if len(allowUsers) == 0 {
+		allowUsers = []string{pxy.GetUserInfo().User}
+	}
+	listener, errRet := pxy.rc.VisitorManager.Listen(pxy.GetName(), pxy.cfg.Sk, allowUsers)
 	if errRet != nil {
 		err = errRet
 		return

--- a/server/proxy/xtcp.go
+++ b/server/proxy/xtcp.go
@@ -35,11 +35,15 @@ func (pxy *XTCPProxy) Run() (remoteAddr string, err error) {
 	xl := pxy.xl
 
 	if pxy.rc.NatHoleController == nil {
-		xl.Error("udp port for xtcp is not specified.")
 		err = fmt.Errorf("xtcp is not supported in frps")
 		return
 	}
-	sidCh := pxy.rc.NatHoleController.ListenClient(pxy.GetName(), pxy.cfg.Sk)
+	allowUsers := pxy.cfg.AllowUsers
+	// if allowUsers is empty, only allow same user from proxy
+	if len(allowUsers) == 0 {
+		allowUsers = []string{pxy.GetUserInfo().User}
+	}
+	sidCh := pxy.rc.NatHoleController.ListenClient(pxy.GetName(), pxy.cfg.Sk, allowUsers)
 	go func() {
 		for {
 			select {

--- a/server/service.go
+++ b/server/service.go
@@ -587,6 +587,15 @@ func (svr *Service) RegisterWorkConn(workConn net.Conn, newMsg *msg.NewWorkConn)
 }
 
 func (svr *Service) RegisterVisitorConn(visitorConn net.Conn, newMsg *msg.NewVisitorConn) error {
+	visitorUser := ""
+	// TODO: Compatible with old versions, can be without runID, user is empty. In later versions, it will be mandatory to include runID.
+	if newMsg.RunID != "" {
+		ctl, exist := svr.ctlManager.GetByID(newMsg.RunID)
+		if !exist {
+			return fmt.Errorf("no client control found for run id [%s]", newMsg.RunID)
+		}
+		visitorUser = ctl.loginMsg.User
+	}
 	return svr.rc.VisitorManager.NewConn(newMsg.ProxyName, visitorConn, newMsg.Timestamp, newMsg.SignKey,
-		newMsg.UseEncryption, newMsg.UseCompression)
+		newMsg.UseEncryption, newMsg.UseCompression, visitorUser)
 }

--- a/server/visitor/visitor.go
+++ b/server/visitor/visitor.go
@@ -21,57 +21,69 @@ import (
 	"sync"
 
 	libio "github.com/fatedier/golib/io"
+	"github.com/samber/lo"
 
 	utilnet "github.com/fatedier/frp/pkg/util/net"
 	"github.com/fatedier/frp/pkg/util/util"
 )
 
+type listenerBundle struct {
+	l          *utilnet.InternalListener
+	sk         string
+	allowUsers []string
+}
+
 // Manager for visitor listeners.
 type Manager struct {
-	visitorListeners map[string]*utilnet.InternalListener
-	skMap            map[string]string
+	listeners map[string]*listenerBundle
 
 	mu sync.RWMutex
 }
 
 func NewManager() *Manager {
 	return &Manager{
-		visitorListeners: make(map[string]*utilnet.InternalListener),
-		skMap:            make(map[string]string),
+		listeners: make(map[string]*listenerBundle),
 	}
 }
 
-func (vm *Manager) Listen(name string, sk string) (l *utilnet.InternalListener, err error) {
+func (vm *Manager) Listen(name string, sk string, allowUsers []string) (l *utilnet.InternalListener, err error) {
 	vm.mu.Lock()
 	defer vm.mu.Unlock()
 
-	if _, ok := vm.visitorListeners[name]; ok {
+	if _, ok := vm.listeners[name]; ok {
 		err = fmt.Errorf("custom listener for [%s] is repeated", name)
 		return
 	}
 
 	l = utilnet.NewInternalListener()
-	vm.visitorListeners[name] = l
-	vm.skMap[name] = sk
+	vm.listeners[name] = &listenerBundle{
+		l:          l,
+		sk:         sk,
+		allowUsers: allowUsers,
+	}
 	return
 }
 
 func (vm *Manager) NewConn(name string, conn net.Conn, timestamp int64, signKey string,
-	useEncryption bool, useCompression bool,
+	useEncryption bool, useCompression bool, visitorUser string,
 ) (err error) {
 	vm.mu.RLock()
 	defer vm.mu.RUnlock()
 
-	if l, ok := vm.visitorListeners[name]; ok {
-		var sk string
-		if sk = vm.skMap[name]; util.GetAuthKey(sk, timestamp) != signKey {
+	if l, ok := vm.listeners[name]; ok {
+		if util.GetAuthKey(l.sk, timestamp) != signKey {
 			err = fmt.Errorf("visitor connection of [%s] auth failed", name)
+			return
+		}
+
+		if !lo.Contains(l.allowUsers, visitorUser) && !lo.Contains(l.allowUsers, "*") {
+			err = fmt.Errorf("visitor connection of [%s] user [%s] not allowed", name, visitorUser)
 			return
 		}
 
 		var rwc io.ReadWriteCloser = conn
 		if useEncryption {
-			if rwc, err = libio.WithEncryption(rwc, []byte(sk)); err != nil {
+			if rwc, err = libio.WithEncryption(rwc, []byte(l.sk)); err != nil {
 				err = fmt.Errorf("create encryption connection failed: %v", err)
 				return
 			}
@@ -79,7 +91,7 @@ func (vm *Manager) NewConn(name string, conn net.Conn, timestamp int64, signKey 
 		if useCompression {
 			rwc = libio.WithCompression(rwc)
 		}
-		err = l.PutConn(utilnet.WrapReadWriteCloserToConn(rwc, conn))
+		err = l.l.PutConn(utilnet.WrapReadWriteCloserToConn(rwc, conn))
 	} else {
 		err = fmt.Errorf("custom listener for [%s] doesn't exist", name)
 		return
@@ -91,6 +103,5 @@ func (vm *Manager) CloseListener(name string) {
 	vm.mu.Lock()
 	defer vm.mu.Unlock()
 
-	delete(vm.visitorListeners, name)
-	delete(vm.skMap, name)
+	delete(vm.listeners, name)
 }

--- a/test/e2e/framework/process.go
+++ b/test/e2e/framework/process.go
@@ -56,7 +56,7 @@ func (f *Framework) RunProcesses(serverTemplates []string, clientTemplates []str
 		ExpectNoError(err)
 		time.Sleep(500 * time.Millisecond)
 	}
-	time.Sleep(2 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	return currentServerProcesses, currentClientProcesses
 }


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ae8d19f</samp>

This pull request adds a new feature to allow proxy owners to specify which users can access their server role proxies as visitors, and improves the end-to-end testing and error handling for this feature. It also adds a script to download the latest frp release and refactors some configuration and message code for consistency and clarity. The main files affected are `pkg/config/proxy.go`, `pkg/nathole/controller.go`, `server/control.go`, `server/visitor/visitor.go`, `test/e2e/basic/basic.go`, `hack/download.sh`, `pkg/msg/msg.go`, and the proxy files in `server/proxy`.

### WHY
<!-- author to complete -->

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ae8d19f</samp>

*  Add a new script to download the latest frp release from GitHub ([link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-73a177e4add069fec5e561eb32ef0e2a3f990f9cc1f5f95f23a199c046eaf20bR1-R63))
*  Add two new fields to the NewProxy message to support server role proxies and the allow_users feature ([link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-d06db243b3da859f1e0ad2aa35dcdb7d050f1d401faad8668be9ff336165b628L113-R115))
*  Add a new field to the ClientCfg struct to store the list of users that are allowed to access the proxy as visitors ([link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-2f15ef36bc925196e99eb8971b235db30a64a9c44c6ac37215abdaaac812777fL46-R49))
*  Modify the `NatHoleController` to accept and check the allowUsers and visitorUser parameters for xtcp proxies ([link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-2f15ef36bc925196e99eb8971b235db30a64a9c44c6ac37215abdaaac812777fL123-R129), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-2f15ef36bc925196e99eb8971b235db30a64a9c44c6ac37215abdaaac812777fL147-R160))
*  Modify the `Control` struct to pass the visitor user name to the `NatHoleController` and improve the error messages for proxy registration ([link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-292ec4fee0964ed74268d2a5345341096a228f932403bbb4acd1d3e94405d891L527-R527), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-292ec4fee0964ed74268d2a5345341096a228f932403bbb4acd1d3e94405d891L540-R540), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-292ec4fee0964ed74268d2a5345341096a228f932403bbb4acd1d3e94405d891L553-R554))
*  Modify the `Service` struct to get the visitor user name from the control manager and pass it to the `VisitorManager` ([link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-7cd1def768b5bcc52b79dd84b45271a4f4c0604d574564e6b60e8f2770691394L590-R600))
*  Modify the `VisitorManager` to use a new type `listenerBundle` to wrap the listener, sk, and allowUsers fields together, and check the visitor user's permission before accepting the connection ([link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-d5981c6c125eed9ee4794317408ee0883c2bd8744dbbd01634c362e54a97a50fR24), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-d5981c6c125eed9ee4794317408ee0883c2bd8744dbbd01634c362e54a97a50fL29-R38), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-d5981c6c125eed9ee4794317408ee0883c2bd8744dbbd01634c362e54a97a50fL39-R53), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-d5981c6c125eed9ee4794317408ee0883c2bd8744dbbd01634c362e54a97a50fL54-R86), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-d5981c6c125eed9ee4794317408ee0883c2bd8744dbbd01634c362e54a97a50fL82-R94), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-d5981c6c125eed9ee4794317408ee0883c2bd8744dbbd01634c362e54a97a50fL94-R106))
*  Modify the `STCPProxy`, `SUDPProxy`, and `XTCPProxy` structs to accept the allowUsers parameter and pass it to the `VisitorManager` or the `NatHoleController` ([link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-a8a3608f703647da704896989ae588d6b548f5cb25859adb54a2f1fe8f33b4d1L30-R35), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-27e265b12a950d00fe661898c5422ce6a3c99d7b928c44443c293737439122bbL30-R35), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-52f5ffea2008402b178846549fb887fd3961403113f5a846202923dc48936b1cL38-R46))
*  Modify the proxy config package to add methods to marshal and unmarshal the common fields for server role proxies, improve the error messages for configuration parsing, and rename some parameters for consistency ([link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-fd40de974f57bca0b0360aa388aae106227b36be701f6c5fedbd511a6f39a062L355-R355), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-583ded603117becc13d8e964684141cebdb4256ecc9a87f7dce32af788aa039eR181-R190), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-583ded603117becc13d8e964684141cebdb4256ecc9a87f7dce32af788aa039eL263-R273), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-583ded603117becc13d8e964684141cebdb4256ecc9a87f7dce32af788aa039eL277-R297), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-583ded603117becc13d8e964684141cebdb4256ecc9a87f7dce32af788aa039eL344-R382), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-583ded603117becc13d8e964684141cebdb4256ecc9a87f7dce32af788aa039eL485-R499), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-583ded603117becc13d8e964684141cebdb4256ecc9a87f7dce32af788aa039eL503-R517), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-583ded603117becc13d8e964684141cebdb4256ecc9a87f7dce32af788aa039eL539-R570), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-583ded603117becc13d8e964684141cebdb4256ecc9a87f7dce32af788aa039eL613-R634), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-583ded603117becc13d8e964684141cebdb4256ecc9a87f7dce32af788aa039eL656-R691), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-583ded603117becc13d8e964684141cebdb4256ecc9a87f7dce32af788aa039eL725-R748), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-583ded603117becc13d8e964684141cebdb4256ecc9a87f7dce32af788aa039eL787-R808), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-583ded603117becc13d8e964684141cebdb4256ecc9a87f7dce32af788aa039eL841-R862), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-583ded603117becc13d8e964684141cebdb4256ecc9a87f7dce32af788aa039eL895-R916), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-6ee1be2917f26b793160747c763b3b1600cee8faf4985e9147810f2e085428ebL97-R106))
*  Modify the `run-e2e.sh` script to use /bin/sh instead of /usr/bin/env bash, and allow setting the FRPC_PATH and FRPS_PATH variables to use custom binaries for frpc and frps ([link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-0913e7b61c925dbdbf31c36ad24131da81c64f8ec9c3477662eec4cca73dba07L1-R1), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-0913e7b61c925dbdbf31c36ad24131da81c64f8ec9c3477662eec4cca73dba07L16-R29))
*  Add new targets to the Makefile for running end-to-end tests with the last released version of frpc or frps, and remove the lastversion directory after running the e2e-compatibility target ([link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R49-R62), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R68))
*  Modify the basic package to add new fields and parameters to support the allow_users feature for server role proxies, and use a shorter timeout and the keep_tunnel_open option for xtcp proxies to reduce the testing time ([link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-198c426913c63e51585ac1793ca15e8e195cf8a0a72ba93e9b12d2f6acd9fa44L285-R287), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-198c426913c63e51585ac1793ca15e8e195cf8a0a72ba93e9b12d2f6acd9fa44L315-R316), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-198c426913c63e51585ac1793ca15e8e195cf8a0a72ba93e9b12d2f6acd9fa44L323-R339), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-198c426913c63e51585ac1793ca15e8e195cf8a0a72ba93e9b12d2f6acd9fa44L338-R356), [link](https://github.com/fatedier/frp/pull/3472/files?diff=unified&w=0#diff-198c426913c63e51585ac1793ca15e8e195cf8a0a72ba93e9b12d2f6acd9fa44L353-R362))
