### PR TITLE
feat: Add ProxyStarted webhook event for dynamic port notification

### DIFF
--- a/doc/server_plugin.md
+++ b/doc/server_plugin.md
@@ -70,7 +70,7 @@ The response can look like any of the following:
 
 ### Operation
 
-Currently `Login`, `NewProxy`, `CloseProxy`, `Ping`, `NewWorkConn` and `NewUserConn` operations are supported.
+Currently `Login`, `NewProxy`, `ProxyStarted`, `CloseProxy`, `Ping`, `NewWorkConn` and `NewUserConn` operations are supported.
 
 #### Login
 
@@ -134,6 +134,28 @@ Create new proxy
         "multiplexer": <string>
 
         "metas": map<string>string
+    }
+}
+```
+
+#### ProxyStarted
+
+Proxy has been successfully started and port allocation is complete. This event is sent **after** the proxy is running,
+so it includes the actual allocated port (which may differ from the requested port when `remotePort=0`).
+
+This is a notification-only event - plugins cannot reject or modify the content since the proxy is already running.
+
+```
+{
+    "content": {
+        "user": {
+            "user": <string>,
+            "metas": map<string>string
+            "run_id": <string>
+        },
+        "proxy_name": <string>,
+        "proxy_type": <string>,
+        "remote_addr": <string>  // The actual allocated address, e.g., ":6000"
     }
 }
 ```

--- a/pkg/config/v1/validation/validation.go
+++ b/pkg/config/v1/validation/validation.go
@@ -51,6 +51,7 @@ var (
 	SupportedHTTPPluginOps = []string{
 		splugin.OpLogin,
 		splugin.OpNewProxy,
+		splugin.OpProxyStarted,
 		splugin.OpCloseProxy,
 		splugin.OpPing,
 		splugin.OpNewWorkConn,

--- a/pkg/plugin/server/plugin.go
+++ b/pkg/plugin/server/plugin.go
@@ -21,12 +21,13 @@ import (
 const (
 	APIVersion = "0.1.0"
 
-	OpLogin       = "Login"
-	OpNewProxy    = "NewProxy"
-	OpCloseProxy  = "CloseProxy"
-	OpPing        = "Ping"
-	OpNewWorkConn = "NewWorkConn"
-	OpNewUserConn = "NewUserConn"
+	OpLogin        = "Login"
+	OpNewProxy     = "NewProxy"
+	OpProxyStarted = "ProxyStarted"
+	OpCloseProxy   = "CloseProxy"
+	OpPing         = "Ping"
+	OpNewWorkConn  = "NewWorkConn"
+	OpNewUserConn  = "NewUserConn"
 )
 
 type Plugin interface {

--- a/pkg/plugin/server/types.go
+++ b/pkg/plugin/server/types.go
@@ -69,3 +69,13 @@ type NewUserConnContent struct {
 	ProxyType  string   `json:"proxy_type"`
 	RemoteAddr string   `json:"remote_addr"`
 }
+
+// ProxyStartedContent is sent after a proxy has been successfully started
+// and port allocation is complete. This includes the actual allocated port
+// which may differ from the requested port (e.g., when remotePort=0).
+type ProxyStartedContent struct {
+	User       UserInfo `json:"user"`
+	ProxyName  string   `json:"proxy_name"`
+	ProxyType  string   `json:"proxy_type"`
+	RemoteAddr string   `json:"remote_addr"` // The actual allocated address (e.g., ":6000")
+}


### PR DESCRIPTION
## Summary

Add a new `ProxyStarted` server plugin webhook event that fires **after** a proxy has been successfully started and port allocation is complete.

## Problem

The existing `NewProxy` webhook event fires **before** port allocation occurs. This means:
- When using `remotePort = 0` for dynamic port allocation, the webhook only receives `remote_port: 0`
- External systems cannot know the actual allocated port via webhooks
- Users must poll the admin API or wait for `NewUserConn` events to discover the negotiated port

## Solution

Add a new `ProxyStarted` webhook event that:
- Fires immediately after successful proxy registration and port allocation
- Includes `remote_addr` with the actual allocated port (e.g., `:10000`)
- Is a notification-only event (fire and forget) - plugins cannot reject since the proxy is already running
- Follows the same pattern as `CloseProxy` for consistency

## Use Cases

1. **Service Discovery**: Register dynamically allocated ports with service discovery systems (Consul, etcd, etc.)
2. **DNS Updates**: Automatically update DNS records when proxies start
3. **Monitoring**: Track proxy lifecycle with actual port information
4. **Audit Logging**: Complete audit trail including negotiated ports

## Changes

- `pkg/plugin/server/types.go` - Add `ProxyStartedContent` type
- `pkg/plugin/server/plugin.go` - Add `OpProxyStarted` constant  
- `pkg/plugin/server/manager.go` - Add `proxyStartedPlugins` slice and `ProxyStarted()` method
- `pkg/config/v1/validation/validation.go` - Add `ProxyStarted` to `SupportedHTTPPluginOps`
- `server/control.go` - Call `ProxyStarted` webhook after successful proxy registration
- `doc/server_plugin.md` - Update documentation

## Configuration

```toml
# frps.toml
[[httpPlugins]]
name = "port-notifier"
addr = "127.0.0.1:9000"
path = "/handler"
ops = ["ProxyStarted"]
```

## Webhook Payload

```json
{
    "version": "0.1.0",
    "op": "ProxyStarted",
    "content": {
        "user": {
            "user": "myuser",
            "metas": {"key": "value"},
            "run_id": "abc123"
        },
        "proxy_name": "my-tcp-proxy",
        "proxy_type": "tcp",
        "remote_addr": ":10000"
    }
}
```

## Comparison: NewProxy vs ProxyStarted

| Event | When Fired | `remote_port` / `remote_addr` | Can Reject? |
|-------|------------|-------------------------------|-------------|
| `NewProxy` | Before port allocation | Requested port (may be 0) | Yes |
| `ProxyStarted` | After port allocation | Actual allocated port | No |

## Backward Compatibility

This is a purely additive change:
- No existing behavior is modified
- New event is opt-in via plugin configuration
- Existing plugins continue to work unchanged