### PR TITLE
Added support for HTTPS client certificate authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1081,12 +1081,12 @@ name = "web"
 type = "https"
 customDomains = ["test.example.com"]
 
-        [proxies.plugin]
-        type = "https2http"
-        localAddr = "127.0.0.1:80"
-        crtPath = "server.crt"
-        keyPath = "key.pem"
-        clientCertificates = ["authorizedClient_cert.pem"]
+[proxies.plugin]
+type = "https2http"
+localAddr = "127.0.0.1:80"
+crtPath = "server.crt"
+keyPath = "key.pem"
+clientCertificates = ["authorizedClient_cert.pem"]
 ```
 
 In this situation, the client certificate can be self-signed without any detriment to security. Multiple certificates can be generated and allowed to access the service.

--- a/README.md
+++ b/README.md
@@ -1069,7 +1069,7 @@ Visit `http://test.example.com` in the browser and now you are prompted to enter
 
 ### Require HTTPS client certificate for Web Services
 
-Anyone who can guess your HTTPS tunnel URL can access your local web server unless you protect it with a [Client Certificate](https://en.wikipedia.org/wiki/Transport_Layer_Security#Client-authenticated_TLS_handshake).
+Anyone who can guess your HTTPS tunnel URL can access your local web server unless you protect it with a client certificate.
 
 This [mutual authentication](https://en.wikipedia.org/wiki/Mutual_authentication) validates the HTTPS client's certificate on all requests, with each accepted certificate file specified in frpc's configure file.
 
@@ -1084,7 +1084,7 @@ customDomains = ["test.example.com"]
         [proxies.plugin]
         type = "https2http"
         localAddr = "127.0.0.1:80"
-        crtPath = server.crt"
+        crtPath = "server.crt"
         keyPath = "key.pem"
         clientCertificates = ["authorizedClient_cert.pem"]
 ```

--- a/pkg/config/v1/plugin.go
+++ b/pkg/config/v1/plugin.go
@@ -116,13 +116,14 @@ type HTTPProxyPluginOptions struct {
 func (o *HTTPProxyPluginOptions) Complete() {}
 
 type HTTPS2HTTPPluginOptions struct {
-	Type              string           `json:"type,omitempty"`
-	LocalAddr         string           `json:"localAddr,omitempty"`
-	HostHeaderRewrite string           `json:"hostHeaderRewrite,omitempty"`
-	RequestHeaders    HeaderOperations `json:"requestHeaders,omitempty"`
-	EnableHTTP2       *bool            `json:"enableHTTP2,omitempty"`
-	CrtPath           string           `json:"crtPath,omitempty"`
-	KeyPath           string           `json:"keyPath,omitempty"`
+	Type               string           `json:"type,omitempty"`
+	LocalAddr          string           `json:"localAddr,omitempty"`
+	HostHeaderRewrite  string           `json:"hostHeaderRewrite,omitempty"`
+	RequestHeaders     HeaderOperations `json:"requestHeaders,omitempty"`
+	EnableHTTP2        *bool            `json:"enableHTTP2,omitempty"`
+	CrtPath            string           `json:"crtPath,omitempty"`
+	KeyPath            string           `json:"keyPath,omitempty"`
+	ClientCertificates []string         `json:"clientCertificates,omitempty"`
 }
 
 func (o *HTTPS2HTTPPluginOptions) Complete() {
@@ -130,13 +131,14 @@ func (o *HTTPS2HTTPPluginOptions) Complete() {
 }
 
 type HTTPS2HTTPSPluginOptions struct {
-	Type              string           `json:"type,omitempty"`
-	LocalAddr         string           `json:"localAddr,omitempty"`
-	HostHeaderRewrite string           `json:"hostHeaderRewrite,omitempty"`
-	RequestHeaders    HeaderOperations `json:"requestHeaders,omitempty"`
-	EnableHTTP2       *bool            `json:"enableHTTP2,omitempty"`
-	CrtPath           string           `json:"crtPath,omitempty"`
-	KeyPath           string           `json:"keyPath,omitempty"`
+	Type               string           `json:"type,omitempty"`
+	LocalAddr          string           `json:"localAddr,omitempty"`
+	HostHeaderRewrite  string           `json:"hostHeaderRewrite,omitempty"`
+	RequestHeaders     HeaderOperations `json:"requestHeaders,omitempty"`
+	EnableHTTP2        *bool            `json:"enableHTTP2,omitempty"`
+	CrtPath            string           `json:"crtPath,omitempty"`
+	KeyPath            string           `json:"keyPath,omitempty"`
+	ClientCertificates []string         `json:"clientCertificates,omitempty"`
 }
 
 func (o *HTTPS2HTTPSPluginOptions) Complete() {

--- a/pkg/plugin/client/https2https.go
+++ b/pkg/plugin/client/https2https.go
@@ -19,6 +19,7 @@ package plugin
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	stdlog "log"
@@ -95,6 +96,33 @@ func NewHTTPS2HTTPSPlugin(options v1.ClientPluginOptions) (Plugin, error) {
 	tlsConfig, err := transport.NewServerTLSConfig(p.opts.CrtPath, p.opts.KeyPath, "")
 	if err != nil {
 		return nil, fmt.Errorf("gen TLS config error: %v", err)
+	}
+
+	if len(p.opts.ClientCertificates) > 0 {
+		certs, err := transport.LoadCertificatesFromFiles(p.opts.ClientCertificates)
+		if err != nil {
+			return nil, fmt.Errorf("loading Client Certificates failed: %v", err)
+		}
+
+		tlsConfig.ClientAuth = tls.RequireAnyClientCert
+		tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+			if len(rawCerts) == 0 {
+				return fmt.Errorf("no client certificate provided")
+			}
+
+			clientCert, err := x509.ParseCertificate(rawCerts[0])
+			if err != nil {
+				return fmt.Errorf("failed to parse client certificate: %w", err)
+			}
+
+			for _, allowedCert := range certs {
+				if clientCert.Equal(allowedCert) {
+					return nil //match found, accept
+				}
+			}
+
+			return fmt.Errorf("client certificate not recognized")
+		}
 	}
 
 	p.s = &http.Server{

--- a/pkg/transport/tls.go
+++ b/pkg/transport/tls.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"os"
 )
@@ -139,4 +140,29 @@ func NewRandomPrivateKey() ([]byte, error) {
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	})
 	return keyPEM, nil
+}
+
+func LoadCertificatesFromFiles(certFiles []string) ([]*x509.Certificate, error) {
+	var certificates []*x509.Certificate
+
+	for _, file := range certFiles {
+		certPEM, err := os.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read certificate file %s: %w", file, err)
+		}
+
+		block, _ := pem.Decode(certPEM)
+		if block == nil {
+			return nil, fmt.Errorf("failed to decode PEM block")
+		}
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse certificate file %s: %w", file, err)
+		}
+
+		certificates = append(certificates, cert)
+	}
+
+	return certificates, nil
 }


### PR DESCRIPTION
### WHY

While a proxy of "http" type can be protected by "httpUser" and "httpPassword", no such protection is provided for "https" proxies. This leaves them unprotected in case someone guesses the URL, the URL leaks, or someone looks over your shoulder; as a system administrator, you would want to put yet _another_ reverse proxy in front of the service to protect it, or if possible modify the actual service to ask for username and password.

This lack of support for HTTP Basic Authentication on HTTPS proxies has been talked about as a technical limitation:
https://github.com/fatedier/frp/issues/3242#issuecomment-1374694878
And due to my novice skills in Go, I took that to heart and didn't even think of intercepting the encrypted connection, so I turned to the next best thing: HTTPS client certificate authentication, which is done at the TLS configuration level.

This PR adds a new "clientCertificates" configuration to "https2http" and "https2https" plugins, as such:

```toml
[[proxies]]
name = "web"
type = "https"
customDomains = ["test.example.com"]

[proxies.plugin]
type = "https2http"
localAddr = "127.0.0.1:80"
crtPath = "server.crt"
keyPath = "key.pem"
clientCertificates = ["authorizedClient1.cert"]
```

Multiple, self-signed, certificates can be set in this configuration, and at least one of them will be required to access the service. The client certificate can normally be installed at system-level or at application-level, at the discretion of the user.

Below is a demonstration of the feature using the Vivaldi browser, with a self-signed certificate installed at system-level:
[frp_demo.webm](https://github.com/user-attachments/assets/ec436752-5665-403c-81b0-8246762cbf55)

While this form of authentication is not common like Basic Authentication, it does provide security benefits, and I think they're worth considering as well:
https://en.wikipedia.org/wiki/Mutual_authentication#Defenses

Finally, I have updated the README to reflect these changes with instructions; and created two new e2e tests, separate from the existing https2http and https2https tests, specifically for client certificate authentication.
