### PR TITLE
解决goroutine泄漏问题

### DIFF
--- a/server/proxy/xtcp.go
+++ b/server/proxy/xtcp.go
@@ -43,6 +43,7 @@ func NewXTCPProxy(baseProxy *BaseProxy) Proxy {
 	return &XTCPProxy{
 		BaseProxy: baseProxy,
 		cfg:       unwrapped,
+		closeCh:   make(chan struct{}),
 	}
 }
 

--- a/server/proxy/xtcp.go
+++ b/server/proxy/xtcp.go
@@ -19,8 +19,6 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/fatedier/golib/errors"
-
 	v1 "github.com/fatedier/frp/pkg/config/v1"
 	"github.com/fatedier/frp/pkg/msg"
 )
@@ -90,11 +88,9 @@ func (pxy *XTCPProxy) Run() (remoteAddr string, err error) {
 }
 
 func (pxy *XTCPProxy) Close() {
-	pxy.BaseProxy.Close()
-	pxy.rc.NatHoleController.CloseClient(pxy.GetName())
 	pxy.closeOnce.Do(func() {
-		_ = errors.PanicToError(func() {
-			close(pxy.closeCh)
-		})
+		pxy.BaseProxy.Close()
+		pxy.rc.NatHoleController.CloseClient(pxy.GetName())
+		close(pxy.closeCh)
 	})
 }


### PR DESCRIPTION
### WHY
由于`closeCh`没有被初始化，在`Close()`函数中执行`close(pxy.closeCh)`的时候，会panic："panic error: close of nil channel"；导致无法退出`Run()`函数中创建的goroutine，造成goroutine泄漏，同时引发内存泄漏；在我的案例中，client用户单实例大概4000，运行两天，阻塞在`case <-pxy.closeCh`中的goroutine达到三万多；





