### PR TITLE
The client adds displaying the proxy port.

### DIFF
--- a/client/control.go
+++ b/client/control.go
@@ -165,7 +165,7 @@ func (ctl *Control) handleNewProxyResp(m msg.Message) {
 	if err != nil {
 		xl.Warnf("[%s] start error: %v", inMsg.ProxyName, err)
 	} else {
-		xl.Infof("[%s] start proxy success", inMsg.ProxyName)
+		xl.Infof("name:[%s] post:[%s] start proxy success", inMsg.ProxyName, inMsg.RemoteAddr)
 	}
 }
 


### PR DESCRIPTION
When using TCP connections with random ports, it can display the remote port being used. This is suitable for scenarios involving bulk deployment of the same configuration files.