### PR TITLE
support multiple subjects in oidc ping

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -50,7 +50,8 @@ func NewAuthVerifier(cfg v1.AuthServerConfig) (authVerifier Verifier) {
 	case v1.AuthMethodToken:
 		authVerifier = NewTokenAuth(cfg.AdditionalScopes, cfg.Token)
 	case v1.AuthMethodOIDC:
-		authVerifier = NewOidcAuthVerifier(cfg.AdditionalScopes, cfg.OIDC)
+		tokenVerifier := NewTokenVerifier(cfg.OIDC)
+		authVerifier = NewOidcAuthVerifier(cfg.AdditionalScopes, tokenVerifier)
 	}
 	return authVerifier
 }

--- a/pkg/auth/oidc_test.go
+++ b/pkg/auth/oidc_test.go
@@ -1,0 +1,64 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fatedier/frp/pkg/auth"
+	v1 "github.com/fatedier/frp/pkg/config/v1"
+	"github.com/fatedier/frp/pkg/msg"
+)
+
+type mockTokenVerifier struct{}
+
+func (m *mockTokenVerifier) Verify(ctx context.Context, subject string) (*oidc.IDToken, error) {
+	return &oidc.IDToken{
+		Subject: subject,
+	}, nil
+}
+
+func TestPingWithEmptySubjectFromLoginFails(t *testing.T) {
+	r := require.New(t)
+	consumer := auth.NewOidcAuthVerifier([]v1.AuthScope{v1.AuthScopeHeartBeats}, &mockTokenVerifier{})
+	err := consumer.VerifyPing(&msg.Ping{
+		PrivilegeKey: "ping-without-login",
+		Timestamp:    time.Now().UnixMilli(),
+	})
+	r.Error(err)
+	r.Contains(err.Error(), "received different OIDC subject in login and ping")
+}
+
+func TestPingAfterLoginWithNewSubjectSucceeds(t *testing.T) {
+	r := require.New(t)
+	consumer := auth.NewOidcAuthVerifier([]v1.AuthScope{v1.AuthScopeHeartBeats}, &mockTokenVerifier{})
+	err := consumer.VerifyLogin(&msg.Login{
+		PrivilegeKey: "ping-after-login",
+	})
+	r.NoError(err)
+
+	err = consumer.VerifyPing(&msg.Ping{
+		PrivilegeKey: "ping-after-login",
+		Timestamp:    time.Now().UnixMilli(),
+	})
+	r.NoError(err)
+}
+
+func TestPingAfterLoginWithDifferentSubjectFails(t *testing.T) {
+	r := require.New(t)
+	consumer := auth.NewOidcAuthVerifier([]v1.AuthScope{v1.AuthScopeHeartBeats}, &mockTokenVerifier{})
+	err := consumer.VerifyLogin(&msg.Login{
+		PrivilegeKey: "login-with-first-subject",
+	})
+	r.NoError(err)
+
+	err = consumer.VerifyPing(&msg.Ping{
+		PrivilegeKey: "ping-with-different-subject",
+		Timestamp:    time.Now().UnixMilli(),
+	})
+	r.Error(err)
+	r.Contains(err.Error(), "received different OIDC subject in login and ping")
+}


### PR DESCRIPTION
Validate the subject in an oidc ping against a list of logged in subjects.

This resolves the issue that multiple connected FRP clients with different OIDC clients result in a failing ping. The ping would fail because the subject in memory would be the value of the last logged in FRPC.

This change also changes the constructor of OidcAuthVerifier to take a TokenVerifier interface. This will not change production behavior, but makes testing easier because we can inject a mock verifier during testing.

Resolves: #4466
