### PR TITLE
fix: ssh tunnel with user name will lead to invalid proxy name

### DIFF
--- a/pkg/ssh/server.go
+++ b/pkg/ssh/server.go
@@ -109,7 +109,6 @@ func (s *TunnelServer) Run() error {
 	if sshConn.Permissions != nil {
 		clientCfg.User = util.EmptyOr(sshConn.Permissions.Extensions["user"], clientCfg.User)
 	}
-	pc.Complete(clientCfg.User)
 
 	vc, err := virtual.NewClient(virtual.ClientOptions{
 		Common: clientCfg,


### PR DESCRIPTION
### WHY

<!-- author to complete -->
