### PR TITLE
disable quic-go's ECN support by default

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -1,3 +1,4 @@
 ### Fixes
 
 * Fix the issue of incorrect interval time for rotating the log by day.
+* Disable quic-go's ECN support by default. It may cause issues on certain operating systems.

--- a/client/service.go
+++ b/client/service.go
@@ -43,6 +43,10 @@ func init() {
 	crypto.DefaultSalt = "frp"
 	// Disable quic-go's receive buffer warning.
 	os.Setenv("QUIC_GO_DISABLE_RECEIVE_BUFFER_WARNING", "true")
+	// Disable quic-go's ECN support by default. It may cause issues on certain operating systems.
+	if os.Getenv("QUIC_GO_DISABLE_ECN") == "" {
+		os.Setenv("QUIC_GO_DISABLE_ECN", "true")
+	}
 }
 
 type cancelErr struct {

--- a/server/service.go
+++ b/server/service.go
@@ -63,6 +63,10 @@ const (
 func init() {
 	// Disable quic-go's receive buffer warning.
 	os.Setenv("QUIC_GO_DISABLE_RECEIVE_BUFFER_WARNING", "true")
+	// Disable quic-go's ECN support by default. It may cause issues on certain operating systems.
+	if os.Getenv("QUIC_GO_DISABLE_ECN") == "" {
+		os.Setenv("QUIC_GO_DISABLE_ECN", "true")
+	}
 }
 
 // Server service


### PR DESCRIPTION
### WHY

Fix #4067 
