### PR TITLE
Update go-jose and crypto version 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/crypto v0.15.0
+	golang.org/x/crypto v0.17.0
 	golang.org/x/net v0.17.0
 	golang.org/x/oauth2 v0.10.0
 	golang.org/x/sync v0.3.0
@@ -39,7 +39,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.1 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/golang/mock v1.6.0 // indirect


### PR DESCRIPTION
### WHY

After conducting a security scan on the current version of frp, I found that there are security issues in the Golang dependencies go-jose and crypto, corresponding to https://github.com/advisories/GHSA-2c7c-3mj9-8fqh and https://github.com/advisories/GHSA-45x7-px36-x8w8⁠, respectively.

Below is the description corresponding to the vulnerabilities.
https://scout.docker.com/v/GHSA-2c7c-3mj9-8fqh?utm_source=hub&utm_medium=ExternalLink
https://scout.docker.com/v/CVE-2023-48795?utm_source=hub&utm_medium=ExternalLink

The security vulnerability in go-jose has been fixed in version 3.0.1.
The security vulnerability in crypto has been fixed in version 0.17.0.

**issues link:**
https://github.com/fatedier/frp/issues/3886
<!-- author to complete -->
