### PR TITLE
feat: add support for setting custom udp listen port on the xtcp mode

### DIFF
--- a/client/proxy/xtcp.go
+++ b/client/proxy/xtcp.go
@@ -64,7 +64,7 @@ func (pxy *XTCPProxy) InWorkConn(conn net.Conn, startWorkConnMsg *msg.StartWorkC
 	}
 
 	xl.Tracef("nathole prepare start")
-	prepareResult, err := nathole.Prepare([]string{pxy.clientCfg.NatHoleSTUNServer})
+	prepareResult, err := nathole.Prepare([]string{pxy.clientCfg.NatHoleSTUNServer}, "")
 	if err != nil {
 		xl.Warnf("nathole prepare error: %v", err)
 		return

--- a/client/visitor/xtcp.go
+++ b/client/visitor/xtcp.go
@@ -275,7 +275,7 @@ func (sv *XTCPVisitor) makeNatHole() {
 	}
 
 	xl.Tracef("nathole prepare start")
-	prepareResult, err := nathole.Prepare([]string{sv.clientCfg.NatHoleSTUNServer})
+	prepareResult, err := nathole.Prepare([]string{sv.clientCfg.NatHoleSTUNServer}, sv.cfg.UDPListen)
 	if err != nil {
 		xl.Warnf("nathole prepare error: %v", err)
 		return

--- a/pkg/config/v1/visitor.go
+++ b/pkg/config/v1/visitor.go
@@ -157,6 +157,11 @@ type XTCPVisitorConfig struct {
 	MinRetryInterval  int    `json:"minRetryInterval,omitempty"`
 	FallbackTo        string `json:"fallbackTo,omitempty"`
 	FallbackTimeoutMs int    `json:"fallbackTimeoutMs,omitempty"`
+
+	// Specify the listen addr and port for the UDP NAT hole punching, the format is "addr:port" like "0.0.0.0:7000".
+	// It is useful when your router's NAT hole punching doesn't work well, so you can explicitly config a UDP port
+	// forwarding rule on the router to work around.
+	UDPListen string `json:"udpListen,omitempty"`
 }
 
 func (c *XTCPVisitorConfig) Complete(g *ClientCommonConfig) {

--- a/pkg/nathole/nathole.go
+++ b/pkg/nathole/nathole.go
@@ -108,9 +108,9 @@ func PreCheck(
 }
 
 // Prepare is used to do some preparation work before penetration.
-func Prepare(stunServers []string) (*PrepareResult, error) {
+func Prepare(stunServers []string, udpListen string) (*PrepareResult, error) {
 	// discover for Nat type
-	addrs, localAddr, err := Discover(stunServers, "")
+	addrs, localAddr, err := Discover(stunServers, udpListen)
 	if err != nil {
 		return nil, fmt.Errorf("discover error: %v", err)
 	}


### PR DESCRIPTION
### **Enhancing xtcp Connectivity with UDP Port Forwarding**

If the home router’s NAT traversal (hole punching) doesn’t work well—such as when it operates in Symmetric NAT mode only—an explicit **UDP port forwarding rule** can be configured on the router to make the NAT on the configured port deterministic. For example:

#### **Router Configuration**
```
UDP 9999 → {Your-LAN-IP}:9999
```
#### **frpc Configuration**
```toml
[[visitors]]
name = "..."
type = "xtcp"
serverName = "..."
secretKey = "..."
bindAddr = "..."
bindPort = "..."
udpListen = "0.0.0.0:9999"
```
With this setup, frpc will use **UDP port 9999** for communication with the STUN server instead of selecting a random port. Since **port 9999 on the router** is already configured to forwarded all traffics to **{Your-LAN-IP}:9999**, if there's no other Symmetric NAT above the router, a successful **xtcp** connection will be established.