### PR TITLE
initialize tls config with TLS 1.2

### DIFF
--- a/pkg/plugin/client/https2http.go
+++ b/pkg/plugin/client/https2http.go
@@ -104,7 +104,8 @@ func (p *HTTPS2HTTPPlugin) genTLSConfig() (*tls.Config, error) {
 		return nil, err
 	}
 
-	config := &tls.Config{Certificates: []tls.Certificate{cert}}
+	config := &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
+
 	return config, nil
 }
 


### PR DESCRIPTION
### WHY

Fix frpc issue that prevents obtaining A-grade SSL rating from [ssl labs](https://www.ssllabs.com/) caused by incorrect crypto/tls initialization that supports disabled TLS versions.