### PR TITLE
service.Run supports passing in context

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,3 @@ copilot:summary
 
 ### WHY
 <!-- author to complete -->
-
-### Walkthrough
-
-copilot:walkthrough

--- a/cmd/frpc/sub/root.go
+++ b/cmd/frpc/sub/root.go
@@ -15,6 +15,7 @@
 package sub
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"net"
@@ -233,7 +234,7 @@ func startService(
 		go handleSignal(svr, closedDoneCh)
 	}
 
-	err = svr.Run()
+	err = svr.Run(context.Background())
 	if err == nil && shouldGracefulClose {
 		<-closedDoneCh
 	}

--- a/cmd/frps/root.go
+++ b/cmd/frps/root.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -210,6 +211,6 @@ func runServer(cfg config.ServerCommonConf) (err error) {
 		return err
 	}
 	log.Info("frps started successfully")
-	svr.Run()
+	svr.Run(context.Background())
 	return
 }


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0fd5042</samp>

This pull request refactors the context management of the client and server packages, by passing contexts to the `Run` methods of the `Service` structs. This allows for graceful shutdown and cancellation of the services, and improves the consistency and readability of the code. It also updates the `cmd/frpc` and `cmd/frps` commands to use the context package and pass contexts to the services.

### WHY
Fix #2581

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0fd5042</samp>

*  Pass context as argument to `Run` method of `Service` struct in `client` and `server` packages, and create new context with cancel from it ([link](https://github.com/fatedier/frp/pull/3504/files?diff=unified&w=0#diff-37135e06c87eb7f15648ee3df06d54a2a52cab735ea4110e81610945fe38f7d4L109-R111), [link](https://github.com/fatedier/frp/pull/3504/files?diff=unified&w=0#diff-7cd1def768b5bcc52b79dd84b45271a4f4c0604d574564e6b60e8f2770691394L332-R334), [link](https://github.com/fatedier/frp/pull/3504/files?diff=unified&w=0#diff-204e5524f2c503fa2d88a3c6b30cded3937dabf8bb0d9fac3e8da9daa7824638L236-R237), [link](https://github.com/fatedier/frp/pull/3504/files?diff=unified&w=0#diff-da9862f2cd2796cfe7de4e1ae6a3bb45517c8666a780ed932adc177b1878cf69L213-R214))
*  Remove `ctx` and `cancel` fields from `Service` struct in `client` and `server` packages, and store them as local variables in `Run` method ([link](https://github.com/fatedier/frp/pull/3504/files?diff=unified&w=0#diff-37135e06c87eb7f15648ee3df06d54a2a52cab735ea4110e81610945fe38f7d4L96-R96), [link](https://github.com/fatedier/frp/pull/3504/files?diff=unified&w=0#diff-37135e06c87eb7f15648ee3df06d54a2a52cab735ea4110e81610945fe38f7d4L89), [link](https://github.com/fatedier/frp/pull/3504/files?diff=unified&w=0#diff-7cd1def768b5bcc52b79dd84b45271a4f4c0604d574564e6b60e8f2770691394L132-R131), [link](https://github.com/fatedier/frp/pull/3504/files?diff=unified&w=0#diff-7cd1def768b5bcc52b79dd84b45271a4f4c0604d574564e6b60e8f2770691394L118))
*  Close service or server if context is done and exit flag is not set in `client` package, or if context is done in `server` package ([link](https://github.com/fatedier/frp/pull/3504/files?diff=unified&w=0#diff-37135e06c87eb7f15648ee3df06d54a2a52cab735ea4110e81610945fe38f7d4R166-R169), [link](https://github.com/fatedier/frp/pull/3504/files?diff=unified&w=0#diff-7cd1def768b5bcc52b79dd84b45271a4f4c0604d574564e6b60e8f2770691394R348-R353))
*  Set `svr.ctl` and `svr.cancel` to nil after closing them in `GracefulClose` method of `Service` struct in `client` package, and check for nil before calling them ([link](https://github.com/fatedier/frp/pull/3504/files?diff=unified&w=0#diff-37135e06c87eb7f15648ee3df06d54a2a52cab735ea4110e81610945fe38f7d4L325-R337))
*  Set `svr.listener` and `svr.tlsConfig` to nil after closing them in `Close` method of `Service` struct in `server` package, and check for nil before calling `svr.cancel` ([link](https://github.com/fatedier/frp/pull/3504/files?diff=unified&w=0#diff-7cd1def768b5bcc52b79dd84b45271a4f4c0604d574564e6b60e8f2770691394L351-R380))
*  Clarify comment in `keepControllerWorking` function of `client` package to reflect actual delay in reconnecting to server ([link](https://github.com/fatedier/frp/pull/3504/files?diff=unified&w=0#diff-37135e06c87eb7f15648ee3df06d54a2a52cab735ea4110e81610945fe38f7d4L185-R191))
