### PR TITLE
fix that transport.tls.disableCustomTLSFirstByte doesn't take effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,6 +761,8 @@ allowPorts = [
 
 `vhostHTTPPort` and `vhostHTTPSPort` in frps can use same port with `bindPort`. frps will detect the connection's protocol and handle it correspondingly.
 
+What you need to pay attention to is that if you want to configure `vhostHTTPSPort` and `bindPort` to the same port, you need to first set `transport.tls.disableCustomTLSFirstByte` to false.
+
 We would like to try to allow multiple proxies bind a same remote port with different protocols in the future.
 
 ### Bandwidth Limit

--- a/Release.md
+++ b/Release.md
@@ -1,9 +1,3 @@
-### Features
+### Fixes
 
-* Configuration: We now support TOML, YAML, and JSON for configuration. Please note that INI is deprecated and will be removed in future releases. New features will only be available in TOML, YAML, or JSON. Users wanting these new features should switch their configuration format accordingly. #2521
-
-### Breaking Changes
-
-* Change the way to start the visitor through the command line from `frpc stcp --role=visitor xxx` to `frpc stcp visitor xxx`.
-* Modified the semantics of the `server_addr` in the command line, no longer including the port. Added the `server_port` parameter to configure the port.
-* No longer support range ports mapping in TOML/YAML/JSON.
+* `transport.tls.disableCustomTLSFirstByte` doesn't have any effect.

--- a/client/service.go
+++ b/client/service.go
@@ -476,6 +476,9 @@ func (cm *ConnectionManager) realConnect() (net.Conn, error) {
 		// Make sure that if it is wss, the websocket hook is executed after the tls hook.
 		dialOptions = append(dialOptions, libdial.WithAfterHook(libdial.AfterHook{Hook: utilnet.DialHookWebsocket(protocol, tlsConfig.ServerName), Priority: 110}))
 	default:
+		dialOptions = append(dialOptions, libdial.WithAfterHook(libdial.AfterHook{
+			Hook: utilnet.DialHookCustomTLSHeadByte(tlsConfig != nil, lo.FromPtr(cm.cfg.Transport.TLS.DisableCustomTLSFirstByte)),
+		}))
 		dialOptions = append(dialOptions, libdial.WithTLSConfig(tlsConfig))
 	}
 

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 )
 
-var version = "0.52.0"
+var version = "0.52.1"
 
 func Full() string {
 	return version

--- a/test/e2e/v1/basic/client_server.go
+++ b/test/e2e/v1/basic/client_server.go
@@ -291,7 +291,7 @@ var _ = ginkgo.Describe("[Feature: Client-Server]", func() {
 		})
 	})
 
-	ginkgo.Describe("TLS with disable_custom_tls_first_byte set to false", func() {
+	ginkgo.Describe("TLS with disableCustomTLSFirstByte set to false", func() {
 		supportProtocols := []string{"tcp", "kcp", "quic", "websocket"}
 		for _, protocol := range supportProtocols {
 			tmp := protocol
@@ -318,6 +318,24 @@ var _ = ginkgo.Describe("[Feature: Client-Server]", func() {
 					`, renderBindPortConfig(protocol)),
 				client: fmt.Sprintf(`
 					transport.protocol = "%s"
+					`, protocol),
+			})
+		}
+	})
+
+	ginkgo.Describe("Use same port for bindPort and vhostHTTPSPort", func() {
+		supportProtocols := []string{"tcp", "kcp", "quic", "websocket"}
+		for _, protocol := range supportProtocols {
+			tmp := protocol
+			defineClientServerTest("Use same port for bindPort and vhostHTTPSPort: "+strings.ToUpper(tmp), f, &generalTestConfigures{
+				server: fmt.Sprintf(`
+					vhostHTTPSPort = {{ .%s }}
+					%s
+					`, consts.PortServerName, renderBindPortConfig(protocol)),
+				// transport.tls.disableCustomTLSFirstByte should set to false when vhostHTTPSPort is same as bindPort
+				client: fmt.Sprintf(`
+					transport.protocol = "%s"
+					transport.tls.disableCustomTLSFirstByte = false
 					`, protocol),
 			})
 		}


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 815de94</samp>

This pull request adds a new feature to allow custom TLS first byte for HTTPS connections, which can be used to support port reuse for different protocols. It also fixes a bug, updates the version, and improves the documentation and test cases related to this feature.

### WHY
Fix #3656
