### PR TITLE
fix: type error in server_plugin doc

### DIFF
--- a/doc/server_plugin.md
+++ b/doc/server_plugin.md
@@ -121,7 +121,7 @@ Create new proxy
         // http and https only
         "custom_domains": []<string>,
         "subdomain": <string>,
-        "locations": <string>,
+        "locations": []<string>,
         "http_user": <string>,
         "http_pwd": <string>,
         "host_header_rewrite": <string>,


### PR DESCRIPTION
### WHY

The type of `locations` is `[]<string>`, not `<string>`.
