### PR TITLE
fix the issue of duplicate xtcp proxies will cause the previous proxy to become ineffective

### DIFF
--- a/pkg/nathole/controller.go
+++ b/pkg/nathole/controller.go
@@ -121,7 +121,7 @@ func (c *Controller) CleanWorker(ctx context.Context) {
 	}
 }
 
-func (c *Controller) ListenClient(name string, sk string, allowUsers []string) chan string {
+func (c *Controller) ListenClient(name string, sk string, allowUsers []string) (chan string, error) {
 	cfg := &ClientCfg{
 		name:       name,
 		sk:         sk,
@@ -130,9 +130,11 @@ func (c *Controller) ListenClient(name string, sk string, allowUsers []string) c
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	// TODO(fatedier): return error if name already exists
+	if _, ok := c.clientCfgs[name]; ok {
+		return nil, fmt.Errorf("proxy [%s] is repeated", name)
+	}
 	c.clientCfgs[name] = cfg
-	return cfg.sidCh
+	return cfg.sidCh, nil
 }
 
 func (c *Controller) CloseClient(name string) {

--- a/server/control.go
+++ b/server/control.go
@@ -577,6 +577,11 @@ func (ctl *Control) RegisterProxy(pxyMsg *msg.NewProxy) (remoteAddr string, err 
 		}()
 	}
 
+	if ctl.pxyManager.Exist(pxyMsg.ProxyName) {
+		err = fmt.Errorf("proxy [%s] already exists", pxyMsg.ProxyName)
+		return
+	}
+
 	remoteAddr, err = pxy.Run()
 	if err != nil {
 		return

--- a/server/proxy/proxy.go
+++ b/server/proxy/proxy.go
@@ -324,6 +324,13 @@ func (pm *Manager) Add(name string, pxy Proxy) error {
 	return nil
 }
 
+func (pm *Manager) Exist(name string) bool {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	_, ok := pm.pxys[name]
+	return ok
+}
+
 func (pm *Manager) Del(name string) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()

--- a/server/proxy/xtcp.go
+++ b/server/proxy/xtcp.go
@@ -58,7 +58,10 @@ func (pxy *XTCPProxy) Run() (remoteAddr string, err error) {
 	if len(allowUsers) == 0 {
 		allowUsers = []string{pxy.GetUserInfo().User}
 	}
-	sidCh := pxy.rc.NatHoleController.ListenClient(pxy.GetName(), pxy.cfg.Sk, allowUsers)
+	sidCh, err := pxy.rc.NatHoleController.ListenClient(pxy.GetName(), pxy.cfg.Sk, allowUsers)
+	if err != nil {
+		return "", err
+	}
 	go func() {
 		for {
 			select {

--- a/test/e2e/basic/server.go
+++ b/test/e2e/basic/server.go
@@ -37,7 +37,7 @@ var _ = ginkgo.Describe("[Feature: Server Manager]", func() {
 			[tcp-port-not-allowed]
 			type = tcp
 			local_port = {{ .%s }}
-			remote_port = 20001
+			remote_port = 25001
 			`, framework.TCPEchoServerPort)
 		clientConf += fmt.Sprintf(`
 			[tcp-port-unavailable]
@@ -55,7 +55,7 @@ var _ = ginkgo.Describe("[Feature: Server Manager]", func() {
 			[udp-port-not-allowed]
 			type = udp
 			local_port = {{ .%s }}
-			remote_port = 20003
+			remote_port = 25003
 			`, framework.UDPEchoServerPort)
 
 		f.RunProcesses([]string{serverConf}, []string{clientConf})
@@ -65,7 +65,7 @@ var _ = ginkgo.Describe("[Feature: Server Manager]", func() {
 		framework.NewRequestExpect(f).PortName(tcpPortName).Ensure()
 
 		// Not Allowed
-		framework.NewRequestExpect(f).Port(25003).ExpectError(true).Ensure()
+		framework.NewRequestExpect(f).Port(25001).ExpectError(true).Ensure()
 
 		// Unavailable, already bind by frps
 		framework.NewRequestExpect(f).PortName(consts.PortServerName).ExpectError(true).Ensure()


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e61f609</samp>

Improved validation and error handling for proxy names in `nathole`, `control`, and `xtcp` packages. Changed test ports to avoid conflicts with `nathole` package.

### WHY
<!-- author to complete -->

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e61f609</samp>

*  Prevent the registration of repeated proxies and potential conflicts by checking the proxy name in the `pxyManager` and the `clientCfgs` map ([link](https://github.com/fatedier/frp/pull/3489/files?diff=unified&w=0#diff-292ec4fee0964ed74268d2a5345341096a228f932403bbb4acd1d3e94405d891R580-R584), [link](https://github.com/fatedier/frp/pull/3489/files?diff=unified&w=0#diff-2f15ef36bc925196e99eb8971b235db30a64a9c44c6ac37215abdaaac812777fL133-R137), [link](https://github.com/fatedier/frp/pull/3489/files?diff=unified&w=0#diff-1934fd5992845347455fe5e26d6ed40e53ba26f246a0fc9c3d4a70efdbbad6e6R327-R333))
* Return an error from the `ListenClient` function in the `nathole` package if the proxy name is invalid or duplicated and handle it in the `Run` function in the `xtcp` package ([link](https://github.com/fatedier/frp/pull/3489/files?diff=unified&w=0#diff-2f15ef36bc925196e99eb8971b235db30a64a9c44c6ac37215abdaaac812777fL124-R124), [link](https://github.com/fatedier/frp/pull/3489/files?diff=unified&w=0#diff-52f5ffea2008402b178846549fb887fd3961403113f5a846202923dc48936b1cL61-R64))
* Change the remote ports of the TCP and UDP echo servers in the `test/e2e/basic/server.go` file to avoid the port conflict with the `nathole` package ([link](https://github.com/fatedier/frp/pull/3489/files?diff=unified&w=0#diff-ebf6cb4ccb64fd8ab33798402e776bbb502d3f13be272a797c5ea66a937eca1bL40-R40), [link](https://github.com/fatedier/frp/pull/3489/files?diff=unified&w=0#diff-ebf6cb4ccb64fd8ab33798402e776bbb502d3f13be272a797c5ea66a937eca1bL58-R58))
* Update the port of the not allowed request in the `test/e2e/basic/server.go` file to test the case when the client tries to access a port that is not allowed by the server ([link](https://github.com/fatedier/frp/pull/3489/files?diff=unified&w=0#diff-ebf6cb4ccb64fd8ab33798402e776bbb502d3f13be272a797c5ea66a937eca1bL68-R68))
