### PR TITLE
server/proxy: simplify the code

### DIFF
--- a/pkg/nathole/controller.go
+++ b/pkg/nathole/controller.go
@@ -130,6 +130,7 @@ func (c *Controller) ListenClient(name string, sk string, allowUsers []string) c
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// TODO(fatedier): return error if name already exists
 	c.clientCfgs[name] = cfg
 	return cfg.sidCh
 }

--- a/server/proxy/https.go
+++ b/server/proxy/https.go
@@ -15,18 +15,32 @@
 package proxy
 
 import (
+	"reflect"
 	"strings"
-
-	"golang.org/x/time/rate"
 
 	"github.com/fatedier/frp/pkg/config"
 	"github.com/fatedier/frp/pkg/util/util"
 	"github.com/fatedier/frp/pkg/util/vhost"
 )
 
+func init() {
+	RegisterProxyFactory(reflect.TypeOf(&config.HTTPSProxyConf{}), NewHTTPSProxy)
+}
+
 type HTTPSProxy struct {
 	*BaseProxy
 	cfg *config.HTTPSProxyConf
+}
+
+func NewHTTPSProxy(baseProxy *BaseProxy, cfg config.ProxyConf) Proxy {
+	unwrapped, ok := cfg.(*config.HTTPSProxyConf)
+	if !ok {
+		return nil
+	}
+	return &HTTPSProxy{
+		BaseProxy: baseProxy,
+		cfg:       unwrapped,
+	}
 }
 
 func (pxy *HTTPSProxy) Run() (remoteAddr string, err error) {
@@ -67,17 +81,13 @@ func (pxy *HTTPSProxy) Run() (remoteAddr string, err error) {
 		addrs = append(addrs, util.CanonicalAddr(routeConfig.Domain, pxy.serverCfg.VhostHTTPSPort))
 	}
 
-	pxy.startListenHandler(pxy, HandleUserTCPConnection)
+	pxy.startCommonTCPListenersHandler()
 	remoteAddr = strings.Join(addrs, ",")
 	return
 }
 
 func (pxy *HTTPSProxy) GetConf() config.ProxyConf {
 	return pxy.cfg
-}
-
-func (pxy *HTTPSProxy) GetLimiter() *rate.Limiter {
-	return pxy.limiter
 }
 
 func (pxy *HTTPSProxy) Close() {

--- a/server/proxy/proxy.go
+++ b/server/proxy/proxy.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"reflect"
 	"strconv"
 	"sync"
 	"time"
@@ -35,6 +36,12 @@ import (
 	"github.com/fatedier/frp/server/controller"
 	"github.com/fatedier/frp/server/metrics"
 )
+
+var proxyFactoryRegistry = map[reflect.Type]func(*BaseProxy, config.ProxyConf) Proxy{}
+
+func RegisterProxyFactory(proxyConfType reflect.Type, factory func(*BaseProxy, config.ProxyConf) Proxy) {
+	proxyFactoryRegistry[proxyConfType] = factory
+}
 
 type GetWorkConnFn func() (net.Conn, error)
 
@@ -63,6 +70,7 @@ type BaseProxy struct {
 	limiter       *rate.Limiter
 	userInfo      plugin.UserInfo
 	loginMsg      *msg.Login
+	pxyConf       config.ProxyConf
 
 	mu  sync.RWMutex
 	xl  *xlog.Logger
@@ -91,6 +99,10 @@ func (pxy *BaseProxy) GetUserInfo() plugin.UserInfo {
 
 func (pxy *BaseProxy) GetLoginMsg() *msg.Login {
 	return pxy.loginMsg
+}
+
+func (pxy *BaseProxy) GetLimiter() *rate.Limiter {
+	return pxy.limiter
 }
 
 func (pxy *BaseProxy) Close() {
@@ -155,10 +167,8 @@ func (pxy *BaseProxy) GetWorkConnFromPool(src, dst net.Addr) (workConn net.Conn,
 	return
 }
 
-// startListenHandler start a goroutine handler for each listener.
-// p: p will just be passed to handler(Proxy, utilnet.Conn).
-// handler: each proxy type can set different handler function to deal with connections accepted from listeners.
-func (pxy *BaseProxy) startListenHandler(p Proxy, handler func(Proxy, net.Conn, config.ServerCommonConf)) {
+// startCommonTCPListenersHandler start a goroutine handler for each listener.
+func (pxy *BaseProxy) startCommonTCPListenersHandler() {
 	xl := xlog.FromContextSafe(pxy.ctx)
 	for _, listener := range pxy.listeners {
 		go func(l net.Listener) {
@@ -187,10 +197,70 @@ func (pxy *BaseProxy) startListenHandler(p Proxy, handler func(Proxy, net.Conn, 
 					return
 				}
 				xl.Info("get a user connection [%s]", c.RemoteAddr().String())
-				go handler(p, c, pxy.serverCfg)
+				go pxy.handleUserTCPConnection(c)
 			}
 		}(listener)
 	}
+}
+
+// HandleUserTCPConnection is used for incoming user TCP connections.
+func (pxy *BaseProxy) handleUserTCPConnection(userConn net.Conn) {
+	xl := xlog.FromContextSafe(pxy.Context())
+	defer userConn.Close()
+
+	serverCfg := pxy.serverCfg
+	cfg := pxy.pxyConf.GetBaseConfig()
+	// server plugin hook
+	rc := pxy.GetResourceController()
+	content := &plugin.NewUserConnContent{
+		User:       pxy.GetUserInfo(),
+		ProxyName:  pxy.GetName(),
+		ProxyType:  cfg.ProxyType,
+		RemoteAddr: userConn.RemoteAddr().String(),
+	}
+	_, err := rc.PluginManager.NewUserConn(content)
+	if err != nil {
+		xl.Warn("the user conn [%s] was rejected, err:%v", content.RemoteAddr, err)
+		return
+	}
+
+	// try all connections from the pool
+	workConn, err := pxy.GetWorkConnFromPool(userConn.RemoteAddr(), userConn.LocalAddr())
+	if err != nil {
+		return
+	}
+	defer workConn.Close()
+
+	var local io.ReadWriteCloser = workConn
+	xl.Trace("handler user tcp connection, use_encryption: %t, use_compression: %t", cfg.UseEncryption, cfg.UseCompression)
+	if cfg.UseEncryption {
+		local, err = libio.WithEncryption(local, []byte(serverCfg.Token))
+		if err != nil {
+			xl.Error("create encryption stream error: %v", err)
+			return
+		}
+	}
+	if cfg.UseCompression {
+		local = libio.WithCompression(local)
+	}
+
+	if pxy.GetLimiter() != nil {
+		local = libio.WrapReadWriteCloser(limit.NewReader(local, pxy.GetLimiter()), limit.NewWriter(local, pxy.GetLimiter()), func() error {
+			return local.Close()
+		})
+	}
+
+	xl.Debug("join connections, workConn(l[%s] r[%s]) userConn(l[%s] r[%s])", workConn.LocalAddr().String(),
+		workConn.RemoteAddr().String(), userConn.LocalAddr().String(), userConn.RemoteAddr().String())
+
+	name := pxy.GetName()
+	proxyType := cfg.ProxyType
+	metrics.Server.OpenConnection(name, proxyType)
+	inCount, outCount, _ := libio.Join(local, userConn)
+	metrics.Server.CloseConnection(name, proxyType)
+	metrics.Server.AddTrafficIn(name, proxyType, inCount)
+	metrics.Server.AddTrafficOut(name, proxyType, outCount)
+	xl.Debug("join connections closed")
 }
 
 func NewProxy(ctx context.Context, userInfo plugin.UserInfo, rc *controller.ResourceController, poolCount int,
@@ -216,114 +286,18 @@ func NewProxy(ctx context.Context, userInfo plugin.UserInfo, rc *controller.Reso
 		ctx:           xlog.NewContext(ctx, xl),
 		userInfo:      userInfo,
 		loginMsg:      loginMsg,
+		pxyConf:       pxyConf,
 	}
-	switch cfg := pxyConf.(type) {
-	case *config.TCPProxyConf:
-		basePxy.usedPortsNum = 1
-		pxy = &TCPProxy{
-			BaseProxy: &basePxy,
-			cfg:       cfg,
-		}
-	case *config.TCPMuxProxyConf:
-		pxy = &TCPMuxProxy{
-			BaseProxy: &basePxy,
-			cfg:       cfg,
-		}
-	case *config.HTTPProxyConf:
-		pxy = &HTTPProxy{
-			BaseProxy: &basePxy,
-			cfg:       cfg,
-		}
-	case *config.HTTPSProxyConf:
-		pxy = &HTTPSProxy{
-			BaseProxy: &basePxy,
-			cfg:       cfg,
-		}
-	case *config.UDPProxyConf:
-		basePxy.usedPortsNum = 1
-		pxy = &UDPProxy{
-			BaseProxy: &basePxy,
-			cfg:       cfg,
-		}
-	case *config.STCPProxyConf:
-		pxy = &STCPProxy{
-			BaseProxy: &basePxy,
-			cfg:       cfg,
-		}
-	case *config.XTCPProxyConf:
-		pxy = &XTCPProxy{
-			BaseProxy: &basePxy,
-			cfg:       cfg,
-		}
-	case *config.SUDPProxyConf:
-		pxy = &SUDPProxy{
-			BaseProxy: &basePxy,
-			cfg:       cfg,
-		}
-	default:
+
+	factory := proxyFactoryRegistry[reflect.TypeOf(pxyConf)]
+	if factory == nil {
 		return pxy, fmt.Errorf("proxy type not support")
 	}
-	return
-}
-
-// HandleUserTCPConnection is used for incoming user TCP connections.
-// It can be used for tcp, http, https type.
-func HandleUserTCPConnection(pxy Proxy, userConn net.Conn, serverCfg config.ServerCommonConf) {
-	xl := xlog.FromContextSafe(pxy.Context())
-	defer userConn.Close()
-
-	// server plugin hook
-	rc := pxy.GetResourceController()
-	content := &plugin.NewUserConnContent{
-		User:       pxy.GetUserInfo(),
-		ProxyName:  pxy.GetName(),
-		ProxyType:  pxy.GetConf().GetBaseConfig().ProxyType,
-		RemoteAddr: userConn.RemoteAddr().String(),
+	pxy = factory(&basePxy, pxyConf)
+	if pxy == nil {
+		return nil, fmt.Errorf("proxy not created")
 	}
-	_, err := rc.PluginManager.NewUserConn(content)
-	if err != nil {
-		xl.Warn("the user conn [%s] was rejected, err:%v", content.RemoteAddr, err)
-		return
-	}
-
-	// try all connections from the pool
-	workConn, err := pxy.GetWorkConnFromPool(userConn.RemoteAddr(), userConn.LocalAddr())
-	if err != nil {
-		return
-	}
-	defer workConn.Close()
-
-	var local io.ReadWriteCloser = workConn
-	cfg := pxy.GetConf().GetBaseConfig()
-	xl.Trace("handler user tcp connection, use_encryption: %t, use_compression: %t", cfg.UseEncryption, cfg.UseCompression)
-	if cfg.UseEncryption {
-		local, err = libio.WithEncryption(local, []byte(serverCfg.Token))
-		if err != nil {
-			xl.Error("create encryption stream error: %v", err)
-			return
-		}
-	}
-	if cfg.UseCompression {
-		local = libio.WithCompression(local)
-	}
-
-	if pxy.GetLimiter() != nil {
-		local = libio.WrapReadWriteCloser(limit.NewReader(local, pxy.GetLimiter()), limit.NewWriter(local, pxy.GetLimiter()), func() error {
-			return local.Close()
-		})
-	}
-
-	xl.Debug("join connections, workConn(l[%s] r[%s]) userConn(l[%s] r[%s])", workConn.LocalAddr().String(),
-		workConn.RemoteAddr().String(), userConn.LocalAddr().String(), userConn.RemoteAddr().String())
-
-	name := pxy.GetName()
-	proxyType := pxy.GetConf().GetBaseConfig().ProxyType
-	metrics.Server.OpenConnection(name, proxyType)
-	inCount, outCount, _ := libio.Join(local, userConn)
-	metrics.Server.CloseConnection(name, proxyType)
-	metrics.Server.AddTrafficIn(name, proxyType, inCount)
-	metrics.Server.AddTrafficOut(name, proxyType, outCount)
-	xl.Debug("join connections closed")
+	return pxy, nil
 }
 
 type Manager struct {

--- a/server/proxy/sudp.go
+++ b/server/proxy/sudp.go
@@ -15,14 +15,29 @@
 package proxy
 
 import (
-	"golang.org/x/time/rate"
+	"reflect"
 
 	"github.com/fatedier/frp/pkg/config"
 )
 
+func init() {
+	RegisterProxyFactory(reflect.TypeOf(&config.SUDPProxyConf{}), NewSUDPProxy)
+}
+
 type SUDPProxy struct {
 	*BaseProxy
 	cfg *config.SUDPProxyConf
+}
+
+func NewSUDPProxy(baseProxy *BaseProxy, cfg config.ProxyConf) Proxy {
+	unwrapped, ok := cfg.(*config.SUDPProxyConf)
+	if !ok {
+		return nil
+	}
+	return &SUDPProxy{
+		BaseProxy: baseProxy,
+		cfg:       unwrapped,
+	}
 }
 
 func (pxy *SUDPProxy) Run() (remoteAddr string, err error) {
@@ -40,16 +55,12 @@ func (pxy *SUDPProxy) Run() (remoteAddr string, err error) {
 	pxy.listeners = append(pxy.listeners, listener)
 	xl.Info("sudp proxy custom listen success")
 
-	pxy.startListenHandler(pxy, HandleUserTCPConnection)
+	pxy.startCommonTCPListenersHandler()
 	return
 }
 
 func (pxy *SUDPProxy) GetConf() config.ProxyConf {
 	return pxy.cfg
-}
-
-func (pxy *SUDPProxy) GetLimiter() *rate.Limiter {
-	return pxy.limiter
 }
 
 func (pxy *SUDPProxy) Close() {

--- a/server/proxy/tcp.go
+++ b/server/proxy/tcp.go
@@ -17,24 +17,39 @@ package proxy
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"strconv"
-
-	"golang.org/x/time/rate"
 
 	"github.com/fatedier/frp/pkg/config"
 )
+
+func init() {
+	RegisterProxyFactory(reflect.TypeOf(&config.TCPProxyConf{}), NewTCPProxy)
+}
 
 type TCPProxy struct {
 	*BaseProxy
 	cfg *config.TCPProxyConf
 
-	realPort int
+	realBindPort int
+}
+
+func NewTCPProxy(baseProxy *BaseProxy, cfg config.ProxyConf) Proxy {
+	unwrapped, ok := cfg.(*config.TCPProxyConf)
+	if !ok {
+		return nil
+	}
+	baseProxy.usedPortsNum = 1
+	return &TCPProxy{
+		BaseProxy: baseProxy,
+		cfg:       unwrapped,
+	}
 }
 
 func (pxy *TCPProxy) Run() (remoteAddr string, err error) {
 	xl := pxy.xl
 	if pxy.cfg.Group != "" {
-		l, realPort, errRet := pxy.rc.TCPGroupCtl.Listen(pxy.name, pxy.cfg.Group, pxy.cfg.GroupKey, pxy.serverCfg.ProxyBindAddr, pxy.cfg.RemotePort)
+		l, realBindPort, errRet := pxy.rc.TCPGroupCtl.Listen(pxy.name, pxy.cfg.Group, pxy.cfg.GroupKey, pxy.serverCfg.ProxyBindAddr, pxy.cfg.RemotePort)
 		if errRet != nil {
 			err = errRet
 			return
@@ -44,20 +59,20 @@ func (pxy *TCPProxy) Run() (remoteAddr string, err error) {
 				l.Close()
 			}
 		}()
-		pxy.realPort = realPort
+		pxy.realBindPort = realBindPort
 		pxy.listeners = append(pxy.listeners, l)
 		xl.Info("tcp proxy listen port [%d] in group [%s]", pxy.cfg.RemotePort, pxy.cfg.Group)
 	} else {
-		pxy.realPort, err = pxy.rc.TCPPortManager.Acquire(pxy.name, pxy.cfg.RemotePort)
+		pxy.realBindPort, err = pxy.rc.TCPPortManager.Acquire(pxy.name, pxy.cfg.RemotePort)
 		if err != nil {
 			return
 		}
 		defer func() {
 			if err != nil {
-				pxy.rc.TCPPortManager.Release(pxy.realPort)
+				pxy.rc.TCPPortManager.Release(pxy.realBindPort)
 			}
 		}()
-		listener, errRet := net.Listen("tcp", net.JoinHostPort(pxy.serverCfg.ProxyBindAddr, strconv.Itoa(pxy.realPort)))
+		listener, errRet := net.Listen("tcp", net.JoinHostPort(pxy.serverCfg.ProxyBindAddr, strconv.Itoa(pxy.realBindPort)))
 		if errRet != nil {
 			err = errRet
 			return
@@ -66,9 +81,9 @@ func (pxy *TCPProxy) Run() (remoteAddr string, err error) {
 		xl.Info("tcp proxy listen port [%d]", pxy.cfg.RemotePort)
 	}
 
-	pxy.cfg.RemotePort = pxy.realPort
-	remoteAddr = fmt.Sprintf(":%d", pxy.realPort)
-	pxy.startListenHandler(pxy, HandleUserTCPConnection)
+	pxy.cfg.RemotePort = pxy.realBindPort
+	remoteAddr = fmt.Sprintf(":%d", pxy.realBindPort)
+	pxy.startCommonTCPListenersHandler()
 	return
 }
 
@@ -76,13 +91,9 @@ func (pxy *TCPProxy) GetConf() config.ProxyConf {
 	return pxy.cfg
 }
 
-func (pxy *TCPProxy) GetLimiter() *rate.Limiter {
-	return pxy.limiter
-}
-
 func (pxy *TCPProxy) Close() {
 	pxy.BaseProxy.Close()
 	if pxy.cfg.Group == "" {
-		pxy.rc.TCPPortManager.Release(pxy.realPort)
+		pxy.rc.TCPPortManager.Release(pxy.realBindPort)
 	}
 }

--- a/server/proxy/xtcp.go
+++ b/server/proxy/xtcp.go
@@ -16,19 +16,34 @@ package proxy
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/fatedier/golib/errors"
-	"golang.org/x/time/rate"
 
 	"github.com/fatedier/frp/pkg/config"
 	"github.com/fatedier/frp/pkg/msg"
 )
+
+func init() {
+	RegisterProxyFactory(reflect.TypeOf(&config.XTCPProxyConf{}), NewXTCPProxy)
+}
 
 type XTCPProxy struct {
 	*BaseProxy
 	cfg *config.XTCPProxyConf
 
 	closeCh chan struct{}
+}
+
+func NewXTCPProxy(baseProxy *BaseProxy, cfg config.ProxyConf) Proxy {
+	unwrapped, ok := cfg.(*config.XTCPProxyConf)
+	if !ok {
+		return nil
+	}
+	return &XTCPProxy{
+		BaseProxy: baseProxy,
+		cfg:       unwrapped,
+	}
 }
 
 func (pxy *XTCPProxy) Run() (remoteAddr string, err error) {
@@ -70,10 +85,6 @@ func (pxy *XTCPProxy) Run() (remoteAddr string, err error) {
 
 func (pxy *XTCPProxy) GetConf() config.ProxyConf {
 	return pxy.cfg
-}
-
-func (pxy *XTCPProxy) GetLimiter() *rate.Limiter {
-	return pxy.limiter
 }
 
 func (pxy *XTCPProxy) Close() {


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 12a1233</samp>

This pull request refactors the `proxy` package to use a proxy factory registry, simplify the creation and handling of different proxy types, and add support for new proxy types such as `HTTPProxy`, `TCPMuxProxy`, and `XTCPProxy`. It also adds a TODO comment to `pkg/nathole/controller.go` to handle name conflicts in the NAT hole punching service.

### WHY
<!-- author to complete -->

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 12a1233</samp>

*  Implement a proxy factory registry using `reflect` package to create proxies based on their configuration types ([link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-caa797e117b55f9ac97a0334c16735f3f3775ca8e0d4800a4ff7b66be7ab1e07L20-R23),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-caa797e117b55f9ac97a0334c16735f3f3775ca8e0d4800a4ff7b66be7ab1e07R33-R36),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-ffeee43b930a44c7d8ea834888693156097988a8da5d4dde5cdbc16c04782d46L18-R20),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-ffeee43b930a44c7d8ea834888693156097988a8da5d4dde5cdbc16c04782d46R26-R29),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-1934fd5992845347455fe5e26d6ed40e53ba26f246a0fc9c3d4a70efdbbad6e6R22),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-1934fd5992845347455fe5e26d6ed40e53ba26f246a0fc9c3d4a70efdbbad6e6R40-R45),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-1934fd5992845347455fe5e26d6ed40e53ba26f246a0fc9c3d4a70efdbbad6e6R73),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-1934fd5992845347455fe5e26d6ed40e53ba26f246a0fc9c3d4a70efdbbad6e6L196-R212),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-1934fd5992845347455fe5e26d6ed40e53ba26f246a0fc9c3d4a70efdbbad6e6R266-R302),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-a8a3608f703647da704896989ae588d6b548f5cb25859adb54a2f1fe8f33b4d1L18-R26),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-a8a3608f703647da704896989ae588d6b548f5cb25859adb54a2f1fe8f33b4d1R32-R42),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-27e265b12a950d00fe661898c5422ce6a3c99d7b928c44443c293737439122bbL18-R26),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-27e265b12a950d00fe661898c5422ce6a3c99d7b928c44443c293737439122bbR32-R42),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-633b82351162c59f88cada389d9cbf9d310d3810f6c092bac10430f0c330b1e5L20-R52),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-726a3183adcaf6e00708e701699b38c362eaa7011b9b9bc222689eea3ba2cca8L20-R22),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-726a3183adcaf6e00708e701699b38c362eaa7011b9b9bc222689eea3ba2cca8R29-R32),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-7daa863210605d2a527d8323dc1270152f3729178fa2ca658a6001a3481c7613R22),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-7daa863210605d2a527d8323dc1270152f3729178fa2ca658a6001a3481c7613L37-R45),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-52f5ffea2008402b178846549fb887fd3961403113f5a846202923dc48936b1cL19-R21),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-52f5ffea2008402b178846549fb887fd3961403113f5a846202923dc48936b1cR27-R30))
*  Use the common function `startCommonTCPListenersHandler` defined in the `BaseProxy` type to start goroutine handlers for TCP-based proxies, instead of using the `startListenHandler` function ([link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-caa797e117b55f9ac97a0334c16735f3f3775ca8e0d4800a4ff7b66be7ab1e07R44-R54),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-ffeee43b930a44c7d8ea834888693156097988a8da5d4dde5cdbc16c04782d46L70-R84),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-1934fd5992845347455fe5e26d6ed40e53ba26f246a0fc9c3d4a70efdbbad6e6L158-R171),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-1934fd5992845347455fe5e26d6ed40e53ba26f246a0fc9c3d4a70efdbbad6e6L190-R200),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-a8a3608f703647da704896989ae588d6b548f5cb25859adb54a2f1fe8f33b4d1L43-R58),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-726a3183adcaf6e00708e701699b38c362eaa7011b9b9bc222689eea3ba2cca8L81-R95))
*  Use the proxy configuration stored in the `BaseProxy` type, instead of calling the `GetConf` function of the proxy, in the function `HandleUserTCPConnection` and the proxy handlers ([link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-1934fd5992845347455fe5e26d6ed40e53ba26f246a0fc9c3d4a70efdbbad6e6L280-R218),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-1934fd5992845347455fe5e26d6ed40e53ba26f246a0fc9c3d4a70efdbbad6e6L297),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-1934fd5992845347455fe5e26d6ed40e53ba26f246a0fc9c3d4a70efdbbad6e6L320-R257))
*  Rename the field `realPort` to `realBindPort` in the `TCPProxy`, `UDPProxy`, and `XTCPProxy` types, which reflects the fact that this field stores the port that the proxy binds to on the server side ([link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-633b82351162c59f88cada389d9cbf9d310d3810f6c092bac10430f0c330b1e5L47-R66),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-633b82351162c59f88cada389d9cbf9d310d3810f6c092bac10430f0c330b1e5L57-R75),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-633b82351162c59f88cada389d9cbf9d310d3810f6c092bac10430f0c330b1e5L79-R97),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-7daa863210605d2a527d8323dc1270152f3729178fa2ca658a6001a3481c7613L70-R92),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-7daa863210605d2a527d8323dc1270152f3729178fa2ca658a6001a3481c7613L257-R269))
*  Remove the unused or duplicated `GetLimiter` function from the `HTTPProxy`, `HTTPSProxy`, `STCPProxy`, `SUDPProxy`, `TCPMuxProxy`, and `XTCPProxy` types, and use the `GetLimiter` function defined in the `BaseProxy` type instead ([link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-caa797e117b55f9ac97a0334c16735f3f3775ca8e0d4800a4ff7b66be7ab1e07L140-L143),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-ffeee43b930a44c7d8ea834888693156097988a8da5d4dde5cdbc16c04782d46L79-L82),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-a8a3608f703647da704896989ae588d6b548f5cb25859adb54a2f1fe8f33b4d1L51-L54),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-27e265b12a950d00fe661898c5422ce6a3c99d7b928c44443c293737439122bbL51-L54),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-726a3183adcaf6e00708e701699b38c362eaa7011b9b9bc222689eea3ba2cca8L104-L107),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-7daa863210605d2a527d8323dc1270152f3729178fa2ca658a6001a3481c7613L236-L239),[link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-52f5ffea2008402b178846549fb887fd3961403113f5a846202923dc48936b1cL75-L78))
*  Add a TODO comment to the function `ListenClient` in `pkg/nathole/controller.go` to handle the case where a client tries to register a name that already exists in the NAT hole punching service ([link](https://github.com/fatedier/frp/pull/3488/files?diff=unified&w=0#diff-2f15ef36bc925196e99eb8971b235db30a64a9c44c6ac37215abdaaac812777fR133))
