### PR TITLE
plugin: fix http2 not enabled for https2http and https2https plugin

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -1,14 +1,3 @@
-### Notable Changes
-
-We have optimized the heartbeat mechanism when tcpmux is enabled (enabled by default). The default value of `heartbeatInterval` has been adjusted to -1. This update ensures that when tcpmux is active, the client does not send additional heartbeats to the server. Since tcpmux incorporates its own heartbeat system, this change effectively reduces unnecessary data consumption, streamlining communication efficiency between client and server.
-
-When connecting to frps versions older than v0.39.0 might encounter compatibility issues due to changes in the heartbeat mechanism. As a temporary workaround, setting the `heartbeatInterval` to 30 can help maintain stable connectivity with these older versions. We recommend updating to the latest frps version to leverage full functionality and improvements.
-
-### Features
-
-* Show tcpmux proxies on the frps dashboard.
-* `http` proxy can modify the response header. For example, `responseHeaders.set.foo = "bar"` will add a new header `foo: bar` to the response.
-
 ### Fixes
 
-* When an HTTP proxy request times out, it returns 504 instead of 404 now.
+* Fixed an issue where HTTP/2 was not enabled for https2http and https2https plugins.

--- a/pkg/plugin/client/https2http.go
+++ b/pkg/plugin/client/https2http.go
@@ -72,11 +72,6 @@ func NewHTTPS2HTTPPlugin(options v1.ClientPluginOptions) (Plugin, error) {
 		ErrorLog:   stdlog.New(log.NewWriteLogger(log.WarnLevel, 2), "", 0),
 	}
 
-	p.s = &http.Server{
-		Handler:           rp,
-		ReadHeaderTimeout: 60 * time.Second,
-	}
-
 	var (
 		tlsConfig *tls.Config
 		err       error
@@ -90,10 +85,15 @@ func NewHTTPS2HTTPPlugin(options v1.ClientPluginOptions) (Plugin, error) {
 	if err != nil {
 		return nil, fmt.Errorf("gen TLS config error: %v", err)
 	}
-	ln := tls.NewListener(listener, tlsConfig)
+
+	p.s = &http.Server{
+		Handler:           rp,
+		ReadHeaderTimeout: 60 * time.Second,
+		TLSConfig:         tlsConfig,
+	}
 
 	go func() {
-		_ = p.s.Serve(ln)
+		_ = p.s.ServeTLS(listener, "", "")
 	}()
 	return p, nil
 }

--- a/pkg/plugin/client/https2https.go
+++ b/pkg/plugin/client/https2https.go
@@ -78,11 +78,6 @@ func NewHTTPS2HTTPSPlugin(options v1.ClientPluginOptions) (Plugin, error) {
 		ErrorLog:   stdlog.New(log.NewWriteLogger(log.WarnLevel, 2), "", 0),
 	}
 
-	p.s = &http.Server{
-		Handler:           rp,
-		ReadHeaderTimeout: 60 * time.Second,
-	}
-
 	var (
 		tlsConfig *tls.Config
 		err       error
@@ -96,10 +91,15 @@ func NewHTTPS2HTTPSPlugin(options v1.ClientPluginOptions) (Plugin, error) {
 	if err != nil {
 		return nil, fmt.Errorf("gen TLS config error: %v", err)
 	}
-	ln := tls.NewListener(listener, tlsConfig)
+
+	p.s = &http.Server{
+		Handler:           rp,
+		ReadHeaderTimeout: 60 * time.Second,
+		TLSConfig:         tlsConfig,
+	}
 
 	go func() {
-		_ = p.s.Serve(ln)
+		_ = p.s.ServeTLS(listener, "", "")
 	}()
 	return p, nil
 }


### PR DESCRIPTION
### WHY

Fix #4217 