### PR TITLE
fix legacy ini proxy conversion panic

### DIFF
--- a/pkg/config/legacy/conversion.go
+++ b/pkg/config/legacy/conversion.go
@@ -306,6 +306,7 @@ func Convert_ProxyConf_To_v1(conf ProxyConf) v1.ProxyConfigurer {
 		c := &v1.XTCPProxyConfig{ProxyBaseConfig: *outBase}
 		c.Secretkey = v.Sk
 		c.AllowUsers = v.AllowUsers
+		out = c
 	}
 	return out
 }

--- a/test/e2e/framework/consts/consts.go
+++ b/test/e2e/framework/consts/consts.go
@@ -25,6 +25,7 @@ log.level = "trace"
 	DefaultClientConfig = `
 serverAddr = "127.0.0.1"
 serverPort = {{ .%s }}
+loginFailExit = false
 log.level = "trace"
 `
 
@@ -38,6 +39,7 @@ log.level = "trace"
 	[common]
 	server_addr = 127.0.0.1
 	server_port = {{ .%s }}
+	login_fail_exit = false
 	log_level = trace
 	`
 )

--- a/test/e2e/framework/process.go
+++ b/test/e2e/framework/process.go
@@ -40,6 +40,7 @@ func (f *Framework) RunProcesses(serverTemplates []string, clientTemplates []str
 		currentServerProcesses = append(currentServerProcesses, p)
 		err = p.Start()
 		ExpectNoError(err)
+		time.Sleep(500 * time.Millisecond)
 	}
 	time.Sleep(1 * time.Second)
 


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9cff3d0</samp>

Fix plugin configuration loss when using legacy API. Assign input parameter to output variable in `Convert_ProxyConf_To_v1` function in `pkg/config/legacy/conversion.go`.

### WHY
Fix #3665
