### PR TITLE
resolve shellcheck warnings

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -10,7 +10,7 @@ if ! command -v ginkgo >/dev/null 2>&1; then
 fi
 
 debug=false
-if [ "x${DEBUG}" = "xtrue" ]; then
+if [ "${DEBUG:-false}" = "true" ]; then
     debug=true
 fi
 logLevel=debug
@@ -31,4 +31,4 @@ if [ "${CONCURRENCY}" ]; then
     concurrency="${CONCURRENCY}"
 fi
 
-ginkgo -nodes=${concurrency} --poll-progress-after=60s ${ROOT}/test/e2e -- -frpc-path=${frpcPath} -frps-path=${frpsPath} -log-level=${logLevel} -debug=${debug}
+ginkgo -nodes="${concurrency}" --poll-progress-after=60s "${ROOT}/test/e2e" -- -frpc-path="${frpcPath}" -frps-path="${frpsPath}" -log-level="${logLevel}" -debug="${debug}"

--- a/package.sh
+++ b/package.sh
@@ -2,13 +2,12 @@
 set -e
 
 # compile for version
-make
-if [ $? -ne 0 ]; then
+if ! make; then
     echo "make error"
     exit 1
 fi
 
-frp_version=`./bin/frps --version`
+frp_version="$(./bin/frps --version)"
 echo "build version: $frp_version"
 
 # cross_compiles
@@ -27,22 +26,22 @@ for os in $os_all; do
     for arch in $arch_all; do
         for extra in $extra_all; do
             suffix="${os}_${arch}"
-            if [ "x${extra}" != x"_" ]; then
+            if [ "${extra}" != "_" ]; then
                 suffix="${os}_${arch}_${extra}"
             fi
             frp_dir_name="frp_${frp_version}_${suffix}"
             frp_path="./packages/frp_${frp_version}_${suffix}"
 
-            if [ "x${os}" = x"windows" ]; then
+            if [ "${os}" = "windows" ]; then
                 if [ ! -f "./frpc_${os}_${arch}.exe" ]; then
                     continue
                 fi
                 if [ ! -f "./frps_${os}_${arch}.exe" ]; then
                     continue
                 fi
-                mkdir ${frp_path}
-                mv ./frpc_${os}_${arch}.exe ${frp_path}/frpc.exe
-                mv ./frps_${os}_${arch}.exe ${frp_path}/frps.exe
+                mkdir "${frp_path}"
+                mv "./frpc_${os}_${arch}.exe" "${frp_path}/frpc.exe"
+                mv "./frps_${os}_${arch}.exe" "${frp_path}/frps.exe"
             else
                 if [ ! -f "./frpc_${suffix}" ]; then
                     continue
@@ -50,23 +49,23 @@ for os in $os_all; do
                 if [ ! -f "./frps_${suffix}" ]; then
                     continue
                 fi
-                mkdir ${frp_path}
-                mv ./frpc_${suffix} ${frp_path}/frpc
-                mv ./frps_${suffix} ${frp_path}/frps
-            fi  
-            cp ../LICENSE ${frp_path}
-            cp -f ../conf/frpc.toml ${frp_path}
-            cp -f ../conf/frps.toml ${frp_path}
+                mkdir "${frp_path}"
+                mv "./frpc_${suffix}" "${frp_path}/frpc"
+                mv "./frps_${suffix}" "${frp_path}/frps"
+            fi
+            cp ../LICENSE "${frp_path}"
+            cp -f ../conf/frpc.toml "${frp_path}"
+            cp -f ../conf/frps.toml "${frp_path}"
 
             # packages
             cd ./packages
-            if [ "x${os}" = x"windows" ]; then
-                zip -rq ${frp_dir_name}.zip ${frp_dir_name}
+            if [ "${os}" = "windows" ]; then
+                zip -rq "${frp_dir_name}.zip" "${frp_dir_name}"
             else
-                tar -zcf ${frp_dir_name}.tar.gz ${frp_dir_name}
-            fi  
+                tar -zcf "${frp_dir_name}.tar.gz" "${frp_dir_name}"
+            fi
             cd ..
-            rm -rf ${frp_path}
+            rm -rf "${frp_path}"
         done
     done
 done


### PR DESCRIPTION
I’m not sure which shells you want to support, but for now ShellCheck supports sh, bash, dash, and ksh, and it was complaining about these issues. It doesn’t support zsh, ash, csh, or others—but most of its complaints are pretty reasonable (though you could definitely argue about that x-prefixing thing 🤷).

It’s a minor thing, I know… but I wanted to familiarize myself with the project a bit—and since I was already using a couple of these files in my own projects (not sure if I even have the permission to do that 🫣), I figured I’d fix them here too :). Feel free to ignore the pull request if it doesn’t fit.

Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?. (shellcheck SC2181) 
https://www.shellcheck.net/wiki/SC2181

Use $(...) notation instead of legacy backticks `...`. (shellcheck SC2006)
https://www.shellcheck.net/wiki/SC2006

Avoid x-prefix in comparisons as it no longer serves a purpose. (shellcheck SC2268) https://www.shellcheck.net/wiki/SC2268

Double quote to prevent globbing and word splitting.
(shellcheck SC2086)
https://www.shellcheck.net/wiki/SC2086

Double quote to prevent globbing and word splitting.
(shellcheck SC2086)
https://www.shellcheck.net/wiki/SC2086
