### PR TITLE
tcp ip address whitelist on frps server

### DIFF
--- a/conf/frps.toml
+++ b/conf/frps.toml
@@ -1,1 +1,4 @@
 bindPort = 7000
+
+# Uncomment to restrict client connections to specific IP addresses
+# allowedClientIPs = ["127.0.0.1", "192.168.1.0/24"]

--- a/conf/frps.toml
+++ b/conf/frps.toml
@@ -1,4 +1,4 @@
 bindPort = 7000
 
-# Uncomment to restrict client connections to specific IP addresses
-# allowedClientIPs = ["127.0.0.1", "192.168.1.0/24"]
+# Uncomment to restrict access to proxied services to specific IP addresses
+# allowedAccessIPs = ["127.0.0.1", "192.168.1.0/24"]

--- a/conf/frps_full_example.toml
+++ b/conf/frps_full_example.toml
@@ -133,6 +133,11 @@ allowPorts = [
 # Max ports can be used for each client, default value is 0 means no limit
 maxPortsPerClient = 0
 
+# Only allow client connections from specified IP addresses or CIDR blocks.
+# If empty, all IPs are allowed. If specified, only IPs in this list can connect.
+# Examples: ["127.0.0.1", "192.168.1.0/24", "10.0.0.0/8"]
+# allowedClientIPs = ["127.0.0.1", "192.168.1.0/24"]
+
 # If subDomainHost is not empty, you can set subdomain when type is http or https in frpc's configure file
 # When subdomain is test, the host used by routing is test.frps.com
 subDomainHost = "frps.com"

--- a/conf/frps_full_example.toml
+++ b/conf/frps_full_example.toml
@@ -133,10 +133,10 @@ allowPorts = [
 # Max ports can be used for each client, default value is 0 means no limit
 maxPortsPerClient = 0
 
-# Only allow client connections from specified IP addresses or CIDR blocks.
-# If empty, all IPs are allowed. If specified, only IPs in this list can connect.
+# Only allow access to proxied services from specified IP addresses or CIDR blocks.
+# If empty, all IPs are allowed. If specified, only IPs in this list can access proxied services.
 # Examples: ["127.0.0.1", "192.168.1.0/24", "10.0.0.0/8"]
-# allowedClientIPs = ["127.0.0.1", "192.168.1.0/24"]
+# allowedAccessIPs = ["127.0.0.1", "192.168.1.0/24"]
 
 # If subDomainHost is not empty, you can set subdomain when type is http or https in frpc's configure file
 # When subdomain is test, the host used by routing is test.frps.com

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -246,7 +246,7 @@ func RegisterServerConfigFlags(cmd *cobra.Command, c *v1.ServerConfig, opts ...R
 	cmd.PersistentFlags().StringVarP(&c.Auth.Token, "token", "t", "", "auth token")
 	cmd.PersistentFlags().StringVarP(&c.SubDomainHost, "subdomain_host", "", "", "subdomain host")
 	cmd.PersistentFlags().VarP(&PortsRangeSliceFlag{V: &c.AllowPorts}, "allow_ports", "", "allow ports")
-	cmd.PersistentFlags().StringSliceVarP(&c.AllowedClientIPs, "allowed_client_ips", "", []string{}, "allowed client IP addresses or CIDR blocks")
+	cmd.PersistentFlags().StringSliceVarP(&c.AllowedAccessIPs, "allowed_access_ips", "", []string{}, "allowed IP addresses or CIDR blocks for accessing proxied services")
 	cmd.PersistentFlags().Int64VarP(&c.MaxPortsPerClient, "max_ports_per_client", "", 0, "max ports per client")
 	cmd.PersistentFlags().BoolVarP(&c.Transport.TLS.Force, "tls_only", "", false, "frps tls only")
 

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -246,6 +246,7 @@ func RegisterServerConfigFlags(cmd *cobra.Command, c *v1.ServerConfig, opts ...R
 	cmd.PersistentFlags().StringVarP(&c.Auth.Token, "token", "t", "", "auth token")
 	cmd.PersistentFlags().StringVarP(&c.SubDomainHost, "subdomain_host", "", "", "subdomain host")
 	cmd.PersistentFlags().VarP(&PortsRangeSliceFlag{V: &c.AllowPorts}, "allow_ports", "", "allow ports")
+	cmd.PersistentFlags().StringSliceVarP(&c.AllowedClientIPs, "allowed_client_ips", "", []string{}, "allowed client IP addresses or CIDR blocks")
 	cmd.PersistentFlags().Int64VarP(&c.MaxPortsPerClient, "max_ports_per_client", "", 0, "max ports per client")
 	cmd.PersistentFlags().BoolVarP(&c.Transport.TLS.Force, "tls_only", "", false, "frps tls only")
 

--- a/pkg/config/v1/server.go
+++ b/pkg/config/v1/server.go
@@ -98,9 +98,9 @@ type ServerConfig struct {
 
 	AllowPorts []types.PortsRange `json:"allowPorts,omitempty"`
 
-	// AllowedClientIPs specifies IP addresses or CIDR blocks that are allowed to connect.
-	// If empty, all IPs are allowed. If specified, only IPs in this list can connect.
-	AllowedClientIPs []string `json:"allowedClientIPs,omitempty"`
+	// AllowedAccessIPs specifies IP addresses or CIDR blocks that are allowed to access proxied services.
+	// If empty, all IPs are allowed. If specified, only IPs in this list can access the proxied services.
+	AllowedAccessIPs []string `json:"allowedAccessIPs,omitempty"`
 
 	HTTPPlugins []HTTPPluginOptions `json:"httpPlugins,omitempty"`
 }

--- a/pkg/config/v1/server.go
+++ b/pkg/config/v1/server.go
@@ -98,6 +98,10 @@ type ServerConfig struct {
 
 	AllowPorts []types.PortsRange `json:"allowPorts,omitempty"`
 
+	// AllowedClientIPs specifies IP addresses or CIDR blocks that are allowed to connect.
+	// If empty, all IPs are allowed. If specified, only IPs in this list can connect.
+	AllowedClientIPs []string `json:"allowedClientIPs,omitempty"`
+
 	HTTPPlugins []HTTPPluginOptions `json:"httpPlugins,omitempty"`
 }
 

--- a/pkg/util/net/ip_validator.go
+++ b/pkg/util/net/ip_validator.go
@@ -1,0 +1,101 @@
+// Copyright 2023 The frp Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package net
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+type IPValidator struct {
+	allowedIPs []*net.IPNet
+}
+
+func NewIPValidator(allowedClientIPs []string) (*IPValidator, error) {
+	if len(allowedClientIPs) == 0 {
+		return &IPValidator{allowedIPs: nil}, nil
+	}
+
+	validator := &IPValidator{
+		allowedIPs: make([]*net.IPNet, 0, len(allowedClientIPs)),
+	}
+
+	for _, ipStr := range allowedClientIPs {
+		ipStr = strings.TrimSpace(ipStr)
+		if ipStr == "" {
+			continue
+		}
+
+		if strings.Contains(ipStr, "/") {
+			_, ipNet, err := net.ParseCIDR(ipStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid CIDR block %s: %v", ipStr, err)
+			}
+			validator.allowedIPs = append(validator.allowedIPs, ipNet)
+		} else {
+			ip := net.ParseIP(ipStr)
+			if ip == nil {
+				return nil, fmt.Errorf("invalid IP address: %s", ipStr)
+			}
+			
+			var ipNet *net.IPNet
+			if ip.To4() != nil {
+				ipNet = &net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)}
+			} else {
+				ipNet = &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}
+			}
+			validator.allowedIPs = append(validator.allowedIPs, ipNet)
+		}
+	}
+
+	return validator, nil
+}
+
+func (v *IPValidator) IsAllowed(ipStr string) bool {
+	if len(v.allowedIPs) == 0 {
+		return true
+	}
+
+	host, _, err := net.SplitHostPort(ipStr)
+	if err != nil {
+		host = ipStr
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+
+	for _, allowedNet := range v.allowedIPs {
+		if allowedNet.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (v *IPValidator) GetAllowedIPs() []string {
+	if len(v.allowedIPs) == 0 {
+		return []string{}
+	}
+
+	result := make([]string, len(v.allowedIPs))
+	for i, ipNet := range v.allowedIPs {
+		result[i] = ipNet.String()
+	}
+	return result
+}


### PR DESCRIPTION
# Add IP Address Whitelist for Proxied Services

## WHY

This feature addresses the need to restrict access to proxied services based on client IP addresses. Currently, FRP allows any IP to connect to proxied services once they're exposed. This creates security concerns for users who want to limit access to specific IP ranges or trusted networks.

### Configuration Options:

**TOML Configuration:**
```toml
# frps.toml
bindPort = 7000
allowedAccessIPs = ["127.0.0.1", "192.168.1.0/24", "10.0.0.0/8"]
```

**Command Line:**
```bash
./frps --allowed-access-ips 127.0.0.1,192.168.1.0/24
```

## Breaking Changes
None - this is a backward compatible feature that defaults to allowing all IPs when not configured.