### PR TITLE
fix(backoff): close of closed out channel

### DIFF
--- a/pkg/util/wait/backoff.go
+++ b/pkg/util/wait/backoff.go
@@ -19,8 +19,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/samber/lo"
-
 	"github.com/fatedier/frp/pkg/util/util"
 )
 
@@ -186,7 +184,7 @@ func MergeAndCloseOnAnyStopChannel[T any](upstreams ...<-chan T) <-chan T {
 	closeOnce := sync.Once{}
 	for _, upstream := range upstreams {
 		ch := upstream
-		go lo.Try0(func() {
+		go func() {
 			select {
 			case <-ch:
 				closeOnce.Do(func() {
@@ -194,7 +192,7 @@ func MergeAndCloseOnAnyStopChannel[T any](upstreams ...<-chan T) <-chan T {
 				})
 			case <-out:
 			}
-		})
+		}()
 	}
 	return out
 }

--- a/pkg/util/wait/backoff.go
+++ b/pkg/util/wait/backoff.go
@@ -16,6 +16,7 @@ package wait
 
 import (
 	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/samber/lo"
@@ -182,13 +183,15 @@ func Until(f func(), period time.Duration, stopCh <-chan struct{}) {
 
 func MergeAndCloseOnAnyStopChannel[T any](upstreams ...<-chan T) <-chan T {
 	out := make(chan T)
-
+	closeOnce := sync.Once{}
 	for _, upstream := range upstreams {
 		ch := upstream
 		go lo.Try0(func() {
 			select {
 			case <-ch:
-				close(out)
+				closeOnce.Do(func() {
+					close(out)
+				})
 			case <-out:
 			}
 		})


### PR DESCRIPTION
### WHY

currently, MergeAndCloseOnAnyStopChannel may repeatedly call close out chan multiple times. even if Try0 recovered the panic. we should make sure that only once