### PR TITLE
admin user not convert in INI

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -1,3 +1,3 @@
 ### Fixes
 
-* Encryption and compression are not displayed correctly in the dashboard.
+* `admin_user` is not effective in the INI configuration.

--- a/pkg/config/legacy/conversion.go
+++ b/pkg/config/legacy/conversion.go
@@ -71,6 +71,7 @@ func Convert_ClientCommonConf_To_v1(conf *ClientCommonConf) *v1.ClientCommonConf
 
 	out.WebServer.Addr = conf.AdminAddr
 	out.WebServer.Port = conf.AdminPort
+	out.WebServer.User = conf.AdminUser
 	out.WebServer.Password = conf.AdminPwd
 	out.WebServer.AssetsDir = conf.AssetsDir
 	out.WebServer.PprofEnable = conf.PprofEnable


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f95c109</samp>

Fix web server user bug in legacy config conversion. Assign `WebServer.User` to `AdminUser` in `Convert_ClientCommonConf_To_v1` function in `pkg/config/legacy/conversion.go`.

### WHY
Fix #3718
