### PR TITLE
fix: respect explicit transport.tls.force = false when trustedCaFile is set

### DIFF
--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -248,7 +248,7 @@ func RegisterServerConfigFlags(cmd *cobra.Command, c *v1.ServerConfig, opts ...R
 	cmd.PersistentFlags().StringVarP(&c.SubDomainHost, "subdomain_host", "", "", "subdomain host")
 	cmd.PersistentFlags().VarP(&PortsRangeSliceFlag{V: &c.AllowPorts}, "allow_ports", "", "allow ports")
 	cmd.PersistentFlags().Int64VarP(&c.MaxPortsPerClient, "max_ports_per_client", "", 0, "max ports per client")
-	cmd.PersistentFlags().BoolVarP(&c.Transport.TLS.Force, "tls_only", "", false, "frps tls only")
+	c.Transport.TLS.Force = cmd.PersistentFlags().BoolP("tls_only", "", false, "frps tls only")
 
 	webServerTLS := v1.TLSConfig{}
 	cmd.PersistentFlags().StringVarP(&webServerTLS.CertFile, "dashboard_tls_cert_file", "", "", "dashboard tls cert file")

--- a/pkg/config/legacy/conversion.go
+++ b/pkg/config/legacy/conversion.go
@@ -147,7 +147,7 @@ func Convert_ServerCommonConf_To_v1(conf *ServerCommonConf) *v1.ServerConfig {
 	out.Transport.MaxPoolCount = conf.MaxPoolCount
 	out.Transport.HeartbeatTimeout = conf.HeartbeatTimeout
 
-	out.Transport.TLS.Force = conf.TLSOnly
+	out.Transport.TLS.Force = lo.ToPtr(conf.TLSOnly)
 	out.Transport.TLS.CertFile = conf.TLSCertFile
 	out.Transport.TLS.KeyFile = conf.TLSKeyFile
 	out.Transport.TLS.TrustedCaFile = conf.TLSTrustedCaFile

--- a/pkg/config/v1/server.go
+++ b/pkg/config/v1/server.go
@@ -191,14 +191,14 @@ func (c *ServerTransportConfig) Complete() {
 		c.HeartbeatTimeout = util.EmptyOr(c.HeartbeatTimeout, 90)
 	}
 	c.QUIC.Complete()
-	if c.TLS.TrustedCaFile != "" {
-		c.TLS.Force = true
+	if c.TLS.TrustedCaFile != "" && c.TLS.Force == nil {
+		c.TLS.Force = lo.ToPtr(true)
 	}
 }
 
 type TLSServerConfig struct {
 	// Force specifies whether to only accept TLS-encrypted connections.
-	Force bool `json:"force,omitempty"`
+	Force *bool `json:"force,omitempty"`
 
 	TLSConfig
 }

--- a/pkg/config/v1/server_test.go
+++ b/pkg/config/v1/server_test.go
@@ -32,6 +32,49 @@ func TestServerConfigComplete(t *testing.T) {
 	require.Equal(true, lo.FromPtr(c.DetailedErrorsToClient))
 }
 
+func TestServerConfigComplete_TLSForceWithTrustedCaFile(t *testing.T) {
+	// Test: When TrustedCaFile is set and Force is nil, Force should default to true
+	t.Run("default Force to true when trustedCaFile set and Force is nil", func(t *testing.T) {
+		require := require.New(t)
+		c := &ServerConfig{}
+		c.Transport.TLS.TrustedCaFile = "/path/to/ca.crt"
+		err := c.Complete()
+		require.NoError(err)
+		require.Equal(true, lo.FromPtr(c.Transport.TLS.Force))
+	})
+
+	// Test: When TrustedCaFile is set but Force is explicitly set to false, preserve false
+	t.Run("preserve explicit Force=false with trustedCaFile", func(t *testing.T) {
+		require := require.New(t)
+		c := &ServerConfig{}
+		c.Transport.TLS.TrustedCaFile = "/path/to/ca.crt"
+		c.Transport.TLS.Force = lo.ToPtr(false) // Explicitly set to false
+		err := c.Complete()
+		require.NoError(err)
+		require.Equal(false, lo.FromPtr(c.Transport.TLS.Force))
+	})
+
+	// Test: When TrustedCaFile is set and Force is explicitly set to true, preserve true
+	t.Run("preserve explicit Force=true with trustedCaFile", func(t *testing.T) {
+		require := require.New(t)
+		c := &ServerConfig{}
+		c.Transport.TLS.TrustedCaFile = "/path/to/ca.crt"
+		c.Transport.TLS.Force = lo.ToPtr(true) // Explicitly set to true
+		err := c.Complete()
+		require.NoError(err)
+		require.Equal(true, lo.FromPtr(c.Transport.TLS.Force))
+	})
+
+	// Test: When TrustedCaFile is NOT set, Force should remain nil (default)
+	t.Run("Force remains nil when no trustedCaFile", func(t *testing.T) {
+		require := require.New(t)
+		c := &ServerConfig{}
+		err := c.Complete()
+		require.NoError(err)
+		require.Nil(c.Transport.TLS.Force)
+	})
+}
+
 func TestAuthServerConfig_Complete(t *testing.T) {
 	require := require.New(t)
 	cfg := &AuthServerConfig{}
@@ -39,3 +82,4 @@ func TestAuthServerConfig_Complete(t *testing.T) {
 	require.NoError(err)
 	require.EqualValues("token", cfg.Method)
 }
+

--- a/server/api/controller.go
+++ b/server/api/controller.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/samber/lo"
+
 	"github.com/fatedier/frp/pkg/config/types"
 	v1 "github.com/fatedier/frp/pkg/config/v1"
 	"github.com/fatedier/frp/pkg/metrics/mem"
@@ -72,7 +74,7 @@ func (c *Controller) APIServerInfo(ctx *httppkg.Context) (any, error) {
 		MaxPortsPerClient:     c.serverCfg.MaxPortsPerClient,
 		HeartBeatTimeout:      c.serverCfg.Transport.HeartbeatTimeout,
 		AllowPortsStr:         types.PortsRangeSlice(c.serverCfg.AllowPorts).String(),
-		TLSForce:              c.serverCfg.Transport.TLS.Force,
+		TLSForce:              lo.FromPtr(c.serverCfg.Transport.TLS.Force),
 
 		TotalTrafficIn:  serverStats.TotalTrafficIn,
 		TotalTrafficOut: serverStats.TotalTrafficOut,

--- a/server/service.go
+++ b/server/service.go
@@ -514,7 +514,7 @@ func (svr *Service) HandleListener(l net.Listener, internal bool) {
 		if !internal {
 			log.Tracef("start check TLS connection...")
 			originConn := c
-			forceTLS := svr.cfg.Transport.TLS.Force
+			forceTLS := lo.FromPtr(svr.cfg.Transport.TLS.Force)
 			var isTLS, custom bool
 			c, isTLS, custom, err = netpkg.CheckAndEnableTLSServerConnWithTimeout(c, svr.tlsConfig, forceTLS, connReadTimeout)
 			if err != nil {


### PR DESCRIPTION
### WHY

Fixes #5131

When `transport.tls.force = false` is explicitly set in `frps.toml` alongside `transport.tls.trustedCaFile`, the server incorrectly rejected non-TLS connections.

### Root Cause

In `ServerTransportConfig.Complete()`, the code unconditionally set `Force = true` whenever `TrustedCaFile` was configured, ignoring the user's explicit setting.

### Solution

Changed `TLSServerConfig.Force` from `bool` to `*bool` to distinguish between unset (nil) and explicitly set false. Now the default is only applied when `Force` is nil.

### Changes

- `pkg/config/v1/server.go` - Changed `Force` type and fixed `Complete()`
- `pkg/config/flags.go` - Updated CLI flag binding
- `pkg/config/legacy/conversion.go` - Use `lo.ToPtr()` for conversion
- `server/api/controller.go` - Use `lo.FromPtr()` for API response  
- `server/service.go` - Use `lo.FromPtr()` for TLS check
- `pkg/config/v1/server_test.go` - Added 4 test cases

### Backward Compatibility

Fully backward compatible - only the explicit `force = false` case is now respected.
