### PR TITLE
Makefile.cross-compiles: Fix softfloat flag not being honored for mipsle

### DIFF
--- a/Makefile.cross-compiles
+++ b/Makefile.cross-compiles
@@ -18,7 +18,7 @@ app:
 		if [ "$${os}" = "linux" ] && [ "$${arch}" = "arm" ] && [ "$${extra}" != "" ] ; then \
 			flags=GOARM=$${extra}; \
 			target_suffix=$${os}_$${arch}_$${extra}; \
-		elif [ "$${os}" = "linux" ] && [ "$${arch}" = "mips" ] && [ "$${extra}" != "" ] ; then \
+		elif [ "$${os}" = "linux" ] && ([ "$${arch}" = "mips" ] || [ "$${arch}" = "mipsle" ]) && [ "$${extra}" != "" ] ; then \
 		    flags=GOMIPS=$${extra}; \
 		fi; \
 		echo "Build $${os}-$${arch}$${extra:+ ($${extra})}..."; \


### PR DESCRIPTION
### WHY

When building using Makefile.cross-compiles, softfloat flag was being applied only to "mips" big-endian builds but not "mipsle" little-endian builds despite the flag being set in architecture list. This resulted in binaries which would not run on target machines without a FPU or a FPU emulator in kernel.
This change fixes the "if" statement in Makefile.cross-compiles to correctly apply the softfloat flag to both "mips" and "mipsle" builds.

Binaries run fine on a system with a BCM4706 MIPS SoC.