### PR TITLE
call config complete in nathole discover

### DIFF
--- a/cmd/frpc/sub/nathole.go
+++ b/cmd/frpc/sub/nathole.go
@@ -51,6 +51,7 @@ var natholeDiscoveryCmd = &cobra.Command{
 		cfg, _, _, _, err := config.LoadClientConfig(cfgFile, strictConfigMode)
 		if err != nil {
 			cfg = &v1.ClientCommonConfig{}
+			cfg.Complete()
 		}
 		if natHoleSTUNServer != "" {
 			cfg.NatHoleSTUNServer = natHoleSTUNServer


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ab91bb6</samp>

Refactor NAT hole feature and add more options for the `cfg` struct. Add `cfg.Complete()` method to `sub.RunClient` function to fill in default values.

### WHY
Fix #3812