### PR TITLE
frpc: exit with code 1 if first login failed

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -1,3 +1,3 @@
 ### Fixes
 
-* `admin_user` is not effective in the INI configuration.
+* frpc: Return code 1 when the first login attempt fails and exits.

--- a/client/service.go
+++ b/client/service.go
@@ -83,8 +83,8 @@ func NewService(
 	pxyCfgs []v1.ProxyConfigurer,
 	visitorCfgs []v1.VisitorConfigurer,
 	cfgFile string,
-) (svr *Service, err error) {
-	svr = &Service{
+) *Service {
+	return &Service{
 		authSetter:  auth.NewAuthSetter(cfg.Auth),
 		cfg:         cfg,
 		cfgFile:     cfgFile,
@@ -93,7 +93,6 @@ func NewService(
 		ctx:         context.Background(),
 		exit:        0,
 	}
-	return
 }
 
 func (svr *Service) GetController() *Control {

--- a/cmd/frpc/sub/root.go
+++ b/cmd/frpc/sub/root.go
@@ -139,10 +139,7 @@ func startService(
 		log.Info("start frpc service for config file [%s]", cfgFile)
 		defer log.Info("frpc service for config file [%s] stopped", cfgFile)
 	}
-	svr, err := client.NewService(cfg, pxyCfgs, visitorCfgs, cfgFile)
-	if err != nil {
-		return err
-	}
+	svr := client.NewService(cfg, pxyCfgs, visitorCfgs, cfgFile)
 
 	shouldGracefulClose := cfg.Transport.Protocol == "kcp" || cfg.Transport.Protocol == "quic"
 	// Capture the exit signal if we use kcp or quic.
@@ -150,6 +147,5 @@ func startService(
 		go handleTermSignal(svr)
 	}
 
-	_ = svr.Run(context.Background())
-	return nil
+	return svr.Run(context.Background())
 }


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 59df343</samp>

Refactor `client` and `cmd/frpc` packages to simplify service creation and error handling. Enhance code readability and efficiency.

### WHY
Fix #3731
