### PR TITLE
fix: ClientConfig marshals incorrectly

### DIFF
--- a/pkg/config/v1/proxy.go
+++ b/pkg/config/v1/proxy.go
@@ -189,6 +189,10 @@ func (c *TypedProxyConfig) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+func (c *TypedProxyConfig) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.ProxyConfigurer)
+}
+
 type ProxyConfigurer interface {
 	Complete(namePrefix string)
 	GetBaseConfig() *ProxyBaseConfig


### PR DESCRIPTION
### WHY

the output of `yaml.Marshal(&ClientConfig{})` is incorrect, this PR fixed this error.

### How to reproduce it
1. build a `ClientConfig` object `clientConfig` with `Proxies` field set
2. call `yaml.Marshal(&clientConfig)` and set the output to `yamlConfig`
3. call `config.LoadConfigure(yamlConfig, &clientConfig, false)` to unmarshal the output
4. check the new unmarshalled `clientConfig`, the `Proxies` part is lost
