### PR TITLE
Update quic-go dependency from v0.48.2 to v0.53.0

### DIFF
--- a/client/connector.go
+++ b/client/connector.go
@@ -48,7 +48,7 @@ type defaultConnectorImpl struct {
 	cfg *v1.ClientCommonConfig
 
 	muxSession *fmux.Session
-	quicConn   quic.Connection
+	quicConn   *quic.Conn
 	closeOnce  sync.Once
 }
 

--- a/client/visitor/xtcp.go
+++ b/client/visitor/xtcp.go
@@ -398,7 +398,7 @@ func (ks *KCPTunnelSession) Close() {
 }
 
 type QUICTunnelSession struct {
-	session    quic.Connection
+	session    *quic.Conn
 	listenConn *net.UDPConn
 	mu         sync.RWMutex
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/pion/stun/v2 v2.0.0
 	github.com/pires/go-proxyproto v0.7.0
 	github.com/prometheus/client_golang v1.19.1
-	github.com/quic-go/quic-go v0.48.2
+	github.com/quic-go/quic-go v0.53.0
 	github.com/rodaine/table v1.2.0
 	github.com/samber/lo v1.47.0
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
@@ -68,7 +68,6 @@ require (
 	github.com/vishvananda/netns v0.0.4 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/mock v0.5.0 // indirect
-	golang.org/x/exp v0.0.0-20241204233417-43b7b7cde48d // indirect
 	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/text v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/prometheus/common v0.48.0 h1:QO8U2CdOzSn1BBsmXJXduaaW+dY/5QLjfB8svtSz
 github.com/prometheus/common v0.48.0/go.mod h1:0/KsvlIEfPQCQ5I2iNSAWKPZziNCvRs5EC6ILDTlAPc=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/quic-go/quic-go v0.48.2 h1:wsKXZPeGWpMpCGSWqOcqpW2wZYic/8T3aqiOID0/KWE=
-github.com/quic-go/quic-go v0.48.2/go.mod h1:yBgs3rWBOADpga7F+jJsb6Ybg1LSYiQvwWlLX+/6HMs=
+github.com/quic-go/quic-go v0.53.0 h1:QHX46sISpG2S03dPeZBgVIZp8dGagIaiu2FiVYvpCZI=
+github.com/quic-go/quic-go v0.53.0/go.mod h1:e68ZEaCdyviluZmy44P6Iey98v/Wfz6HCjQEm+l8zTY=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rodaine/table v1.2.0 h1:38HEnwK4mKSHQJIkavVj+bst1TEY7j9zhLMWu4QJrMA=
@@ -167,8 +167,6 @@ golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98y
 golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
 golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20241204233417-43b7b7cde48d h1:0olWaB5pg3+oychR51GUVCEsGkeCU/2JxjBgIo4f3M0=
-golang.org/x/exp v0.0.0-20241204233417-43b7b7cde48d/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/pkg/util/net/conn.go
+++ b/pkg/util/net/conn.go
@@ -197,11 +197,11 @@ func (statsConn *StatsConn) Close() (err error) {
 }
 
 type wrapQuicStream struct {
-	quic.Stream
-	c quic.Connection
+	*quic.Stream
+	c *quic.Conn
 }
 
-func QuicStreamToNetConn(s quic.Stream, c quic.Connection) net.Conn {
+func QuicStreamToNetConn(s *quic.Stream, c *quic.Conn) net.Conn {
 	return &wrapQuicStream{
 		Stream: s,
 		c:      c,

--- a/server/service.go
+++ b/server/service.go
@@ -550,7 +550,7 @@ func (svr *Service) HandleQUICListener(l *quic.Listener) {
 			return
 		}
 		// Start a new goroutine to handle connection.
-		go func(ctx context.Context, frpConn quic.Connection) {
+		go func(ctx context.Context, frpConn *quic.Conn) {
 			for {
 				stream, err := frpConn.AcceptStream(context.Background())
 				if err != nil {


### PR DESCRIPTION

# Update quic-go dependency from v0.48.2 to v0.53.0

## Summary

This PR addresses issue #4852 by updating the quic-go dependency from v0.48.2 to v0.53.0. The update includes necessary API changes due to breaking changes in quic-go v0.53.0, where `quic.Connection` interface was replaced with `*quic.Conn` struct and `quic.Stream` interface was replaced with `*quic.Stream` struct.

**Changes made:**
- Updated `go.mod` to use `github.com/quic-go/quic-go v0.53.0`
- Replaced all `quic.Connection` references with `*quic.Conn` across 4 files
- Updated `quic.Stream` embedding in `wrapQuicStream` struct to use `*quic.Stream`
- Updated function signatures and struct field types accordingly

All existing unit tests pass and linting shows no issues.

## Review & Testing Checklist for Human

This is a **medium-risk change** affecting core networking functionality. Please verify:

- [ ] **Test the original build scenario**: Reproduce the exact build error described in issue #4852 to confirm it's resolved
- [ ] **End-to-end QUIC functionality**: Test QUIC-based connections between frpc and frps to ensure basic functionality works
- [ ] **API correctness verification**: Cross-reference the API changes against [quic-go v0.53.0 documentation](https://github.com/quic-go/quic-go/releases/tag/v0.53.0) to ensure correct usage
- [ ] **Performance testing**: Run basic performance tests on QUIC connections to check for regressions
- [ ] **Client/server compatibility**: Test that updated client and server components work together correctly

**Recommended test plan**: Set up a simple frp tunnel using QUIC transport and verify data flows correctly in both directions.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "Dependency Update"
        gomod["go.mod<br/>quic-go v0.48.2 → v0.53.0"]:::major-edit
    end
    
    subgraph "Core QUIC Components"
        netpkg["pkg/util/net/conn.go<br/>QuicStreamToNetConn()"]:::minor-edit
        server["server/service.go<br/>HandleQUICListener()"]:::minor-edit
        connector["client/connector.go<br/>defaultConnectorImpl"]:::minor-edit
        visitor["client/visitor/xtcp.go<br/>QUICTunnelSession"]:::minor-edit
    end
    
    subgraph "QUIC Flow"
        client_conn["Client QUIC Connection"] --> server_conn["Server QUIC Connection"]
        server_conn --> stream_handling["Stream Handling"]
        stream_handling --> netconn["Net.Conn Conversion"]
    end
    
    gomod -.-> netpkg
    gomod -.-> server
    gomod -.-> connector
    gomod -.-> visitor
    
    
    connector --> client_conn
    visitor --> client_conn
    server --> server_conn
    netpkg --> netconn
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This PR implements the exact changes requested in issue #4852 to resolve build errors with quic-go dependency conflicts
- The API changes are mechanical but affect critical networking paths in both client and server components
- All changes follow the quic-go v0.53.0 migration pattern: interface types became struct pointer types
- Session requested by @fatedier
- Link to Devin run: https://app.devin.ai/sessions/bdaa32361f044e9d92d67dc8bdb98c09
