### PR TITLE
client, pkg, server, test: replaced 'interface{}' with 'any'

### DIFF
--- a/client/event/event.go
+++ b/client/event/event.go
@@ -8,7 +8,7 @@ import (
 
 var ErrPayloadType = errors.New("error payload type")
 
-type Handler func(payload interface{}) error
+type Handler func(payload any) error
 
 type StartProxyPayload struct {
 	NewProxyMsg *msg.NewProxy

--- a/client/proxy/proxy_manager.go
+++ b/client/proxy/proxy_manager.go
@@ -96,7 +96,7 @@ func (pm *Manager) HandleWorkConn(name string, workConn net.Conn, m *msg.StartWo
 	}
 }
 
-func (pm *Manager) HandleEvent(payload interface{}) error {
+func (pm *Manager) HandleEvent(payload any) error {
 	var m msg.Message
 	switch e := payload.(type) {
 	case *event.StartProxyPayload:

--- a/pkg/config/legacy/client.go
+++ b/pkg/config/legacy/client.go
@@ -170,7 +170,7 @@ type ClientCommonConf struct {
 }
 
 // Supported sources including: string(file path), []byte, Reader interface.
-func UnmarshalClientConfFromIni(source interface{}) (ClientCommonConf, error) {
+func UnmarshalClientConfFromIni(source any) (ClientCommonConf, error) {
 	f, err := ini.LoadSources(ini.LoadOptions{
 		Insensitive:         false,
 		InsensitiveSections: false,
@@ -203,7 +203,7 @@ func UnmarshalClientConfFromIni(source interface{}) (ClientCommonConf, error) {
 // otherwise just start proxies in startProxy map
 func LoadAllProxyConfsFromIni(
 	prefix string,
-	source interface{},
+	source any,
 	start []string,
 ) (map[string]ProxyConf, map[string]VisitorConf, error) {
 	f, err := ini.LoadSources(ini.LoadOptions{

--- a/pkg/config/legacy/server.go
+++ b/pkg/config/legacy/server.go
@@ -217,7 +217,7 @@ func GetDefaultServerConf() ServerCommonConf {
 	}
 }
 
-func UnmarshalServerConfFromIni(source interface{}) (ServerCommonConf, error) {
+func UnmarshalServerConfFromIni(source any) (ServerCommonConf, error) {
 	f, err := ini.LoadSources(ini.LoadOptions{
 		Insensitive:         false,
 		InsensitiveSections: false,

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -118,7 +118,7 @@ func LoadConfigure(b []byte, c any, strict bool) error {
 	defer v1.DisallowUnknownFieldsMu.Unlock()
 	v1.DisallowUnknownFields = strict
 
-	var tomlObj interface{}
+	var tomlObj any
 	// Try to unmarshal as TOML first; swallow errors from that (assume it's not valid TOML).
 	if err := toml.Unmarshal(b, &tomlObj); err == nil {
 		b, err = json.Marshal(&tomlObj)

--- a/pkg/msg/ctl.go
+++ b/pkg/msg/ctl.go
@@ -39,6 +39,6 @@ func ReadMsgInto(c io.Reader, msg Message) (err error) {
 	return msgCtl.ReadMsgInto(c, msg)
 }
 
-func WriteMsg(c io.Writer, msg interface{}) (err error) {
+func WriteMsg(c io.Writer, msg any) (err error) {
 	return msgCtl.WriteMsg(c, msg)
 }

--- a/pkg/msg/msg.go
+++ b/pkg/msg/msg.go
@@ -40,7 +40,7 @@ const (
 	TypeNatHoleReport      = '6'
 )
 
-var msgTypeMap = map[byte]interface{}{
+var msgTypeMap = map[byte]any{
 	TypeLogin:              Login{},
 	TypeLoginResp:          LoginResp{},
 	TypeNewProxy:           NewProxy{},

--- a/pkg/plugin/server/http.go
+++ b/pkg/plugin/server/http.go
@@ -72,7 +72,7 @@ func (p *httpPlugin) IsSupport(op string) bool {
 	return false
 }
 
-func (p *httpPlugin) Handle(ctx context.Context, op string, content interface{}) (*Response, interface{}, error) {
+func (p *httpPlugin) Handle(ctx context.Context, op string, content any) (*Response, any, error) {
 	r := &Request{
 		Version: APIVersion,
 		Op:      op,

--- a/pkg/plugin/server/manager.go
+++ b/pkg/plugin/server/manager.go
@@ -75,7 +75,7 @@ func (m *Manager) Login(content *LoginContent) (*LoginContent, error) {
 			Reject:   false,
 			Unchange: true,
 		}
-		retContent interface{}
+		retContent any
 		err        error
 	)
 	reqid, _ := util.RandID()
@@ -109,7 +109,7 @@ func (m *Manager) NewProxy(content *NewProxyContent) (*NewProxyContent, error) {
 			Reject:   false,
 			Unchange: true,
 		}
-		retContent interface{}
+		retContent any
 		err        error
 	)
 	reqid, _ := util.RandID()
@@ -168,7 +168,7 @@ func (m *Manager) Ping(content *PingContent) (*PingContent, error) {
 			Reject:   false,
 			Unchange: true,
 		}
-		retContent interface{}
+		retContent any
 		err        error
 	)
 	reqid, _ := util.RandID()
@@ -202,7 +202,7 @@ func (m *Manager) NewWorkConn(content *NewWorkConnContent) (*NewWorkConnContent,
 			Reject:   false,
 			Unchange: true,
 		}
-		retContent interface{}
+		retContent any
 		err        error
 	)
 	reqid, _ := util.RandID()
@@ -236,7 +236,7 @@ func (m *Manager) NewUserConn(content *NewUserConnContent) (*NewUserConnContent,
 			Reject:   false,
 			Unchange: true,
 		}
-		retContent interface{}
+		retContent any
 		err        error
 	)
 	reqid, _ := util.RandID()

--- a/pkg/plugin/server/plugin.go
+++ b/pkg/plugin/server/plugin.go
@@ -32,5 +32,5 @@ const (
 type Plugin interface {
 	Name() string
 	IsSupport(op string) bool
-	Handle(ctx context.Context, op string, content interface{}) (res *Response, retContent interface{}, err error)
+	Handle(ctx context.Context, op string, content any) (res *Response, retContent any, err error)
 }

--- a/pkg/plugin/server/types.go
+++ b/pkg/plugin/server/types.go
@@ -19,16 +19,16 @@ import (
 )
 
 type Request struct {
-	Version string      `json:"version"`
-	Op      string      `json:"op"`
-	Content interface{} `json:"content"`
+	Version string `json:"version"`
+	Op      string `json:"op"`
+	Content any    `json:"content"`
 }
 
 type Response struct {
-	Reject       bool        `json:"reject"`
-	RejectReason string      `json:"reject_reason"`
-	Unchange     bool        `json:"unchange"`
-	Content      interface{} `json:"content"`
+	Reject       bool   `json:"reject"`
+	RejectReason string `json:"reject_reason"`
+	Unchange     bool   `json:"unchange"`
+	Content      any    `json:"content"`
 }
 
 type LoginContent struct {

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -67,27 +67,27 @@ func InitLogger(logPath string, levelStr string, maxDays int, disableLogColor bo
 	Logger = Logger.WithOptions(options...)
 }
 
-func Errorf(format string, v ...interface{}) {
+func Errorf(format string, v ...any) {
 	Logger.Errorf(format, v...)
 }
 
-func Warnf(format string, v ...interface{}) {
+func Warnf(format string, v ...any) {
 	Logger.Warnf(format, v...)
 }
 
-func Infof(format string, v ...interface{}) {
+func Infof(format string, v ...any) {
 	Logger.Infof(format, v...)
 }
 
-func Debugf(format string, v ...interface{}) {
+func Debugf(format string, v ...any) {
 	Logger.Debugf(format, v...)
 }
 
-func Tracef(format string, v ...interface{}) {
+func Tracef(format string, v ...any) {
 	Logger.Tracef(format, v...)
 }
 
-func Logf(level log.Level, offset int, format string, v ...interface{}) {
+func Logf(level log.Level, offset int, format string, v ...any) {
 	Logger.Logf(level, offset, format, v...)
 }
 

--- a/pkg/util/vhost/router.go
+++ b/pkg/util/vhost/router.go
@@ -24,7 +24,7 @@ type Router struct {
 	httpUser string
 
 	// store any object here
-	payload interface{}
+	payload any
 }
 
 func NewRouters() *Routers {
@@ -33,7 +33,7 @@ func NewRouters() *Routers {
 	}
 }
 
-func (r *Routers) Add(domain, location, httpUser string, payload interface{}) error {
+func (r *Routers) Add(domain, location, httpUser string, payload any) error {
 	domain = strings.ToLower(domain)
 
 	r.mutex.Lock()

--- a/pkg/util/xlog/xlog.go
+++ b/pkg/util/xlog/xlog.go
@@ -94,22 +94,22 @@ func (l *Logger) Spawn() *Logger {
 	return nl
 }
 
-func (l *Logger) Errorf(format string, v ...interface{}) {
+func (l *Logger) Errorf(format string, v ...any) {
 	log.Logger.Errorf(l.prefixString+format, v...)
 }
 
-func (l *Logger) Warnf(format string, v ...interface{}) {
+func (l *Logger) Warnf(format string, v ...any) {
 	log.Logger.Warnf(l.prefixString+format, v...)
 }
 
-func (l *Logger) Infof(format string, v ...interface{}) {
+func (l *Logger) Infof(format string, v ...any) {
 	log.Logger.Infof(l.prefixString+format, v...)
 }
 
-func (l *Logger) Debugf(format string, v ...interface{}) {
+func (l *Logger) Debugf(format string, v ...any) {
 	log.Logger.Debugf(l.prefixString+format, v...)
 }
 
-func (l *Logger) Tracef(format string, v ...interface{}) {
+func (l *Logger) Tracef(format string, v ...any) {
 	log.Logger.Tracef(l.prefixString+format, v...)
 }

--- a/server/dashboard_api.go
+++ b/server/dashboard_api.go
@@ -196,15 +196,15 @@ func getConfByType(proxyType string) any {
 
 // Get proxy info.
 type ProxyStatsInfo struct {
-	Name            string      `json:"name"`
-	Conf            interface{} `json:"conf"`
-	ClientVersion   string      `json:"clientVersion,omitempty"`
-	TodayTrafficIn  int64       `json:"todayTrafficIn"`
-	TodayTrafficOut int64       `json:"todayTrafficOut"`
-	CurConns        int64       `json:"curConns"`
-	LastStartTime   string      `json:"lastStartTime"`
-	LastCloseTime   string      `json:"lastCloseTime"`
-	Status          string      `json:"status"`
+	Name            string `json:"name"`
+	Conf            any    `json:"conf"`
+	ClientVersion   string `json:"clientVersion,omitempty"`
+	TodayTrafficIn  int64  `json:"todayTrafficIn"`
+	TodayTrafficOut int64  `json:"todayTrafficOut"`
+	CurConns        int64  `json:"curConns"`
+	LastStartTime   string `json:"lastStartTime"`
+	LastCloseTime   string `json:"lastCloseTime"`
+	Status          string `json:"status"`
 }
 
 type GetProxyInfoResp struct {
@@ -272,14 +272,14 @@ func (svr *Service) getProxyStatsByType(proxyType string) (proxyInfos []*ProxySt
 
 // Get proxy info by name.
 type GetProxyStatsResp struct {
-	Name            string      `json:"name"`
-	Conf            interface{} `json:"conf"`
-	TodayTrafficIn  int64       `json:"todayTrafficIn"`
-	TodayTrafficOut int64       `json:"todayTrafficOut"`
-	CurConns        int64       `json:"curConns"`
-	LastStartTime   string      `json:"lastStartTime"`
-	LastCloseTime   string      `json:"lastCloseTime"`
-	Status          string      `json:"status"`
+	Name            string `json:"name"`
+	Conf            any    `json:"conf"`
+	TodayTrafficIn  int64  `json:"todayTrafficIn"`
+	TodayTrafficOut int64  `json:"todayTrafficOut"`
+	CurConns        int64  `json:"curConns"`
+	LastStartTime   string `json:"lastStartTime"`
+	LastCloseTime   string `json:"lastCloseTime"`
+	Status          string `json:"status"`
 }
 
 // /api/proxy/:type/:name

--- a/test/e2e/framework/expect.go
+++ b/test/e2e/framework/expect.go
@@ -5,75 +5,75 @@ import (
 )
 
 // ExpectEqual expects the specified two are the same, otherwise an exception raises
-func ExpectEqual(actual interface{}, extra interface{}, explain ...interface{}) {
+func ExpectEqual(actual any, extra any, explain ...any) {
 	gomega.ExpectWithOffset(1, actual).To(gomega.Equal(extra), explain...)
 }
 
 // ExpectEqualValues expects the specified two are the same, it not strict about type
-func ExpectEqualValues(actual interface{}, extra interface{}, explain ...interface{}) {
+func ExpectEqualValues(actual any, extra any, explain ...any) {
 	gomega.ExpectWithOffset(1, actual).To(gomega.BeEquivalentTo(extra), explain...)
 }
 
-func ExpectEqualValuesWithOffset(offset int, actual interface{}, extra interface{}, explain ...interface{}) {
+func ExpectEqualValuesWithOffset(offset int, actual any, extra any, explain ...any) {
 	gomega.ExpectWithOffset(1+offset, actual).To(gomega.BeEquivalentTo(extra), explain...)
 }
 
 // ExpectNotEqual expects the specified two are not the same, otherwise an exception raises
-func ExpectNotEqual(actual interface{}, extra interface{}, explain ...interface{}) {
+func ExpectNotEqual(actual any, extra any, explain ...any) {
 	gomega.ExpectWithOffset(1, actual).NotTo(gomega.Equal(extra), explain...)
 }
 
 // ExpectError expects an error happens, otherwise an exception raises
-func ExpectError(err error, explain ...interface{}) {
+func ExpectError(err error, explain ...any) {
 	gomega.ExpectWithOffset(1, err).To(gomega.HaveOccurred(), explain...)
 }
 
-func ExpectErrorWithOffset(offset int, err error, explain ...interface{}) {
+func ExpectErrorWithOffset(offset int, err error, explain ...any) {
 	gomega.ExpectWithOffset(1+offset, err).To(gomega.HaveOccurred(), explain...)
 }
 
 // ExpectNoError checks if "err" is set, and if so, fails assertion while logging the error.
-func ExpectNoError(err error, explain ...interface{}) {
+func ExpectNoError(err error, explain ...any) {
 	ExpectNoErrorWithOffset(1, err, explain...)
 }
 
 // ExpectNoErrorWithOffset checks if "err" is set, and if so, fails assertion while logging the error at "offset" levels above its caller
 // (for example, for call chain f -> g -> ExpectNoErrorWithOffset(1, ...) error would be logged for "f").
-func ExpectNoErrorWithOffset(offset int, err error, explain ...interface{}) {
+func ExpectNoErrorWithOffset(offset int, err error, explain ...any) {
 	gomega.ExpectWithOffset(1+offset, err).NotTo(gomega.HaveOccurred(), explain...)
 }
 
-func ExpectContainSubstring(actual, substr string, explain ...interface{}) {
+func ExpectContainSubstring(actual, substr string, explain ...any) {
 	gomega.ExpectWithOffset(1, actual).To(gomega.ContainSubstring(substr), explain...)
 }
 
 // ExpectConsistOf expects actual contains precisely the extra elements.  The ordering of the elements does not matter.
-func ExpectConsistOf(actual interface{}, extra interface{}, explain ...interface{}) {
+func ExpectConsistOf(actual any, extra any, explain ...any) {
 	gomega.ExpectWithOffset(1, actual).To(gomega.ConsistOf(extra), explain...)
 }
 
-func ExpectContainElements(actual interface{}, extra interface{}, explain ...interface{}) {
+func ExpectContainElements(actual any, extra any, explain ...any) {
 	gomega.ExpectWithOffset(1, actual).To(gomega.ContainElements(extra), explain...)
 }
 
-func ExpectNotContainElements(actual interface{}, extra interface{}, explain ...interface{}) {
+func ExpectNotContainElements(actual any, extra any, explain ...any) {
 	gomega.ExpectWithOffset(1, actual).NotTo(gomega.ContainElements(extra), explain...)
 }
 
 // ExpectHaveKey expects the actual map has the key in the keyset
-func ExpectHaveKey(actual interface{}, key interface{}, explain ...interface{}) {
+func ExpectHaveKey(actual any, key any, explain ...any) {
 	gomega.ExpectWithOffset(1, actual).To(gomega.HaveKey(key), explain...)
 }
 
 // ExpectEmpty expects actual is empty
-func ExpectEmpty(actual interface{}, explain ...interface{}) {
+func ExpectEmpty(actual any, explain ...any) {
 	gomega.ExpectWithOffset(1, actual).To(gomega.BeEmpty(), explain...)
 }
 
-func ExpectTrue(actual interface{}, explain ...interface{}) {
+func ExpectTrue(actual any, explain ...any) {
 	gomega.ExpectWithOffset(1, actual).Should(gomega.BeTrue(), explain...)
 }
 
-func ExpectTrueWithOffset(offset int, actual interface{}, explain ...interface{}) {
+func ExpectTrueWithOffset(offset int, actual any, explain ...any) {
 	gomega.ExpectWithOffset(1+offset, actual).Should(gomega.BeTrue(), explain...)
 }

--- a/test/e2e/framework/log.go
+++ b/test/e2e/framework/log.go
@@ -11,18 +11,18 @@ func nowStamp() string {
 	return time.Now().Format(time.StampMilli)
 }
 
-func log(level string, format string, args ...interface{}) {
+func log(level string, format string, args ...any) {
 	fmt.Fprintf(ginkgo.GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", args...)
 }
 
 // Logf logs the info.
-func Logf(format string, args ...interface{}) {
+func Logf(format string, args ...any) {
 	log("INFO", format, args...)
 }
 
 // Failf logs the fail info, including a stack trace starts with its direct caller
 // (for example, for call chain f -> g -> Failf("foo", ...) error would be logged for "g").
-func Failf(format string, args ...interface{}) {
+func Failf(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
 	skip := 1
 	ginkgo.Fail(msg, skip)

--- a/test/e2e/framework/mockservers.go
+++ b/test/e2e/framework/mockservers.go
@@ -67,8 +67,8 @@ func (m *MockServers) Close() {
 	os.Remove(m.udsEchoServer.BindAddr())
 }
 
-func (m *MockServers) GetTemplateParams() map[string]interface{} {
-	ret := make(map[string]interface{})
+func (m *MockServers) GetTemplateParams() map[string]any {
+	ret := make(map[string]any)
 	ret[TCPEchoServerPort] = m.tcpEchoServer.BindPort()
 	ret[UDPEchoServerPort] = m.udpEchoServer.BindPort()
 	ret[UDSEchoServerAddr] = m.udsEchoServer.BindAddr()
@@ -76,7 +76,7 @@ func (m *MockServers) GetTemplateParams() map[string]interface{} {
 	return ret
 }
 
-func (m *MockServers) GetParam(key string) interface{} {
+func (m *MockServers) GetParam(key string) any {
 	params := m.GetTemplateParams()
 	if v, ok := params[key]; ok {
 		return v

--- a/test/e2e/framework/request.go
+++ b/test/e2e/framework/request.go
@@ -42,7 +42,7 @@ type RequestExpect struct {
 	f           *Framework
 	expectResp  []byte
 	expectError bool
-	explain     []interface{}
+	explain     []any
 }
 
 func NewRequestExpect(f *Framework) *RequestExpect {
@@ -51,7 +51,7 @@ func NewRequestExpect(f *Framework) *RequestExpect {
 		f:           f,
 		expectResp:  []byte(consts.TestString),
 		expectError: false,
-		explain:     make([]interface{}, 0),
+		explain:     make([]any, 0),
 	}
 }
 
@@ -94,7 +94,7 @@ func (e *RequestExpect) ExpectError(expectErr bool) *RequestExpect {
 	return e
 }
 
-func (e *RequestExpect) Explain(explain ...interface{}) *RequestExpect {
+func (e *RequestExpect) Explain(explain ...any) *RequestExpect {
 	e.explain = explain
 	return e
 }


### PR DESCRIPTION
### WHY

For uniformity and because go 1.22.0 is used, I've replaced all 'interface{}' with the alias 'any'.
