### PR TITLE
feat(plugin): add rootca and tls verify for client http plugins

### DIFF
--- a/pkg/config/v1/plugin.go
+++ b/pkg/config/v1/plugin.go
@@ -103,6 +103,7 @@ type HTTP2HTTPSPluginOptions struct {
 	LocalAddr         string           `json:"localAddr,omitempty"`
 	HostHeaderRewrite string           `json:"hostHeaderRewrite,omitempty"`
 	RequestHeaders    HeaderOperations `json:"requestHeaders,omitempty"`
+	RootCA            string           `json:"rootCA,omitempty"`
 }
 
 func (o *HTTP2HTTPSPluginOptions) Complete() {}
@@ -137,6 +138,7 @@ type HTTPS2HTTPSPluginOptions struct {
 	EnableHTTP2       *bool            `json:"enableHTTP2,omitempty"`
 	CrtPath           string           `json:"crtPath,omitempty"`
 	KeyPath           string           `json:"keyPath,omitempty"`
+	RootCA            string           `json:"rootCA,omitempty"`
 }
 
 func (o *HTTPS2HTTPSPluginOptions) Complete() {


### PR DESCRIPTION
### WHY

It would be nice to support a custom CA cert and perform TLS verification of the connections between the `httputil.ReverseProxy` and the proxied service in the client `*2https` plugins.
 
This PR adds support for loading a rootCA and verifying TLS connections for the client http plugins.

I manually tested this by adding an incorrect root CA cert and attempting to make use of the proxy:

<img width="371" alt="Screenshot 2024-09-25 at 2 46 40 PM" src="https://github.com/user-attachments/assets/7b276257-a662-4d8c-9f47-2d4d3ce14165">

and verify failed as expected.

After adding the proper root CA certificate, the verify and proxy worked as expected. 