### PR TITLE
fix webserver port not being released on frpc svr.Close()

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -403,6 +403,10 @@ func (svr *Service) stop() {
 		svr.ctl.GracefulClose(svr.gracefulShutdownDuration)
 		svr.ctl = nil
 	}
+	if svr.webServer != nil {
+		svr.webServer.Close()
+		svr.webServer = nil
+	}
 }
 
 func (svr *Service) getProxyStatus(name string) (*proxy.WorkingStatus, bool) {


### PR DESCRIPTION
### WHY

fix webserver port not being released on frpc svr.Close()