### PR TITLE
feat: add proxy_status metric

### DIFF
--- a/pkg/metrics/aggregate/server.go
+++ b/pkg/metrics/aggregate/server.go
@@ -68,6 +68,12 @@ func (m *serverMetrics) CloseProxy(name string, proxyType string) {
 	}
 }
 
+func (m *serverMetrics) ProxyStatus(name string, proxyType string, online bool) {
+	for _, v := range m.ms {
+		v.ProxyStatus(name, proxyType, online)
+	}
+}
+
 func (m *serverMetrics) OpenConnection(name string, proxyType string) {
 	for _, v := range m.ms {
 		v.OpenConnection(name, proxyType)

--- a/pkg/metrics/mem/server.go
+++ b/pkg/metrics/mem/server.go
@@ -133,6 +133,20 @@ func (m *serverMetrics) CloseProxy(name string, proxyType string) {
 	}
 }
 
+func (m *serverMetrics) ProxyStatus(name string, proxyType string, online bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	proxyStats, ok := m.info.ProxyStatistics[name]
+	if ok {
+		if online {
+			proxyStats.Status = "online"
+		} else {
+			proxyStats.Status = "offline"
+		}
+		m.info.ProxyStatistics[name] = proxyStats
+	}
+}
+
 func (m *serverMetrics) OpenConnection(name string, _ string) {
 	m.info.CurConns.Inc(1)
 
@@ -217,6 +231,7 @@ func (m *serverMetrics) GetProxiesByType(proxyType string) []*ProxyStats {
 			TodayTrafficIn:  proxyStats.TrafficIn.TodayCount(),
 			TodayTrafficOut: proxyStats.TrafficOut.TodayCount(),
 			CurConns:        int64(proxyStats.CurConns.Count()),
+			Status:          proxyStats.Status,
 		}
 		if !proxyStats.LastStartTime.IsZero() {
 			ps.LastStartTime = proxyStats.LastStartTime.Format("01-02 15:04:05")
@@ -248,6 +263,7 @@ func (m *serverMetrics) GetProxiesByTypeAndName(proxyType string, proxyName stri
 			TodayTrafficIn:  proxyStats.TrafficIn.TodayCount(),
 			TodayTrafficOut: proxyStats.TrafficOut.TodayCount(),
 			CurConns:        int64(proxyStats.CurConns.Count()),
+			Status:          proxyStats.Status,
 		}
 		if !proxyStats.LastStartTime.IsZero() {
 			res.LastStartTime = proxyStats.LastStartTime.Format("01-02 15:04:05")

--- a/pkg/metrics/mem/types.go
+++ b/pkg/metrics/mem/types.go
@@ -40,6 +40,7 @@ type ProxyStats struct {
 	LastStartTime   string
 	LastCloseTime   string
 	CurConns        int64
+	Status          string
 }
 
 type ProxyTrafficInfo struct {
@@ -56,6 +57,7 @@ type ProxyStatistics struct {
 	CurConns      metric.Counter
 	LastStartTime time.Time
 	LastCloseTime time.Time
+	Status        string
 }
 
 type ServerStatistics struct {

--- a/server/dashboard_api.go
+++ b/server/dashboard_api.go
@@ -17,6 +17,7 @@ package server
 import (
 	"cmp"
 	"encoding/json"
+	"github.com/fatedier/frp/server/metrics"
 	"net/http"
 	"slices"
 
@@ -253,11 +254,13 @@ func (svr *Service) getProxyStatsByType(proxyType string) (proxyInfos []*ProxySt
 				continue
 			}
 			proxyInfo.Status = "online"
+			metrics.Server.ProxyStatus(pxy.GetName(), pxy.GetConfigurer().GetBaseConfig().Type, true)
 			if pxy.GetLoginMsg() != nil {
 				proxyInfo.ClientVersion = pxy.GetLoginMsg().Version
 			}
 		} else {
 			proxyInfo.Status = "offline"
+			metrics.Server.ProxyStatus(pxy.GetName(), pxy.GetConfigurer().GetBaseConfig().Type, false)
 		}
 		proxyInfo.Name = ps.Name
 		proxyInfo.TodayTrafficIn = ps.TodayTrafficIn

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -9,6 +9,7 @@ type ServerMetrics interface {
 	CloseClient()
 	NewProxy(name string, proxyType string)
 	CloseProxy(name string, proxyType string)
+	ProxyStatus(name string, proxyType string, online bool)
 	OpenConnection(name string, proxyType string)
 	CloseConnection(name string, proxyType string)
 	AddTrafficIn(name string, proxyType string, trafficBytes int64)
@@ -31,6 +32,7 @@ func (noopServerMetrics) NewClient()                          {}
 func (noopServerMetrics) CloseClient()                        {}
 func (noopServerMetrics) NewProxy(string, string)             {}
 func (noopServerMetrics) CloseProxy(string, string)           {}
+func (noopServerMetrics) ProxyStatus(string, string, bool)    {}
 func (noopServerMetrics) OpenConnection(string, string)       {}
 func (noopServerMetrics) CloseConnection(string, string)      {}
 func (noopServerMetrics) AddTrafficIn(string, string, int64)  {}


### PR DESCRIPTION
Added a proxy_status metric that is either 1 (online) or 0 (offline).

### WHY

We want to be able to tell when a customers proxy goes offline, and do alerting on it.