### PR TITLE
udp: fix proxy protocol header sent on every packet instead of first packet only

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -2,3 +2,7 @@
 
 * frpc now supports a `clientID` option to uniquely identify client instances. The server dashboard displays all connected clients with their online/offline status, connection history, and metadata, making it easier to monitor and manage multiple frpc deployments.
 * Redesigned the frps web dashboard with a modern UI, dark mode support, and improved navigation.
+
+## Fixes
+
+* Fixed UDP proxy protocol sending header on every packet instead of only the first packet of each session.

--- a/pkg/proto/udp/udp.go
+++ b/pkg/proto/udp/udp.go
@@ -124,8 +124,8 @@ func Forwarder(dstAddr *net.UDPAddr, readCh <-chan *msg.UDPPacket, sendCh chan<-
 			}
 			mu.Unlock()
 
-			// Add proxy protocol header if configured
-			if proxyProtocolVersion != "" && udpMsg.RemoteAddr != nil {
+			// Add proxy protocol header if configured (only for the first packet of a new connection)
+			if !ok && proxyProtocolVersion != "" && udpMsg.RemoteAddr != nil {
 				ppBuf, err := netpkg.BuildProxyProtocolHeader(udpMsg.RemoteAddr, dstAddr, proxyProtocolVersion)
 				if err == nil {
 					// Prepend proxy protocol header to the UDP payload


### PR DESCRIPTION
### WHY

FIx #5102
