### PR TITLE
fix: fix frpc default config filename

### DIFF
--- a/cmd/frpc/sub/root.go
+++ b/cmd/frpc/sub/root.go
@@ -43,7 +43,7 @@ var (
 )
 
 func init() {
-	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "./frpc.ini", "config file of frpc")
+	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "./frpc.toml", "config file of frpc")
 	rootCmd.PersistentFlags().StringVarP(&cfgDir, "config_dir", "", "", "config directory, run one frpc service for each file in config directory")
 	rootCmd.PersistentFlags().BoolVarP(&showVersion, "version", "v", false, "version of frpc")
 	rootCmd.PersistentFlags().BoolVarP(&strictConfigMode, "strict_config", "", false, "strict config parsing mode, unknown fields will cause an error")


### PR DESCRIPTION
### WHY

The configuration file cannot be found when starting with `./frpc` by default.
<!-- author to complete -->
