### PR TITLE
yamux: change default MaxStreamWindowSize to 6MB

### DIFF
--- a/client/proxy/xtcp.go
+++ b/client/proxy/xtcp.go
@@ -137,7 +137,7 @@ func (pxy *XTCPProxy) listenByKCP(listenConn *net.UDPConn, raddr *net.UDPAddr, s
 
 	fmuxCfg := fmux.DefaultConfig()
 	fmuxCfg.KeepAliveInterval = 10 * time.Second
-	fmuxCfg.MaxStreamWindowSize = 2 * 1024 * 1024
+	fmuxCfg.MaxStreamWindowSize = 6 * 1024 * 1024
 	fmuxCfg.LogOutput = io.Discard
 	session, err := fmux.Server(remote, fmuxCfg)
 	if err != nil {

--- a/client/service.go
+++ b/client/service.go
@@ -396,6 +396,7 @@ func (cm *ConnectionManager) OpenConnection() error {
 	fmuxCfg := fmux.DefaultConfig()
 	fmuxCfg.KeepAliveInterval = time.Duration(cm.cfg.TCPMuxKeepaliveInterval) * time.Second
 	fmuxCfg.LogOutput = io.Discard
+	fmuxCfg.MaxStreamWindowSize = 6 * 1024 * 1024
 	session, err := fmux.Client(conn, fmuxCfg)
 	if err != nil {
 		return err

--- a/client/visitor/xtcp.go
+++ b/client/visitor/xtcp.go
@@ -351,7 +351,7 @@ func (ks *KCPTunnelSession) Init(listenConn *net.UDPConn, raddr *net.UDPAddr) er
 
 	fmuxCfg := fmux.DefaultConfig()
 	fmuxCfg.KeepAliveInterval = 10 * time.Second
-	fmuxCfg.MaxStreamWindowSize = 2 * 1024 * 1024
+	fmuxCfg.MaxStreamWindowSize = 6 * 1024 * 1024
 	fmuxCfg.LogOutput = io.Discard
 	session, err := fmux.Client(remote, fmuxCfg)
 	if err != nil {

--- a/server/service.go
+++ b/server/service.go
@@ -461,6 +461,7 @@ func (svr *Service) HandleListener(l net.Listener) {
 				fmuxCfg := fmux.DefaultConfig()
 				fmuxCfg.KeepAliveInterval = time.Duration(svr.cfg.TCPMuxKeepaliveInterval) * time.Second
 				fmuxCfg.LogOutput = io.Discard
+				fmuxCfg.MaxStreamWindowSize = 6 * 1024 * 1024
 				session, err := fmux.Server(frpConn, fmuxCfg)
 				if err != nil {
 					log.Warn("Failed to create mux connection: %v", err)


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f37825b</samp>

Increased the `fmux` `MaxStreamWindowSize` parameter from 2 MB to 6 MB in all files related to xtcp proxy mode. This improves the performance and stability of xtcp proxy mode by allowing more TCP streams to be multiplexed over a single connection.

### WHY
Fix #2987

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f37825b</samp>

*  Increase `MaxStreamWindowSize` of `fmux` configuration from 2 MB to 6 MB for xtcp proxy mode ([link](https://github.com/fatedier/frp/pull/3474/files?diff=unified&w=0#diff-4cb1b15b8cab86ab95dc1aba5fea2604cfd0aaa79fe92369da06f2c3d9f12e93L140-R140), [link](https://github.com/fatedier/frp/pull/3474/files?diff=unified&w=0#diff-37135e06c87eb7f15648ee3df06d54a2a52cab735ea4110e81610945fe38f7d4R399), [link](https://github.com/fatedier/frp/pull/3474/files?diff=unified&w=0#diff-ab3060623fd2bc094ac0766bc594d8ab3b4de37fb944ad03c80bb25af0c9e486L354-R354), [link](https://github.com/fatedier/frp/pull/3474/files?diff=unified&w=0#diff-7cd1def768b5bcc52b79dd84b45271a4f4c0604d574564e6b60e8f2770691394R464))
