### PR TITLE
Update README.md - add note for public purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,8 @@ webServer.password = "admin"
 
 Then visit `http://[serverAddr]:7500` to see the dashboard, with username and password both being `admin`.
 
+Note that if you want your server to be accessed from public networks, then also add `webServer.addr = "0.0.0.0"` line. For security reasons (credits [#3709](https://github.com/fatedier/frp/issues/3709)), value `127.0.0.1` is used by default. 
+
 Additionally, you can use HTTPS port by using your domains wildcard or normal SSL certificate:
 
 ```toml


### PR DESCRIPTION
Some people set servers in purpose to be accessed through public internet. This line gets rid of some misunderstanding if they want publicly accessed server.
