### PR TITLE
xtcp: add configuration to disable assisted addresses in NAT traversal

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -1,7 +1,3 @@
 ## Features
 
-* Support tokenSource for loading authentication tokens from files.
-
-## Fixes
-
-* Fix SSH tunnel gateway incorrectly binding to proxyBindAddr instead of bindAddr, which caused external connections to fail when proxyBindAddr was set to 127.0.0.1.
+* Add NAT traversal configuration options for XTCP proxies and visitors. Support disabling assisted addresses to avoid using slow VPN connections during NAT hole punching.

--- a/client/proxy/xtcp.go
+++ b/client/proxy/xtcp.go
@@ -64,11 +64,19 @@ func (pxy *XTCPProxy) InWorkConn(conn net.Conn, startWorkConnMsg *msg.StartWorkC
 	}
 
 	xl.Tracef("nathole prepare start")
-	prepareResult, err := nathole.Prepare([]string{pxy.clientCfg.NatHoleSTUNServer})
+
+	// Prepare NAT traversal options
+	var opts nathole.PrepareOptions
+	if pxy.cfg.NatTraversal != nil && pxy.cfg.NatTraversal.DisableAssistedAddrs {
+		opts.DisableAssistedAddrs = true
+	}
+
+	prepareResult, err := nathole.Prepare([]string{pxy.clientCfg.NatHoleSTUNServer}, opts)
 	if err != nil {
 		xl.Warnf("nathole prepare error: %v", err)
 		return
 	}
+
 	xl.Infof("nathole prepare success, nat type: %s, behavior: %s, addresses: %v, assistedAddresses: %v",
 		prepareResult.NatType, prepareResult.Behavior, prepareResult.Addrs, prepareResult.AssistedAddrs)
 	defer prepareResult.ListenConn.Close()

--- a/client/visitor/xtcp.go
+++ b/client/visitor/xtcp.go
@@ -276,11 +276,19 @@ func (sv *XTCPVisitor) makeNatHole() {
 	}
 
 	xl.Tracef("nathole prepare start")
-	prepareResult, err := nathole.Prepare([]string{sv.clientCfg.NatHoleSTUNServer})
+
+	// Prepare NAT traversal options
+	var opts nathole.PrepareOptions
+	if sv.cfg.NatTraversal != nil && sv.cfg.NatTraversal.DisableAssistedAddrs {
+		opts.DisableAssistedAddrs = true
+	}
+
+	prepareResult, err := nathole.Prepare([]string{sv.clientCfg.NatHoleSTUNServer}, opts)
 	if err != nil {
 		xl.Warnf("nathole prepare error: %v", err)
 		return
 	}
+
 	xl.Infof("nathole prepare success, nat type: %s, behavior: %s, addresses: %v, assistedAddresses: %v",
 		prepareResult.NatType, prepareResult.Behavior, prepareResult.Addrs, prepareResult.AssistedAddrs)
 

--- a/conf/frpc_full_example.toml
+++ b/conf/frpc_full_example.toml
@@ -372,6 +372,14 @@ localPort = 22
 # Otherwise, visitors from same user can connect. '*' means allow all users.
 allowUsers = ["user1", "user2"]
 
+# NAT traversal configuration (optional)
+[proxies.natTraversal]
+# Disable the use of local network interfaces (assisted addresses) for NAT traversal.
+# When enabled, only STUN-discovered public addresses will be used.
+# This can improve performance when you have slow VPN connections.
+# Default: false
+disableAssistedAddrs = false
+
 [[proxies]]
 name = "vnet-server"
 type = "stcp"
@@ -410,6 +418,13 @@ maxRetriesAnHour = 8
 minRetryInterval = 90
 # fallbackTo = "stcp_visitor"
 # fallbackTimeoutMs = 500
+
+# NAT traversal configuration (optional)
+[visitors.natTraversal]
+# Disable the use of local network interfaces (assisted addresses) for NAT traversal.
+# When enabled, only STUN-discovered public addresses will be used.
+# Default: false
+disableAssistedAddrs = false
 
 [[visitors]]
 name = "vnet-visitor"

--- a/pkg/config/v1/common.go
+++ b/pkg/config/v1/common.go
@@ -96,6 +96,14 @@ type TLSConfig struct {
 	ServerName string `json:"serverName,omitempty"`
 }
 
+// NatTraversalConfig defines configuration options for NAT traversal
+type NatTraversalConfig struct {
+	// DisableAssistedAddrs disables the use of local network interfaces
+	// for assisted connections during NAT traversal. When enabled,
+	// only STUN-discovered public addresses will be used.
+	DisableAssistedAddrs bool `json:"disableAssistedAddrs,omitempty"`
+}
+
 type LogConfig struct {
 	// This is destination where frp should write the logs.
 	// If "console" is used, logs will be printed to stdout, otherwise,

--- a/pkg/config/v1/proxy.go
+++ b/pkg/config/v1/proxy.go
@@ -422,6 +422,9 @@ type XTCPProxyConfig struct {
 
 	Secretkey  string   `json:"secretKey,omitempty"`
 	AllowUsers []string `json:"allowUsers,omitempty"`
+
+	// NatTraversal configuration for NAT traversal
+	NatTraversal *NatTraversalConfig `json:"natTraversal,omitempty"`
 }
 
 func (c *XTCPProxyConfig) MarshalToMsg(m *msg.NewProxy) {

--- a/pkg/config/v1/visitor.go
+++ b/pkg/config/v1/visitor.go
@@ -160,6 +160,9 @@ type XTCPVisitorConfig struct {
 	MinRetryInterval  int    `json:"minRetryInterval,omitempty"`
 	FallbackTo        string `json:"fallbackTo,omitempty"`
 	FallbackTimeoutMs int    `json:"fallbackTimeoutMs,omitempty"`
+
+	// NatTraversal configuration for NAT traversal
+	NatTraversal *NatTraversalConfig `json:"natTraversal,omitempty"`
 }
 
 func (c *XTCPVisitorConfig) Complete(g *ClientCommonConfig) {


### PR DESCRIPTION
### WHY

Fix #3717
Fix #4903
