### PR TITLE
Fix loginFailExit = false bug

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -1,3 +1,5 @@
 ### Features
 
 * Added a new plugin `tls2raw`: Enables TLS termination and forwarding of decrypted raw traffic to local service.
+
+* Fixed the issue that when `loginFailExit = false`, the frpc stop command cannot be stopped correctly if the server is not successfully connected after startup.

--- a/client/service.go
+++ b/client/service.go
@@ -169,6 +169,15 @@ func (svr *Service) Run(ctx context.Context) error {
 		netpkg.SetDefaultDNSAddress(svr.common.DNSServer)
 	}
 
+	if svr.webServer != nil {
+		go func() {
+			log.Infof("admin server listen on %s", svr.webServer.Address())
+			if err := svr.webServer.Run(); err != nil {
+				log.Warnf("admin server exit with error: %v", err)
+			}
+		}()
+	}
+
 	// first login to frps
 	svr.loopLoginUntilSuccess(10*time.Second, lo.FromPtr(svr.common.LoginFailExit))
 	if svr.ctl == nil {
@@ -179,14 +188,6 @@ func (svr *Service) Run(ctx context.Context) error {
 
 	go svr.keepControllerWorking()
 
-	if svr.webServer != nil {
-		go func() {
-			log.Infof("admin server listen on %s", svr.webServer.Address())
-			if err := svr.webServer.Run(); err != nil {
-				log.Warnf("admin server exit with error: %v", err)
-			}
-		}()
-	}
 	<-svr.ctx.Done()
 	svr.stop()
 	return nil


### PR DESCRIPTION
### WHY

<!-- author to complete -->
Fixed the issue that when loginFailExit = false, the frpc stop command cannot be stopped correctly if the server is not successfully connected after startup