### PR TITLE
Strict configuration parsing

### DIFF
--- a/client/admin_api.go
+++ b/client/admin_api.go
@@ -57,7 +57,7 @@ func (svr *Service) apiReload(w http.ResponseWriter, _ *http.Request) {
 		}
 	}()
 
-	cliCfg, pxyCfgs, visitorCfgs, _, err := config.LoadClientConfig(svr.cfgFile)
+	cliCfg, pxyCfgs, visitorCfgs, _, err := config.LoadClientConfig(svr.cfgFile, svr.strictConfig)
 	if err != nil {
 		res.Code = 400
 		res.Msg = err.Error()

--- a/client/service.go
+++ b/client/service.go
@@ -70,6 +70,9 @@ type Service struct {
 	// string if no configuration file was used.
 	cfgFile string
 
+	// Whether strict configuration parsing had been requested.
+	strictConfig bool
+
 	// service context
 	ctx context.Context
 	// call cancel to stop service
@@ -82,14 +85,16 @@ func NewService(
 	pxyCfgs []v1.ProxyConfigurer,
 	visitorCfgs []v1.VisitorConfigurer,
 	cfgFile string,
+	strictConfig bool,
 ) *Service {
 	return &Service{
-		authSetter:  auth.NewAuthSetter(cfg.Auth),
-		cfg:         cfg,
-		cfgFile:     cfgFile,
-		pxyCfgs:     pxyCfgs,
-		visitorCfgs: visitorCfgs,
-		ctx:         context.Background(),
+		authSetter:   auth.NewAuthSetter(cfg.Auth),
+		cfg:          cfg,
+		cfgFile:      cfgFile,
+		strictConfig: strictConfig,
+		pxyCfgs:      pxyCfgs,
+		visitorCfgs:  visitorCfgs,
+		ctx:          context.Background(),
 	}
 }
 

--- a/cmd/frpc/sub/admin.go
+++ b/cmd/frpc/sub/admin.go
@@ -52,7 +52,7 @@ func NewAdminCommand(name, short string, handler func(*v1.ClientCommonConfig) er
 		Use:   name,
 		Short: short,
 		Run: func(cmd *cobra.Command, args []string) {
-			cfg, _, _, _, err := config.LoadClientConfig(cfgFile)
+			cfg, _, _, _, err := config.LoadClientConfig(cfgFile, strictConfig)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)

--- a/cmd/frpc/sub/nathole.go
+++ b/cmd/frpc/sub/nathole.go
@@ -48,7 +48,7 @@ var natholeDiscoveryCmd = &cobra.Command{
 	Short: "Discover nathole information from stun server",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// ignore error here, because we can use command line pameters
-		cfg, _, _, _, err := config.LoadClientConfig(cfgFile)
+		cfg, _, _, _, err := config.LoadClientConfig(cfgFile, strictConfig)
 		if err != nil {
 			cfg = &v1.ClientCommonConfig{}
 		}

--- a/cmd/frpc/sub/proxy.go
+++ b/cmd/frpc/sub/proxy.go
@@ -84,7 +84,7 @@ func NewProxyCommand(name string, c v1.ProxyConfigurer, clientCfg *v1.ClientComm
 				fmt.Println(err)
 				os.Exit(1)
 			}
-			err := startService(clientCfg, []v1.ProxyConfigurer{c}, nil, "")
+			err := startService(clientCfg, []v1.ProxyConfigurer{c}, nil, "", strictConfig)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)
@@ -110,7 +110,7 @@ func NewVisitorCommand(name string, c v1.VisitorConfigurer, clientCfg *v1.Client
 				fmt.Println(err)
 				os.Exit(1)
 			}
-			err := startService(clientCfg, nil, []v1.VisitorConfigurer{c}, "")
+			err := startService(clientCfg, nil, []v1.VisitorConfigurer{c}, "", strictConfig)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)

--- a/cmd/frpc/sub/verify.go
+++ b/cmd/frpc/sub/verify.go
@@ -37,7 +37,7 @@ var verifyCmd = &cobra.Command{
 			return nil
 		}
 
-		cliCfg, pxyCfgs, visitorCfgs, _, err := config.LoadClientConfig(cfgFile)
+		cliCfg, pxyCfgs, visitorCfgs, _, err := config.LoadClientConfig(cfgFile, strictConfig)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/cmd/frps/root.go
+++ b/cmd/frps/root.go
@@ -30,8 +30,9 @@ import (
 )
 
 var (
-	cfgFile     string
-	showVersion bool
+	cfgFile      string
+	showVersion  bool
+	strictConfig bool
 
 	serverCfg v1.ServerConfig
 )
@@ -39,6 +40,7 @@ var (
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file of frps")
 	rootCmd.PersistentFlags().BoolVarP(&showVersion, "version", "v", false, "version of frps")
+	rootCmd.PersistentFlags().BoolVarP(&strictConfig, "strict_config", "", false, "strict config parsing mode")
 
 	RegisterServerConfigFlags(rootCmd, &serverCfg)
 }
@@ -58,7 +60,7 @@ var rootCmd = &cobra.Command{
 			err            error
 		)
 		if cfgFile != "" {
-			svrCfg, isLegacyFormat, err = config.LoadServerConfig(cfgFile)
+			svrCfg, isLegacyFormat, err = config.LoadServerConfig(cfgFile, strictConfig)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)

--- a/cmd/frps/verify.go
+++ b/cmd/frps/verify.go
@@ -36,7 +36,7 @@ var verifyCmd = &cobra.Command{
 			fmt.Println("frps: the configuration file is not specified")
 			return nil
 		}
-		svrCfg, _, err := config.LoadServerConfig(cfgFile)
+		svrCfg, _, err := config.LoadServerConfig(cfgFile, strictConfig)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -22,9 +22,7 @@ import (
 	v1 "github.com/fatedier/frp/pkg/config/v1"
 )
 
-func TestLoadConfigure(t *testing.T) {
-	require := require.New(t)
-	content := `
+const tomlServerContent = `
 bindAddr = "127.0.0.1"
 kcpBindPort = 7000
 quicBindPort = 7001
@@ -33,13 +31,40 @@ custom404Page = "/abc.html"
 transport.tcpKeepalive = 10
 `
 
-	svrCfg := v1.ServerConfig{}
-	err := LoadConfigure([]byte(content), &svrCfg)
-	require.NoError(err)
-	require.EqualValues("127.0.0.1", svrCfg.BindAddr)
-	require.EqualValues(7000, svrCfg.KCPBindPort)
-	require.EqualValues(7001, svrCfg.QUICBindPort)
-	require.EqualValues(7005, svrCfg.TCPMuxHTTPConnectPort)
-	require.EqualValues("/abc.html", svrCfg.Custom404Page)
-	require.EqualValues(10, svrCfg.Transport.TCPKeepAlive)
+const yamlServerContent = `
+bindAddr: 127.0.0.1
+kcpBindPort: 7000
+quicBindPort: 7001
+tcpmuxHTTPConnectPort: 7005
+custom404Page: /abc.html
+transport:
+  tcpKeepalive: 10
+`
+
+const jsonServerContent = `
+{
+  "bindAddr": "127.0.0.1",
+  "kcpBindPort": 7000,
+  "quicBindPort": 7001,
+  "tcpmuxHTTPConnectPort": 7005,
+  "custom404Page": "/abc.html",
+  "transport": {
+    "tcpKeepalive": 10
+  }
+}
+`
+
+func TestLoadServerConfig(t *testing.T) {
+	for _, content := range []string{tomlServerContent, yamlServerContent, jsonServerContent} {
+		svrCfg := v1.ServerConfig{}
+		err := LoadConfigure([]byte(content), &svrCfg)
+		require := require.New(t)
+		require.NoError(err)
+		require.EqualValues("127.0.0.1", svrCfg.BindAddr)
+		require.EqualValues(7000, svrCfg.KCPBindPort)
+		require.EqualValues(7001, svrCfg.QUICBindPort)
+		require.EqualValues(7005, svrCfg.TCPMuxHTTPConnectPort)
+		require.EqualValues("/abc.html", svrCfg.Custom404Page)
+		require.EqualValues(10, svrCfg.Transport.TCPKeepAlive)
+	}
 }

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -57,7 +58,7 @@ const jsonServerContent = `
 func TestLoadServerConfig(t *testing.T) {
 	for _, content := range []string{tomlServerContent, yamlServerContent, jsonServerContent} {
 		svrCfg := v1.ServerConfig{}
-		err := LoadConfigure([]byte(content), &svrCfg)
+		err := LoadConfigure([]byte(content), &svrCfg, true)
 		require := require.New(t)
 		require.NoError(err)
 		require.EqualValues("127.0.0.1", svrCfg.BindAddr)
@@ -66,5 +67,25 @@ func TestLoadServerConfig(t *testing.T) {
 		require.EqualValues(7005, svrCfg.TCPMuxHTTPConnectPort)
 		require.EqualValues("/abc.html", svrCfg.Custom404Page)
 		require.EqualValues(10, svrCfg.Transport.TCPKeepAlive)
+	}
+}
+
+// Test that loading in strict mode fails when the config is invalid.
+func TestLoadServerConfigErrorMode(t *testing.T) {
+	for strict := range []bool{false, true} {
+		for _, content := range []string{tomlServerContent, yamlServerContent, jsonServerContent} {
+			// Break the content with an innocent typo
+			brokenContent := strings.Replace(content, "bindAddr", "bindAdur", 1)
+			svrCfg := v1.ServerConfig{}
+			err := LoadConfigure([]byte(brokenContent), &svrCfg, strict == 1)
+			require := require.New(t)
+			if strict == 1 {
+				require.ErrorContains(err, "bindAdur")
+			} else {
+				require.NoError(err)
+				// BindAddr didn't get parsed because of the typo.
+				require.EqualValues("", svrCfg.BindAddr)
+			}
+		}
 	}
 }


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 70600fb</samp>

This pull request adds a new feature to enable strict configuration parsing mode for both frpc and frps, which will reject any config file with unknown fields. It introduces a new command line flag `--strict_config` and modifies various config loading and service starting functions to use the flag. It also adds new test cases and imports a new `yaml` package to implement the feature. The affected files are `client/service.go`, `client/admin_api.go`, `cmd/frpc/sub/*.go`, `cmd/frps/root.go`, and `cmd/frps/verify.go` in the `fatedier/frp` repository.

### WHY

See #3769.

This PR adds a new `--strict_config` option that makes all configuration parsing stricter, for all modes of operation (not just `verify`). Right now it means that extraneous keys are not allowed, making it easier to catch e.g. typos in configuration.

This is opt-in.