### PR TITLE
recover query cleaned by proxy

### DIFF
--- a/pkg/util/vhost/http.go
+++ b/pkg/util/vhost/http.go
@@ -66,7 +66,8 @@ func NewHTTPReverseProxy(option HTTPReverseProxyOptions, vhostRouter *Routers) *
 			req.URL.Scheme = "http"
 			reqRouteInfo := req.Context().Value(RouteInfoKey).(*RequestRouteInfo)
 			originalHost, _ := httppkg.CanonicalHost(reqRouteInfo.Host)
-
+			//recover clean by proxy https://cs.opensource.google/go/go/+/refs/tags/go1.23.4:src/net/http/httputil/reverseproxy.go;l=427
+			req.URL.RawQuery = r.In.URL.RawQuery
 			rc := req.Context().Value(RouteConfigKey).(*RouteConfig)
 			if rc != nil {
 				if rc.RewriteHost != "" {


### PR DESCRIPTION
### WHY
some request url like "http://a.b.c/cgi-bin/ajax?ajaxmethod=web_get_brmad&token=Mozilla/5.0%20(Macintosh;%20Intel%20Mac%20OS%20X%2010_15_7)%20AppleWebKit/537.36%20(KHTML,%20like%20Gecko)%20Chrome/131.0.0.0%20Safari/537.36"
does not accept by reverse proxy when rewrite, and trim to http://a.b.c/cgi-bin/ajax?ajaxmethod=web_get_brmad

I dont know why the author do this, the comment is not clearly, it is over the bound of the proxy duty. 
maybe set a config flag for user 

<!-- author to complete -->
