### PR TITLE
fix example config

### DIFF
--- a/conf/frpc.toml
+++ b/conf/frpc.toml
@@ -36,7 +36,7 @@ auth.token = "12345678"
 # auth.oidc.clientSecret = ""
 # oidc.audience specifies the audience of the token in OIDC authentication.
 # auth.oidc.audience = ""
-# oidc_scope specifies the permisssions of the token in OIDC authentication if AuthenticationMethod == "oidc". By default, this value is "".
+# oidc.scope specifies the permisssions of the token in OIDC authentication if AuthenticationMethod == "oidc". By default, this value is "".
 # auth.oidc.scope = ""
 # oidc.tokenEndpointURL specifies the URL which implements OIDC Token Endpoint.
 # It will be used to get an OIDC token.
@@ -110,7 +110,7 @@ transport.tls.enable = true
 # transport.tls.disableCustomTLSFirstByte = true
 
 # Heartbeat configure, it's not recommended to modify the default value.
-# The default value of heartbeat_interval is 10 and heartbeat_timeout is 90. Set negative value
+# The default value of heartbeatInterval is 10 and heartbeatTimeout is 90. Set negative value
 # to disable it.
 # transport.heartbeatInterval = 30
 # transport.heartbeatTimeout = 90
@@ -173,7 +173,7 @@ name = "ssh_random"
 type = "tcp"
 localIP = "192.168.31.100"
 localPort = 22
-# If remote_port is 0, frps will assign a random port for you
+# If remotePort is 0, frps will assign a random port for you
 remotePort = 0
 
 [[proxies]]
@@ -183,14 +183,14 @@ localIP = "114.114.114.114"
 localPort = 53
 remotePort = 6002
 
-# Resolve your domain names to [server_addr] so you can use http://web01.yourdomain.com to browse web01 and http://web02.yourdomain.com to browse web02
+# Resolve your domain names to [serverAddr] so you can use http://web01.yourdomain.com to browse web01 and http://web02.yourdomain.com to browse web02
 [[proxies]]
 name = "web01"
 type = "http"
 localIP = "127.0.0.1"
 localPort = 80
 # http username and password are safety certification for http protocol
-# if not set, you can access this custom_domains without certification
+# if not set, you can access this customDomains without certification
 httpUser = "admin"
 httpPassword = "admin"
 # if domain for frps is frps.com, then you can access [web01] proxy by URL http://web01.frps.com
@@ -199,9 +199,8 @@ customDomains = ["web01.yourdomain.com"]
 # locations is only available for http type
 locations = ["/", "/pic"]
 # route requests to this service if http basic auto user is abc
-# route_by_http_user = abc
+# routeByHTTPUser = abc
 hostHeaderRewrite = "example.com"
-# params with prefix "header_" will be used to update http request headers
 requestHeaders.set.x-from-where = "frp"
 healthCheck.type = "http"
 # frpc will send a GET http request '/status' to local http service
@@ -235,7 +234,7 @@ customDomains = ["tunnel1"]
 name = "plugin_unix_domain_socket"
 type = "tcp"
 remotePort = 6003
-# if plugin is defined, local_ip and local_port is useless
+# if plugin is defined, localIP and localPort is useless
 # plugin will handle connections got from frps
 [proxies.plugin]
 type = "unix_domain_socket"
@@ -306,7 +305,7 @@ requestHeaders.set.x-from-where = "frp"
 
 [[proxies]]
 name = "secret_tcp"
-# If the type is secret tcp, remote_port is useless
+# If the type is secret tcp, remotePort is useless
 # Who want to connect local port should deploy another frpc with stcp proxy and role is visitor
 type = "stcp"
 # secretKey is used for authentication for visitors
@@ -353,7 +352,7 @@ bindAddr = "127.0.0.1"
 bindPort = 9001
 # when automatic tunnel persistence is required, set it to true
 keepTunnelOpen = false
-# effective when keep_tunnel_open is set to true, the number of attempts to punch through per hour
+# effective when keepTunnelOpen is set to true, the number of attempts to punch through per hour
 maxRetriesAnHour = 8
 minRetryInterval = 90
 # fallbackTo = "stcp_visitor"

--- a/conf/frps.toml
+++ b/conf/frps.toml
@@ -1,10 +1,10 @@
 # A literal address or host name for IPv6 must be enclosed
 # in square brackets, as in "[::1]:80", "[ipv6-host]:http" or "[ipv6-host%zone]:80"
-# For single "bind_addr" field, no need square brackets, like "bind_addr = ::".
+# For single "bindAddr" field, no need square brackets, like `bindAddr = "::"`.
 bindAddr = "0.0.0.0"
 bindPort = 7000
 
-# udp port used for kcp protocol, it can be same with 'bind_port'.
+# udp port used for kcp protocol, it can be same with 'bindPort'.
 # if not set, kcp is disabled in frps.
 kcpBindPort = 7000
 
@@ -12,8 +12,8 @@ kcpBindPort = 7000
 # if not set, quic is disabled in frps.
 # quicBindPort = 7002
 
-# Specify which address proxy will listen for, default value is same with bind_addr
-# proxy_bind_addr = "127.0.0.1"
+# Specify which address proxy will listen for, default value is same with bindAddr
+# proxyBindAddr = "127.0.0.1"
 
 # quic protocol options
 # transport.quic.keepalivePeriod = 10
@@ -21,7 +21,7 @@ kcpBindPort = 7000
 # transport.quic.maxIncomingStreams = 100000
 
 # Heartbeat configure, it's not recommended to modify the default value
-# The default value of heartbeat_timeout is 90. Set negative value to disable it.
+# The default value of heartbeatTimeout is 90. Set negative value to disable it.
 # transport.heartbeatTimeout = 90
 
 # Pool count in each proxy will keep no more than maxPoolCount.
@@ -46,7 +46,7 @@ tls.force = false
 # transport.tls.trustedCaFile = "ca.crt"
 
 # If you want to support virtual host, you must set the http port for listening (optional)
-# Note: http port and https port can be same with bind_port
+# Note: http port and https port can be same with bindPort
 vhostHTTPPort = 80
 vhostHTTPSPort = 443
 
@@ -59,7 +59,7 @@ vhostHTTPSPort = 443
 # HTTP CONNECT requests. By default, this value is 0.
 # tcpmuxHTTPConnectPort = 1337
 
-# If tcpmux_passthrough is true, frps won't do any update on traffic.
+# If tcpmuxPassthrough is true, frps won't do any update on traffic.
 # tcpmuxPassthrough = false
 
 # Configure the web server to enable the dashboard for frps.

--- a/pkg/config/v1/server.go
+++ b/pkg/config/v1/server.go
@@ -150,6 +150,7 @@ type ServerTransportConfig struct {
 	// TCPMux toggles TCP stream multiplexing. This allows multiple requests
 	// from a client to share a single TCP connection. By default, this value
 	// is true.
+	// $HideFromDoc
 	TCPMux *bool `json:"tcpMux,omitempty"`
 	// TCPMuxKeepaliveInterval specifies the keep alive interval for TCP stream multipler.
 	// If TCPMux is true, heartbeat of application layer is unnecessary because it can only rely on heartbeat in TCPMux.


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1c4b4c6</samp>

This pull request improves the configuration files and documentation of frp. It standardizes the use of camel case for configuration fields in `frpc.toml` and `frps.toml`, and fixes a typo in the latter. It also adds a tag to hide an internal type from the documentation in `server.go`.

### WHY
Fix #3698