### PR TITLE
frpc visitor: add --server-user option to specify server proxy username

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -1,8 +1,3 @@
 ### Features
 
-* Added a new plugin `tls2raw`: Enables TLS termination and forwarding of decrypted raw traffic to local service.
-* Added a default timeout of 30 seconds for the frpc subcommands to prevent commands from being stuck for a long time due to network issues.
-
-### Fixes
-
-* Fixed the issue that when `loginFailExit = false`, the frpc stop command cannot be stopped correctly if the server is not successfully connected after startup.
+* The frpc visitor command-line parameter adds the `--server-user` option to specify the username of the server-side proxy to connect to.

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -140,6 +140,7 @@ func registerVisitorBaseConfigFlags(cmd *cobra.Command, c *v1.VisitorBaseConfig,
 	cmd.Flags().BoolVarP(&c.Transport.UseCompression, "uc", "", false, "use compression")
 	cmd.Flags().StringVarP(&c.SecretKey, "sk", "", "", "secret key")
 	cmd.Flags().StringVarP(&c.ServerName, "server_name", "", "", "server name")
+	cmd.Flags().StringVarP(&c.ServerUser, "server-user", "", "", "server user")
 	cmd.Flags().StringVarP(&c.BindAddr, "bind_addr", "", "", "bind addr")
 	cmd.Flags().IntVarP(&c.BindPort, "bind_port", "", 0, "bind port")
 }


### PR DESCRIPTION
### WHY

Fix #4476 
