### PR TITLE
bump templexxx/cpu version and add support for linux/loong64

### DIFF
--- a/Makefile.cross-compiles
+++ b/Makefile.cross-compiles
@@ -2,7 +2,7 @@ export PATH := $(PATH):`go env GOPATH`/bin
 export GO111MODULE=on
 LDFLAGS := -s -w
 
-os-archs=darwin:amd64 darwin:arm64 freebsd:amd64 linux:amd64 linux:arm:7 linux:arm:5 linux:arm64 windows:amd64 windows:arm64 linux:mips64 linux:mips64le linux:mips:softfloat linux:mipsle:softfloat linux:riscv64 android:arm64
+os-archs=darwin:amd64 darwin:arm64 freebsd:amd64 linux:amd64 linux:arm:7 linux:arm:5 linux:arm64 windows:amd64 windows:arm64 linux:mips64 linux:mips64le linux:mips:softfloat linux:mipsle:softfloat linux:riscv64 linux:loong64 android:arm64
 
 all: build
 

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
-	github.com/templexxx/cpu v0.1.0 // indirect
+	github.com/templexxx/cpu v0.1.1-0.20240303154708-598a14b050c5 // indirect
 	github.com/templexxx/xorsimd v0.4.2 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,9 @@ github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/templexxx/cpu v0.1.0 h1:wVM+WIJP2nYaxVxqgHPD4wGA2aJ9rvrQRV8CvFzNb40=
 github.com/templexxx/cpu v0.1.0/go.mod h1:w7Tb+7qgcAlIyX4NhLuDKt78AHA5SzPmq0Wj6HiEnnk=
+github.com/templexxx/cpu v0.1.1-0.20240303154708-598a14b050c5 h1:Ke6p9WHBy8Ooz8Vg/+o9SHp5yE2VlzzyHVEfHTFmJoM=
+github.com/templexxx/cpu v0.1.1-0.20240303154708-598a14b050c5/go.mod h1:w7Tb+7qgcAlIyX4NhLuDKt78AHA5SzPmq0Wj6HiEnnk=
 github.com/templexxx/xorsimd v0.4.2 h1:ocZZ+Nvu65LGHmCLZ7OoCtg8Fx8jnHKK37SjvngUoVI=
 github.com/templexxx/xorsimd v0.4.2/go.mod h1:HgwaPoDREdi6OnULpSfxhzaiiSUY4Fi3JPn1wpt28NI=
 github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=

--- a/package.sh
+++ b/package.sh
@@ -18,7 +18,7 @@ rm -rf ./release/packages
 mkdir -p ./release/packages
 
 os_all='linux windows darwin freebsd android'
-arch_all='386 amd64 arm arm64 mips64 mips64le mips mipsle riscv64'
+arch_all='386 amd64 arm arm64 mips64 mips64le mips mipsle riscv64 loong64'
 extra_all='_ hf'
 
 cd ./release


### PR DESCRIPTION
### WHY
Loong64 has been officially supported since Go 1.19. The frp is a well-known and commonly used reverse proxy project, adding loong64 port for frp will enable frp to be widely used on the new architecture.
### Result
1. Bump templexxx/cpu from V0.1.0 to latest version fix below error on linux/loong64.
```
go version go1.22.5 linux/loong64
go fmt ./...
env CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -tags frps -o bin/frps ./cmd/frps
# github.com/templexxx/cpu
../../go/pkg/mod/github.com/templexxx/cpu@v0.1.0/cpu.go:93:14: undefined array length CacheLineSize or missing type constraint
../../go/pkg/mod/github.com/templexxx/cpu@v0.1.0/cpu.go:105:14: undefined array length CacheLineSize or missing type constraint
../../go/pkg/mod/github.com/templexxx/cpu@v0.1.0/cpu.go:113:15: undefined array length CacheLineSize or missing type constraint
../../go/pkg/mod/github.com/templexxx/cpu@v0.1.0/cpu.go:138:15: undefined array length CacheLineSize or missing type constraint
../../go/pkg/mod/github.com/templexxx/cpu@v0.1.0/cpu.go:144:19: undefined array length CacheLineSize or missing type constraint
../../go/pkg/mod/github.com/templexxx/cpu@v0.1.0/cpu.go:161:19: undefined array length CacheLineSize or missing type constraint
make: *** [Makefile:32: frps] Error 1
```
2. Add support for packing loong64 port by default.
```
go version go1.22.5 linux/loong64
go fmt ./...
env CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -tags frps -o bin/frps ./cmd/frps
env CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -tags frpc -o bin/frpc ./cmd/frpc
build version: 0.60.0
Build darwin-amd64...
Build darwin-amd64 done
Build darwin-arm64...
Build darwin-arm64 done
Build freebsd-amd64...
Build freebsd-amd64 done
Build linux-amd64...
Build linux-amd64 done
Build linux-arm (7)...
Build linux-arm (7) done
Build linux-arm (5)...
Build linux-arm (5) done
Build linux-arm64...
Build linux-arm64 done
Build windows-amd64...
Build windows-amd64 done
Build windows-arm64...
Build windows-arm64 done
Build linux-mips64...
Build linux-mips64 done
Build linux-mips64le...
Build linux-mips64le done
Build linux-mips (softfloat)...
Build linux-mips (softfloat) done
Build linux-mipsle (softfloat)...
Build linux-mipsle (softfloat) done
Build linux-riscv64...
Build linux-riscv64 done
Build linux-loong64...
Build linux-loong64 done
Build android-arm64...
Build android-arm64 done
```
3. Tested on Loongson 3A6000, everything is fine.