### PR TITLE
Auto pick current version from `go.mod` in `goreleaser.yml`

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,9 +14,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - name: Set up Go
+        uses: kevincobain2000/action-gobrew@v2.2
         with:
-          go-version: '1.21'
+          version: 'mod'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -13,10 +13,10 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: kevincobain2000/action-gobrew@v2.2
         with:
-          go-version: '1.21'
-          
+          version: 'mod'
+
       - name: Make All
         run: |
           ./package.sh


### PR DESCRIPTION
### Summary

Updates `goreleaser.yml` to auto pick go version from `go.mod`

### WHY

Related to https://github.com/fatedier/frp/pull/3573, so you don't have to change the version each time when `go.mod` is changed.

I also considered updating `golangci-lint.yml` and add a matrix as below:

```
jobs:
  golangci:
    strategy:
      matrix:
        go-version: [mod, latest]
        os: [ubuntu-latest, macos-latest]
```

That will auto pick up go version from `go.mod` and the `latest` version that is released. But wasn't sure if you are trying to limit the number of jobs and wasn't on matrix for a special reason.

Action is using https://github.com/kevincobain2000/gobrew for more information.
