### PR TITLE
feat(backoff): add  BackoffUntilNil func in backoff

### DIFF
--- a/pkg/util/wait/backoff.go
+++ b/pkg/util/wait/backoff.go
@@ -158,7 +158,7 @@ func BackoffUntil(f func() error, backoff BackoffManager, sliding bool, stopCh <
 }
 
 func BackoffUntilNil(f func() error, backoff BackoffManager, sliding bool, stopCh <-chan struct{}) {
-	//first try
+	// first try
 	delay := backoff.Backoff(0, false)
 	ticker := time.NewTicker(delay)
 	defer ticker.Stop()


### PR DESCRIPTION
### WHY

<!-- author to complete -->
When loopLoginUntilSuccess is executed, it exits on success without using a channel. So add a new BackoffUntilNil function to handle this.
@https://github.com/fatedier/frp/issues/3860