### PR TITLE
Print detailed information about connection termination to enable external programmes to track connection status from the log

### DIFF
--- a/server/proxy/proxy.go
+++ b/server/proxy/proxy.go
@@ -258,8 +258,12 @@ func (pxy *BaseProxy) handleUserTCPConnection(userConn net.Conn) {
 		})
 	}
 
-	xl.Debugf("join connections, workConn(l[%s] r[%s]) userConn(l[%s] r[%s])", workConn.LocalAddr().String(),
-		workConn.RemoteAddr().String(), userConn.LocalAddr().String(), userConn.RemoteAddr().String())
+	workConnLocal := workConn.LocalAddr(). String()
+	workConnRemote := workConn.RemoteAddr(). String()
+	userConnLocal := userConn.LocalAddr().String()
+	userConnRemote := userConn.RemoteAddr().String()
+	xl.Debugf("join connections, workConn(l[%s] r[%s]) userConn(l[%s] r[%s])", 
+	    workConnLocal, workConnRemote, userConnLocal, userConnRemote)
 
 	name := pxy.GetName()
 	proxyType := cfg.Type
@@ -268,7 +272,9 @@ func (pxy *BaseProxy) handleUserTCPConnection(userConn net.Conn) {
 	metrics.Server.CloseConnection(name, proxyType)
 	metrics.Server.AddTrafficIn(name, proxyType, inCount)
 	metrics.Server.AddTrafficOut(name, proxyType, outCount)
-	xl.Debugf("join connections closed")
+	
+	xl.Debugf("join connections closed, workConn(l[%s] r[%s]) userConn(l[%s] r[%s])", 
+    	workConnLocal, workConnRemote, userConnLocal, userConnRemote)
 }
 
 type Options struct {


### PR DESCRIPTION
### WHY

<!-- author to complete -->
Currently, frps only prints detailed connection information upon connection establishment, whereas when  the connection is closed it merely displays `join connections closed`. 

This hinders external programmes such as fail2ban from tracking connection lifecycles effectively. This pull request will enable connection information to be printed upon termination as well, facilitating the tracking of connections.