### PR TITLE
fixing the incorrect API address when using path reverse proxy

### DIFF
--- a/web/frps/src/components/ProxyView.vue
+++ b/web/frps/src/components/ProxyView.vue
@@ -111,7 +111,7 @@ const formatTrafficOut = (row: BaseProxy, _: TableColumnCtx<BaseProxy>) => {
 }
 
 const clearOfflineProxies = () => {
-  fetch('/api/proxies?status=offline', {
+  fetch('../api/proxies?status=offline', {
     method: 'DELETE',
     credentials: 'include',
   })


### PR DESCRIPTION
The absolute path of the API has been changed to a relative path, fixing the issue of incorrect API address when using path reverse proxy.


![QQ截图20240302202502](https://github.com/fatedier/frp/assets/49368462/7349ff70-4b56-462f-a59c-dfb120ff136f)
