### PR TITLE
fix nil map error when using plugin headers in legacy format

### DIFF
--- a/pkg/config/legacy/conversion.go
+++ b/pkg/config/legacy/conversion.go
@@ -170,13 +170,17 @@ func Convert_ServerCommonConf_To_v1(conf *ServerCommonConf) *v1.ServerConfig {
 
 func transformHeadersFromPluginParams(params map[string]string) v1.HeaderOperations {
 	out := v1.HeaderOperations{}
+	set := make(map[string]string)
 	for k, v := range params {
 		if !strings.HasPrefix(k, "plugin_header_") {
 			continue
 		}
 		if k = strings.TrimPrefix(k, "plugin_header_"); k != "" {
-			out.Set[k] = v
+			set[k] = v
 		}
+	}
+	if len(set) > 0 {
+		out.Set = set
 	}
 	return out
 }

--- a/pkg/config/legacy/conversion.go
+++ b/pkg/config/legacy/conversion.go
@@ -176,10 +176,9 @@ func transformHeadersFromPluginParams(params map[string]string) v1.HeaderOperati
 		}
 		if k = strings.TrimPrefix(k, "plugin_header_"); k != "" {
 			if out.Set == nil {
-				out.Set = map[string]string{k: v}
-			} else {
-				out.Set[k] = v
+				out.Set = make(map[string]string)
 			}
+			out.Set[k] = v
 		}
 	}
 	return out

--- a/pkg/config/legacy/conversion.go
+++ b/pkg/config/legacy/conversion.go
@@ -170,17 +170,17 @@ func Convert_ServerCommonConf_To_v1(conf *ServerCommonConf) *v1.ServerConfig {
 
 func transformHeadersFromPluginParams(params map[string]string) v1.HeaderOperations {
 	out := v1.HeaderOperations{}
-	set := make(map[string]string)
 	for k, v := range params {
 		if !strings.HasPrefix(k, "plugin_header_") {
 			continue
 		}
 		if k = strings.TrimPrefix(k, "plugin_header_"); k != "" {
-			set[k] = v
+			if out.Set == nil {
+				out.Set = map[string]string{k: v}
+			} else {
+				out.Set[k] = v
+			}
 		}
-	}
-	if len(set) > 0 {
-		out.Set = set
 	}
 	return out
 }


### PR DESCRIPTION
### WHY

Fix the error:

```
panic: assignment to entry in nil map
```

when `plugin_header_` prefix is present in legacy proxy config.