### PR TITLE
Feature/retry access token

### DIFF
--- a/pkg/config/v1/client.go
+++ b/pkg/config/v1/client.go
@@ -38,6 +38,9 @@ type ClientCommonConfig struct {
 	// changed to "{user}.{proxy_name}".
 	User string `json:"user,omitempty"`
 
+	// AuthRetryConfig specifies the retry strategy for retrieving access tokens.
+	AuthRetryConfig AuthRetryConfig `json:"authRetry,omitempty"`
+
 	// ServerAddr specifies the address of the server to connect to. By
 	// default, this value is "0.0.0.0".
 	ServerAddr string `json:"serverAddr,omitempty"`
@@ -197,4 +200,6 @@ type AuthOIDCClientConfig struct {
 	// AdditionalEndpointParams specifies additional parameters to be sent
 	// this field will be transfer to map[string][]string in OIDC token generator.
 	AdditionalEndpointParams map[string]string `json:"additionalEndpointParams,omitempty"`
+	// AuthRetryConfig specifies the retry strategy for retrieving access tokens.
+	AuthRetryConfig AuthRetryConfig `json:"authRetry,omitempty"`
 }

--- a/pkg/config/v1/common.go
+++ b/pkg/config/v1/common.go
@@ -16,6 +16,7 @@ package v1
 
 import (
 	"github.com/fatedier/frp/pkg/util/util"
+	"time"
 )
 
 type AuthScope string
@@ -114,4 +115,13 @@ type HTTPPluginOptions struct {
 
 type HeaderOperations struct {
 	Set map[string]string `json:"set,omitempty"`
+}
+
+type AuthRetryConfig struct {
+	// MaxRetries specifies the maximum number of retries to authenticate
+	// with frps. By default, this value is 0.
+	MaxRetries int `json:"maxRetries,omitempty"`
+	// RetryDelay specifies the delay between retries to authenticate with
+	// frps, in seconds. By default, this value is 1.
+	RetryDelay time.Duration `json:"retryDelay,omitempty"`
 }


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d0e5852</samp>

This pull request adds retry support for OIDC authentication in frp clients. It defines a new `AuthRetryConfig` struct to store the retry parameters, and uses it in the `OidcAuthProvider`, `ClientCommonConfig`, and `AuthOIDCClientConfig` structs. It also modifies the `pkg/auth/oidc.go` and `pkg/config/v1/client.go` files to implement the retry logic and configuration parsing.

### WHY
When the OIDC provider is unavailable when a new token is requested, the client
is stuck for an indefinite state. This is only resolved by restarting the client or
the server.

With this feature, we want to achieve a scenario where a token is requested for a
set amount of retries when the OIDC provider is not available.
