### PR TITLE
validate client certificate of frpc for tcpmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ transport.tls.force = true
 transport.tls.certFile = "certificate.crt"
 transport.tls.keyFile = "certificate.key"
 transport.tls.trustedCaFile = "ca.crt"
+transport.tls.clientCertSubjectRegex = "CN=client.com(.+)"
 ```
 
 You will need **a root CA cert** and **at least one SSL/TLS certificate**. It **can** be self-signed or regular (such as Let's Encrypt or another SSL/TLS certificate provider).

--- a/conf/frps_full_example.toml
+++ b/conf/frps_full_example.toml
@@ -47,6 +47,9 @@ tls.force = false
 # transport.tls.keyFile = "server.key"
 # transport.tls.trustedCaFile = "ca.crt"
 
+# Validates the subject of the TLS client certificate using regex. By default, this value is not set and the validation is disabled.
+# transport.tls.clientCertSubjectRegex = "CN=client.com(.+)"
+
 # If you want to support virtual host, you must set the http port for listening (optional)
 # Note: http port and https port can be same with bindPort
 vhostHTTPPort = 80

--- a/pkg/config/v1/common.go
+++ b/pkg/config/v1/common.go
@@ -80,6 +80,9 @@ type TLSConfig struct {
 	// ServerName specifies the custom server name of tls certificate. By
 	// default, server name if same to ServerAddr.
 	ServerName string `json:"serverName,omitempty"`
+	// ClientCertificateSubjectRegex specifies the regex that is used to validate the client certificate subject.
+	// If it's not set, the validation of the subject is disabled.
+	ClientCertificateSubjectRegex string `json:"clientCertSubjectRegex,omitempty"`
 }
 
 type LogConfig struct {

--- a/pkg/util/net/tls.go
+++ b/pkg/util/net/tls.go
@@ -63,18 +63,18 @@ func IsClientCertificateSubjectValid(c net.Conn, tlsConfig v1.TLSServerConfig) b
 	subjectRegex := tlsConfig.ClientCertificateSubjectRegex
 	regex, err := regexp.Compile(subjectRegex)
 	if err != nil {
-		log.Trace("Client certificate subject validation is disabled")
+		log.Trace("TLS client certificate subject validation is disabled")
 		return true
 	}
 
 	tlsConn, ok := c.(*tls.Conn)
 	if !ok {
-		log.Warn("Skip client certificate subject validation because its not a tls connection")
+		log.Warn("Skip TLS client certificate subject validation because its non-TLS connection")
 		return true
 	}
 
 	state := tlsConn.ConnectionState()
-	log.Trace("Validating client certificate subject using regex: %v", subjectRegex)
+	log.Trace("Validating TLS client certificate subject using regex: %v", subjectRegex)
 	if len(state.PeerCertificates) == 0 {
 		log.Warn("No client certificates found in TLS connection, the verification was probably called to early.")
 		return false
@@ -83,10 +83,10 @@ func IsClientCertificateSubjectValid(c net.Conn, tlsConfig v1.TLSServerConfig) b
 	for _, v := range state.PeerCertificates {
 		subject := fmt.Sprintf("%v", v.Subject)
 		if !regex.MatchString(subject) {
-			log.Warn("Client certificate subject %v doesn't match regex %v", v.Subject, subjectRegex)
+			log.Warn("TLS client certificate subject %v doesn't match regex %v", v.Subject, subjectRegex)
 			return false
 		}
-		log.Trace("Client certificate subject is valid")
+		log.Trace("TLS client certificate subject is valid")
 	}
 	return true
 }

--- a/server/service.go
+++ b/server/service.go
@@ -484,6 +484,13 @@ func (svr *Service) HandleListener(l net.Listener) {
 						session.Close()
 						return
 					}
+
+					// Has to be called after session.AcceptStream() so that the client certificates are available
+					if !utilnet.IsClientCertificateSubjectValid(c, svr.cfg.Transport.TLS) {
+						session.Close()
+						return
+					}
+
 					go svr.handleConnection(ctx, stream)
 				}
 			} else {


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b91ac4</samp>

This pull request adds a new option `clientCertSubjectRegex` to the TLS transport configuration, which allows the server to validate the client certificate subject using a regular expression. It modifies the `net`, `config`, `server`, and `README` packages to implement and document this feature.

### WHY
<!-- author to complete -->
