### PR TITLE
fix incorrect use of snappy pool

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -5,3 +5,4 @@
 ### Fixes
 
 * fix a goroutine leak issue caused by Login plugin timeout.
+* Fix an issue introduced in version 0.51.1, enabling `use_compression` will cause some requests to fail.

--- a/client/proxy/proxy.go
+++ b/client/proxy/proxy.go
@@ -142,10 +142,9 @@ func (pxy *BaseProxy) HandleTCPWorkConnection(workConn net.Conn, m *msg.StartWor
 			return
 		}
 	}
+	var compressionResourceRecycleFn func()
 	if baseConfig.UseCompression {
-		var releaseFn func()
-		remote, releaseFn = libio.WithCompressionFromPool(remote)
-		defer releaseFn()
+		remote, compressionResourceRecycleFn = libio.WithCompressionFromPool(remote)
 	}
 
 	// check if we need to send proxy protocol info
@@ -214,5 +213,8 @@ func (pxy *BaseProxy) HandleTCPWorkConnection(workConn net.Conn, m *msg.StartWor
 	xl.Debug("join connections closed")
 	if len(errs) > 0 {
 		xl.Trace("join connections errors: %v", errs)
+	}
+	if compressionResourceRecycleFn != nil {
+		compressionResourceRecycleFn()
 	}
 }

--- a/client/proxy/sudp.go
+++ b/client/proxy/sudp.go
@@ -97,9 +97,7 @@ func (pxy *SUDPProxy) InWorkConn(conn net.Conn, _ *msg.StartWorkConn) {
 		}
 	}
 	if pxy.cfg.UseCompression {
-		var releaseFn func()
-		rwc, releaseFn = libio.WithCompressionFromPool(rwc)
-		defer releaseFn()
+		rwc = libio.WithCompression(rwc)
 	}
 	conn = utilnet.WrapReadWriteCloserToConn(rwc, conn)
 

--- a/client/proxy/udp.go
+++ b/client/proxy/udp.go
@@ -108,9 +108,7 @@ func (pxy *UDPProxy) InWorkConn(conn net.Conn, _ *msg.StartWorkConn) {
 		}
 	}
 	if pxy.cfg.UseCompression {
-		var releaseFn func()
-		rwc, releaseFn = libio.WithCompressionFromPool(rwc)
-		defer releaseFn()
+		rwc = libio.WithCompression(rwc)
 	}
 	conn = utilnet.WrapReadWriteCloserToConn(rwc, conn)
 

--- a/client/visitor/stcp.go
+++ b/client/visitor/stcp.go
@@ -126,9 +126,9 @@ func (sv *STCPVisitor) handleConn(userConn net.Conn) {
 	}
 
 	if sv.cfg.UseCompression {
-		var releaseFn func()
-		remote, releaseFn = libio.WithCompressionFromPool(remote)
-		defer releaseFn()
+		var recycleFn func()
+		remote, recycleFn = libio.WithCompressionFromPool(remote)
+		defer recycleFn()
 	}
 
 	libio.Join(userConn, remote)

--- a/client/visitor/xtcp.go
+++ b/client/visitor/xtcp.go
@@ -200,9 +200,9 @@ func (sv *XTCPVisitor) handleConn(userConn net.Conn) {
 		}
 	}
 	if sv.cfg.UseCompression {
-		var releaseFn func()
-		muxConnRWCloser, releaseFn = libio.WithCompressionFromPool(muxConnRWCloser)
-		defer releaseFn()
+		var recycleFn func()
+		muxConnRWCloser, recycleFn = libio.WithCompressionFromPool(muxConnRWCloser)
+		defer recycleFn()
 	}
 
 	_, _, errs := libio.Join(userConn, muxConnRWCloser)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/coreos/go-oidc/v3 v3.6.0
 	github.com/fatedier/beego v0.0.0-20171024143340-6c6a4f5bd5eb
-	github.com/fatedier/golib v0.1.1-0.20230720124328-204db2e322f8
+	github.com/fatedier/golib v0.1.1-0.20230725122706-dcbaee8eef40
 	github.com/fatedier/kcp-go v2.0.4-0.20190803094908-fe8645b0a904+incompatible
 	github.com/go-playground/validator/v10 v10.14.1
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatedier/beego v0.0.0-20171024143340-6c6a4f5bd5eb h1:wCrNShQidLmvVWn/0PikGmpdP0vtQmnvyRg3ZBEhczw=
 github.com/fatedier/beego v0.0.0-20171024143340-6c6a4f5bd5eb/go.mod h1:wx3gB6dbIfBRcucp94PI9Bt3I0F2c/MyNEWuhzpWiwk=
-github.com/fatedier/golib v0.1.1-0.20230720124328-204db2e322f8 h1:8JYzwZ26k1zEsjgits6GHsQxm2tl3K3FYgMMLcIKBKU=
-github.com/fatedier/golib v0.1.1-0.20230720124328-204db2e322f8/go.mod h1:Lmi9U4VfvdRvonSMh1FgXVy1hCXycVyJk4E9ktokknE=
+github.com/fatedier/golib v0.1.1-0.20230725122706-dcbaee8eef40 h1:BVdpWT6viE/mpuRa6txNyRNjtHa1Efrii9Du6/gHfJ0=
+github.com/fatedier/golib v0.1.1-0.20230725122706-dcbaee8eef40/go.mod h1:Lmi9U4VfvdRvonSMh1FgXVy1hCXycVyJk4E9ktokknE=
 github.com/fatedier/kcp-go v2.0.4-0.20190803094908-fe8645b0a904+incompatible h1:ssXat9YXFvigNge/IkkZvFMn8yeYKFX+uI6wn2mLJ74=
 github.com/fatedier/kcp-go v2.0.4-0.20190803094908-fe8645b0a904+incompatible/go.mod h1:YpCOaxj7vvMThhIQ9AfTOPW2sfztQR5WDfs7AflSy4s=
 github.com/fatedier/yamux v0.0.0-20230628132301-7aca4898904d h1:ynk1ra0RUqDWQfvFi5KtMiSobkVQ3cNc0ODb8CfIETo=

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 )
 
-var version = "0.51.1"
+var version = "0.51.2"
 
 func Full() string {
 	return version

--- a/server/proxy/http.go
+++ b/server/proxy/http.go
@@ -175,9 +175,7 @@ func (pxy *HTTPProxy) GetRealConn(remoteAddr string) (workConn net.Conn, err err
 		}
 	}
 	if pxy.cfg.UseCompression {
-		var releaseFn func()
-		rwc, releaseFn = libio.WithCompressionFromPool(rwc)
-		defer releaseFn()
+		rwc = libio.WithCompression(rwc)
 	}
 
 	if pxy.GetLimiter() != nil {

--- a/server/proxy/proxy.go
+++ b/server/proxy/proxy.go
@@ -241,9 +241,9 @@ func (pxy *BaseProxy) handleUserTCPConnection(userConn net.Conn) {
 		}
 	}
 	if cfg.UseCompression {
-		var releaseFn func()
-		local, releaseFn = libio.WithCompressionFromPool(local)
-		defer releaseFn()
+		var recycleFn func()
+		local, recycleFn = libio.WithCompressionFromPool(local)
+		defer recycleFn()
 	}
 
 	if pxy.GetLimiter() != nil {


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c230c42</samp>

This pull request fixes a memory leak bug in the `client/proxy/proxy.go` file and simplifies the compression code in several other files by using the `libio.WithCompression` function instead of the `libio.WithCompressionFromPool` function. It also updates the `github.com/fatedier/golib` dependency and the `Release.md` file.

### WHY
Fix #3541
