### PR TITLE
add proxy name label to the proxy_count prometheus metric

### DIFF
--- a/pkg/metrics/prometheus/server.go
+++ b/pkg/metrics/prometheus/server.go
@@ -74,7 +74,7 @@ func newServerMetrics() *serverMetrics {
 			Namespace: namespace,
 			Subsystem: serverSubsystem,
 			Name:      "proxy_counts_detailed",
-			Help:      "The current proxy counts with proxy name label",
+			Help:      "The current number of proxies grouped by type and name",
 		}, []string{"type", "name"}),
 		connectionCount: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: namespace,


### PR DESCRIPTION
### WHY

In my use case, I have many different frpc binaries connecting to the same frps binary. Each frpc binary has a unique proxy name configured.

For this reason, it is useful to know which proxy (i.e. worker/control connection) is active. Without this PR, I can only know how many proxies are connected, but not which ones.

Fix #4986
