### PR TITLE
Update Dockerfiles to copy binary from working directory into build container

### DIFF
--- a/dockerfiles/Dockerfile-for-frpc
+++ b/dockerfiles/Dockerfile-for-frpc
@@ -7,6 +7,6 @@ RUN make frpc
 
 FROM alpine:3
 
-COPY --from=building /building/bin/frpc /usr/bin/frpc
+COPY --from=building /building/frpc /usr/bin/frpc
 
 ENTRYPOINT ["/usr/bin/frpc"]

--- a/dockerfiles/Dockerfile-for-frps
+++ b/dockerfiles/Dockerfile-for-frps
@@ -7,6 +7,6 @@ RUN make frps
 
 FROM alpine:3
 
-COPY --from=building /building/bin/frps /usr/bin/frps
+COPY --from=building /building/frps /usr/bin/frps
 
 ENTRYPOINT ["/usr/bin/frps"]


### PR DESCRIPTION
I was trying to build the Docker container using the latest release and the provided Dockerfiles when I received the error below:

```
 => ERROR [stage-1 2/2] COPY --from=building /building/bin/frps /usr/bin/frps                                                                                                                          0.0s
------
 > [stage-1 2/2] COPY --from=building /building/bin/frps /usr/bin/frps:
------
Dockerfile:10
--------------------
   8 |     FROM alpine:3
   9 |
  10 | >>> COPY --from=building /building/bin/frps /usr/bin/frps
  11 |
  12 |     ENTRYPOINT ["/usr/bin/frps"]
--------------------
ERROR: ... /var/lib/docker/tmp/.../building/bin: no such file or directory
```

There is a small typo in the Dockerfiles that copies from `/bin` in the working directory - which does not exist, nor needs to. Updating this to read the frpc/frps file from working directory fixes this error and allows the image to build