### PR TITLE
android: only use google dns server when the default dns server cannot be obtained

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -5,3 +5,4 @@
 ### Changes
 
 * Updated the default value of `transport.tcpMuxKeepaliveInterval` from 60 to 30.
+* On the Android platform, the Google DNS server is used only when the default DNS server cannot be obtained.

--- a/pkg/util/system/system_android.go
+++ b/pkg/util/system/system_android.go
@@ -59,8 +59,12 @@ func fixDNSResolver() {
 	// Note: If there are other methods to obtain the default DNS servers, the default DNS servers should be used preferentially.
 	net.DefaultResolver = &net.Resolver{
 		PreferGo: true,
-		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
-			return net.Dial(network, "8.8.8.8:53")
+		Dial: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if addr == "127.0.0.1:53" || addr == "[::1]:53" {
+				addr = "8.8.8.8:53"
+			}
+			var d net.Dialer
+			return d.DialContext(ctx, network, addr)
 		},
 	}
 }


### PR DESCRIPTION
### WHY

Fix #4228