### PR TITLE
Fix CloseNotifyConn.Close function

### DIFF
--- a/pkg/util/net/conn.go
+++ b/pkg/util/net/conn.go
@@ -149,7 +149,7 @@ func WrapCloseNotifyConn(c net.Conn, closeFn func()) net.Conn {
 func (cc *CloseNotifyConn) Close() (err error) {
 	pflag := atomic.SwapInt32(&cc.closeFlag, 1)
 	if pflag == 0 {
-		err = cc.Close()
+		err = cc.Conn.Close()
 		if cc.closeFn != nil {
 			cc.closeFn()
 		}


### PR DESCRIPTION
### WHY

The `CloseNotifyConn.Close` function calls itself if the `closeFlag` is equal to `0` which would mean it would immediately swap the `closeFlag` value to `1` and never call `closeFn`.  It is unclear what the intent of this call to `cc.Close()` was but I assume it was meant to be a call to close the Conn object instead.