### PR TITLE
Fix README full config links

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,9 +460,9 @@ Note that it may not work with all types of NAT devices. You might want to fallb
 
 Read the full example configuration files to find out even more features not described here.
 
-[Full configuration file for frps (Server)](./conf/frps_full.ini)
+[Full configuration file for frps (Server)](./conf/frps_legacy_full.ini)
 
-[Full configuration file for frpc (Client)](./conf/frpc_full.ini)
+[Full configuration file for frpc (Client)](./conf/frpc_legacy_full.ini)
 
 ### Using Environment Variables
 


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b670fa</samp>

Update documentation links to legacy configuration files. The `README.md` file now points to the old INI format for `frps.ini` and `frpc.ini`, since the master branch uses YAML.

### WHY
<!-- author to complete -->
