### PR TITLE
remove arch 386

### DIFF
--- a/Makefile.cross-compiles
+++ b/Makefile.cross-compiles
@@ -2,7 +2,7 @@ export PATH := $(GOPATH)/bin:$(PATH)
 export GO111MODULE=on
 LDFLAGS := -s -w
 
-os-archs=darwin:amd64 darwin:arm64 freebsd:386 freebsd:amd64 linux:386 linux:amd64 linux:arm linux:arm64 windows:386 windows:amd64 windows:arm64 linux:mips64 linux:mips64le linux:mips:softfloat linux:mipsle:softfloat linux:riscv64
+os-archs=darwin:amd64 darwin:arm64 freebsd:amd64 linux:amd64 linux:arm linux:arm64 windows:amd64 windows:arm64 linux:mips64 linux:mips64le linux:mips:softfloat linux:mipsle:softfloat linux:riscv64
 
 all: build
 
@@ -19,8 +19,6 @@ app:
 		env CGO_ENABLED=0 GOOS=$${os} GOARCH=$${arch} GOMIPS=$${gomips} go build -trimpath -ldflags "$(LDFLAGS)" -o ./release/frps_$${target_suffix} ./cmd/frps;\
 		echo "Build $${os}-$${arch} done";\
 	)
-	@mv ./release/frpc_windows_386 ./release/frpc_windows_386.exe
-	@mv ./release/frps_windows_386 ./release/frps_windows_386.exe
 	@mv ./release/frpc_windows_amd64 ./release/frpc_windows_amd64.exe
 	@mv ./release/frps_windows_amd64 ./release/frps_windows_amd64.exe
 	@mv ./release/frpc_windows_arm64 ./release/frpc_windows_arm64.exe


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef555dc</samp>

Simplify and streamline cross-compiling `frp` binaries. Remove unused architectures and rename commands in `Makefile.cross-compiles`.

### WHY
<!-- author to complete -->
