### PR TITLE
Update tls.go

### DIFF
--- a/pkg/transport/tls.go
+++ b/pkg/transport/tls.go
@@ -95,6 +95,31 @@ func NewServerTLSConfig(certPath, keyPath, caPath string) (*tls.Config, error) {
 
 		base.ClientAuth = tls.RequireAndVerifyClientCert
 		base.ClientCAs = pool
+
+		//20240206 TLS CVE-2016-2183   bye zgh419566
+		base.MinVersion = tls.VersionTLS12
+		base.PreferServerCipherSuites = true
+		base.CipherSuites = []uint16{
+			//tls.TLS_AES_128_GCM_SHA256,
+			//tls.TLS_CHACHA20_POLY1305_SHA256,
+			//tls.TLS_AES_256_GCM_SHA384,
+			//tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			//tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			//tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			//tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			//tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			//tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			//tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+			//tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+			//tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+			//tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+			//tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			//tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		}
 	}
 
 	return base, nil
@@ -122,6 +147,31 @@ func NewClientTLSConfig(certPath, keyPath, caPath, serverName string) (*tls.Conf
 
 		base.RootCAs = pool
 		base.InsecureSkipVerify = false
+
+		//20240206 TLS CVE-2016-2183 by zgh419566
+		base.PreferServerCipherSuites = false
+		base.MinVersion = tls.VersionTLS12
+		base.CipherSuites = []uint16{
+			//tls.TLS_AES_128_GCM_SHA256,
+			//tls.TLS_CHACHA20_POLY1305_SHA256,
+			//tls.TLS_AES_256_GCM_SHA384,
+			//tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			//tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			//tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			//tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			//tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			//tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			//tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+			//tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+			//tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+			//tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+			//tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			//tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		}
 	} else {
 		base.InsecureSkipVerify = true
 	}


### PR DESCRIPTION
force frp use tls1.2 only when set TLS mode
avoid to use 3des algorithm

64-bit block cipher 3DES vulnerable to SWEET32 attack

user can scan it by nmap below:
nmap -sV -p 7000 --script ssl-enum-ciphers x.x.x.x

CVE-2016-2183

reference:
https://github.com/fatedier/frp/issues/3973

https://stackoverflow.com/questions/31226131/how-to-set-tls-cipher-for-go-server

https://www.cnblogs.com/stjwy/p/17286010.html

### WHY

<!-- author to complete -->
