### PR TITLE
Fix missing prefix for `transport.tls.force` in the example

### DIFF
--- a/conf/frps_full_example.toml
+++ b/conf/frps_full_example.toml
@@ -41,7 +41,7 @@ transport.maxPoolCount = 5
 # transport.tcpKeepalive = 7200
 
 # transport.tls.force specifies whether to only accept TLS-encrypted connections. By default, the value is false.
-tls.force = false
+transport.tls.force = false
 
 # transport.tls.certFile = "server.crt"
 # transport.tls.keyFile = "server.key"


### PR DESCRIPTION
### WHY

Add the missing prefix `transport` before `tls.force` in the example config.

```diff
- tls.force = false
+ transport.tls.force = false
```