### PR TITLE
add default config path (-c) for Dockerfiles

### DIFF
--- a/dockerfiles/Dockerfile-for-frpc
+++ b/dockerfiles/Dockerfile-for-frpc
@@ -12,3 +12,5 @@ RUN apk add --no-cache tzdata
 COPY --from=building /building/bin/frpc /usr/bin/frpc
 
 ENTRYPOINT ["/usr/bin/frpc"]
+
+CMD ["-c" "/etc/frp/frpc.toml"]

--- a/dockerfiles/Dockerfile-for-frps
+++ b/dockerfiles/Dockerfile-for-frps
@@ -12,3 +12,5 @@ RUN apk add --no-cache tzdata
 COPY --from=building /building/bin/frps /usr/bin/frps
 
 ENTRYPOINT ["/usr/bin/frps"]
+
+CMD ["-c" "/etc/frp/frps.toml"]


### PR DESCRIPTION
The `Dockerfiles` do not contain a default config file (`-c`). When use `docker-compose.yml`, you must config `command: ["-c", "/etc/frp/frps.toml"]`, this sucks.

Add this to default, and then  become much more clearer.
```
services:
  frps:
    container_name: frps
    image: ghcr.io/fatedier/frps:v0.65.0
    restart: always
    volumes:
      - ./frps.toml:/etc/frp/frps.toml
    ports:
      - "7000:7000"
 ```

```
services:
  frpc:
    container_name: frpc
    image: ghcr.io/fatedier/frpc:v0.65.0
    restart: always
    volumes:
      - ./frpc.toml:/etc/frp/frpc.toml
    ports:
      - "7400:7400"
```

   