### PR TITLE
config: add VhostEnableH2C flag to support HTTP/2 cleartext upgrade

### DIFF
--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -230,6 +230,7 @@ func RegisterServerConfigFlags(cmd *cobra.Command, c *v1.ServerConfig, opts ...R
 	cmd.PersistentFlags().IntVarP(&c.QUICBindPort, "quic_bind_port", "", 0, "quic bind udp port")
 	cmd.PersistentFlags().StringVarP(&c.ProxyBindAddr, "proxy_bind_addr", "", "0.0.0.0", "proxy bind address")
 	cmd.PersistentFlags().IntVarP(&c.VhostHTTPPort, "vhost_http_port", "", 0, "vhost http port")
+	cmd.PersistentFlags().BoolVarP(&c.VhostEnableH2C, "vhost_enable_h2c", "", false, "vhost enable h2c")
 	cmd.PersistentFlags().IntVarP(&c.VhostHTTPSPort, "vhost_https_port", "", 0, "vhost https port")
 	cmd.PersistentFlags().Int64VarP(&c.VhostHTTPTimeout, "vhost_http_timeout", "", 60, "vhost http response header timeout")
 	cmd.PersistentFlags().StringVarP(&c.WebServer.Addr, "dashboard_addr", "", "0.0.0.0", "dashboard address")

--- a/pkg/config/legacy/conversion.go
+++ b/pkg/config/legacy/conversion.go
@@ -110,6 +110,7 @@ func Convert_ServerCommonConf_To_v1(conf *ServerCommonConf) *v1.ServerConfig {
 
 	out.ProxyBindAddr = conf.ProxyBindAddr
 	out.VhostHTTPPort = conf.VhostHTTPPort
+	out.VhostEnableH2C = conf.VhostEnableH2C
 	out.VhostHTTPSPort = conf.VhostHTTPSPort
 	out.TCPMuxHTTPConnectPort = conf.TCPMuxHTTPConnectPort
 	out.TCPMuxPassthrough = conf.TCPMuxPassthrough

--- a/pkg/config/legacy/server.go
+++ b/pkg/config/legacy/server.go
@@ -61,6 +61,11 @@ type ServerCommonConf struct {
 	// requests. If this value is 0, the server will not listen for HTTP
 	// requests. By default, this value is 0.
 	VhostHTTPPort int `ini:"vhost_http_port" json:"vhost_http_port"`
+	// VhostEnableH2c specifies whether to enable HTTP/2 cleartext upgrade.
+	// By default, this value is false. If enabled, the server will be compatible
+	// with http2 on cleartext, accordingly, the vhost server will use http2
+	// transport to proxy the request.
+	VhostEnableH2C bool `json:"vhostEnableH2C,omitempty"`
 	// VhostHTTPSPort specifies the port that the server listens for HTTPS
 	// Vhost requests. If this value is 0, the server will not listen for HTTPS
 	// requests. By default, this value is 0.

--- a/pkg/config/v1/server.go
+++ b/pkg/config/v1/server.go
@@ -47,6 +47,11 @@ type ServerConfig struct {
 	// VhostHTTPTimeout specifies the response header timeout for the Vhost
 	// HTTP server, in seconds. By default, this value is 60.
 	VhostHTTPTimeout int64 `json:"vhostHTTPTimeout,omitempty"`
+	// VhostEnableH2c specifies whether to enable HTTP/2 cleartext upgrade.
+	// By default, this value is false. If enabled, the server will be compatible
+	// with http2 on cleartext, accordingly, the vhost server will use http2
+	// transport to proxy the request.
+	VhostEnableH2C bool `json:"vhostEnableH2C,omitempty"`
 	// VhostHTTPSPort specifies the port that the server listens for HTTPS
 	// Vhost requests. If this value is 0, the server will not listen for HTTPS
 	// requests.

--- a/server/dashboard_api.go
+++ b/server/dashboard_api.go
@@ -70,6 +70,7 @@ type serverInfoResp struct {
 	Version               string `json:"version"`
 	BindPort              int    `json:"bindPort"`
 	VhostHTTPPort         int    `json:"vhostHTTPPort"`
+	VhostEnableH2C        bool   `json:"vhostEnableH2C"`
 	VhostHTTPSPort        int    `json:"vhostHTTPSPort"`
 	TCPMuxHTTPConnectPort int    `json:"tcpmuxHTTPConnectPort"`
 	KCPBindPort           int    `json:"kcpBindPort"`
@@ -111,6 +112,7 @@ func (svr *Service) apiServerInfo(w http.ResponseWriter, r *http.Request) {
 		BindPort:              svr.cfg.BindPort,
 		VhostHTTPPort:         svr.cfg.VhostHTTPPort,
 		VhostHTTPSPort:        svr.cfg.VhostHTTPSPort,
+		VhostEnableH2C:        svr.cfg.VhostEnableH2C,
 		TCPMuxHTTPConnectPort: svr.cfg.TCPMuxHTTPConnectPort,
 		KCPBindPort:           svr.cfg.KCPBindPort,
 		QUICBindPort:          svr.cfg.QUICBindPort,

--- a/server/service.go
+++ b/server/service.go
@@ -281,6 +281,7 @@ func NewService(cfg *v1.ServerConfig) (*Service, error) {
 	if cfg.VhostHTTPPort > 0 {
 		rp := vhost.NewHTTPReverseProxy(vhost.HTTPReverseProxyOptions{
 			ResponseHeaderTimeoutS: cfg.VhostHTTPTimeout,
+			EnableH2C:              cfg.VhostEnableH2C,
 		}, svr.httpVhostRouter)
 		svr.rc.HTTPReverseProxy = rp
 


### PR DESCRIPTION
### WHY

Support `h2c` in virtual host.


Our use case is:

In front of the vhost, we deploy a caddy to reverse the traffic to frps. And use caddy do tls termination, we got a bug, the client always get an error `internal: protocol error: no Grpc-Status trailer: unexpected EOF` when requesting a GRPC streaming API(works well on unary API).

After some investigation and debug, I found we can fix it by support h2c on the vhost layer.


refrence: 

- Issue: https://github.com/golang/go/issues/14141

close #4563 