### PR TITLE
fixed: API error when the proxy name contains "#".

### DIFF
--- a/server/dashboard_api.go
+++ b/server/dashboard_api.go
@@ -17,6 +17,7 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -282,7 +283,7 @@ func (svr *Service) apiProxyByTypeAndName(w http.ResponseWriter, r *http.Request
 	res := GeneralResponse{Code: 200}
 	params := mux.Vars(r)
 	proxyType := params["type"]
-	name := params["name"]
+	name, _ := url.QueryUnescape(params["name"])
 
 	defer func() {
 		log.Info("Http response [%s]: code [%d]", r.URL.Path, res.Code)
@@ -350,7 +351,7 @@ type GetProxyTrafficResp struct {
 func (svr *Service) apiProxyTraffic(w http.ResponseWriter, r *http.Request) {
 	res := GeneralResponse{Code: 200}
 	params := mux.Vars(r)
-	name := params["name"]
+	name, _ := url.QueryUnescape(params["name"])
 
 	defer func() {
 		log.Info("Http response [%s]: code [%d]", r.URL.Path, res.Code)

--- a/web/frps/src/components/Traffic.vue
+++ b/web/frps/src/components/Traffic.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
 }>()
 
 const fetchData = () => {
-  let url = '../api/traffic/' + props.proxyName
+  let url = '../api/traffic/' + encodeURIComponent(props.proxyName)
   fetch(url, { credentials: 'include' })
     .then((res) => {
       return res.json()


### PR DESCRIPTION
### Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4991596</samp>

This pull request fixes a bug that prevented proxies with special characters in their names from displaying traffic statistics in the web dashboard. It encodes the proxy name in the URL query string on the client side and decodes it on the server side in the dashboard API.

### WHY
<!-- author to complete -->

fixed: API error when the proxy name contains "#".