### PR TITLE
Feature: Add remove api for offline proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+.DS_Store
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/pkg/metrics/mem/server.go
+++ b/pkg/metrics/mem/server.go
@@ -260,6 +260,17 @@ func (m *serverMetrics) GetProxiesByTypeAndName(proxyType string, proxyName stri
 	return
 }
 
+func (m *serverMetrics) RemoveProxyByTypeAndName(proxyType string, proxyName string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	sType, ok := m.info.ProxyStatistics[proxyName]
+	if ok && sType.ProxyType == proxyType {
+		delete(m.info.ProxyStatistics, proxyName)
+		return true
+	}
+	return false
+}
+
 func (m *serverMetrics) GetProxyTraffic(name string) (res *ProxyTrafficInfo) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/metrics/mem/types.go
+++ b/pkg/metrics/mem/types.go
@@ -78,6 +78,7 @@ type Collector interface {
 	GetServer() *ServerStats
 	GetProxiesByType(proxyType string) []*ProxyStats
 	GetProxiesByTypeAndName(proxyType string, proxyName string) *ProxyStats
+	RemoveProxyByTypeAndName(proxyType string, proxyName string) bool
 	GetProxyTraffic(name string) *ProxyTrafficInfo
 	ClearOfflineProxies() (int, int)
 }


### PR DESCRIPTION
This PR adds api to remove a single proxy with name and type example:
  curl -X DELETE -u admin:admin -v http://127.0.0.1:7500/api/proxy/tcp/test-tcp
output:
  proxy "test-tcp" deleted

### WHY

Currently, only clear all offline proxy api is provided, this PR provides api for singe proxy removal