### PR TITLE
feat: export client to dynamic lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,11 @@ vet:
 
 frps:
 	env CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o bin/frps ./cmd/frps
+# go build -trimpath -ldflags "-s -w" -o bin/frps ./cmd/frps
 
 frpc:
-	env CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o bin/frpc ./cmd/frpc
+	env CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -buildmode=c-shared  -o bin/frpc ./cmd/frpc
+#env CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -buildmode=c-shared  -o bin/frpc ./cmd/frpc
 
 test: gotest
 

--- a/Makefile.cross-compiles
+++ b/Makefile.cross-compiles
@@ -15,7 +15,7 @@ app:
 		gomips=$(shell echo "$(n)" | cut -d : -f 3);\
 		target_suffix=$${os}_$${arch};\
 		echo "Build $${os}-$${arch}...";\
-		env CGO_ENABLED=0 GOOS=$${os} GOARCH=$${arch} GOMIPS=$${gomips} go build -trimpath -ldflags "$(LDFLAGS)" -o ./release/frpc_$${target_suffix} ./cmd/frpc;\
+		env CGO_ENABLED=0 GOOS=$${os} GOARCH=$${arch} GOMIPS=$${gomips} go build -trimpath -ldflags "$(LDFLAGS)" -buildmode=c-shared -o ./release/frpc_$${target_suffix} ./cmd/frpc;\
 		env CGO_ENABLED=0 GOOS=$${os} GOARCH=$${arch} GOMIPS=$${gomips} go build -trimpath -ldflags "$(LDFLAGS)" -o ./release/frps_$${target_suffix} ./cmd/frps;\
 		echo "Build $${os}-$${arch} done";\
 	)

--- a/cmd/frpc/main.go
+++ b/cmd/frpc/main.go
@@ -14,11 +14,25 @@
 
 package main
 
+import "C"
 import (
+	"fmt"
 	_ "github.com/fatedier/frp/assets/frpc"
 	"github.com/fatedier/frp/cmd/frpc/sub"
+	"os"
+	"time"
 )
 
 func main() {
-	sub.Execute()
+	//sub.Execute()
+}
+
+func frpstart(charargs *C.char) {
+	var stringargs string
+	stringargs = C.GoString(charargs)
+	err := sub.runMultipleClients(stringargs)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 13b82e8</samp>

This pull request adds the ability to run multiple `frpc` clients from a C string argument and compile `frpc` as a shared library. It also makes the linker flags customizable in the `Makefile`.

### WHY
<!-- author to complete -->
