### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       # environment
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: '0'
 
@@ -61,7 +61,7 @@ jobs:
           echo "TAG_FRPS_GPR=ghcr.io/fatedier/frps:${{ env.TAG_NAME }}" >> $GITHUB_ENV
 
       - name: Build and push frpc
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./dockerfiles/Dockerfile-for-frpc
@@ -72,7 +72,7 @@ jobs:
             ${{ env.TAG_FRPC_GPR }}
 
       - name: Build and push frps
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./dockerfiles/Dockerfile-for-frps

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,13 +14,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-go@v6
       with:
         go-version: '1.24'
         cache: false
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v8
+      uses: golangci/golangci-lint-action@v9
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: v2.3

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24'
           

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
       actions: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@v10
       with:
         stale-issue-message: 'Issues go stale after 14d of inactivity. Stale issues rot after an additional 3d of inactivity and eventually close.'
         stale-pr-message: "PRs go stale after 14d of inactivity. Stale PRs rot after an additional 3d of inactivity and eventually close."


### PR DESCRIPTION
### WHY  
This PR updates outdated GitHub Action versions to ensure compatibility with the latest features and security patches. The changes include:  

- Updated `actions/setup-go` from `v5` to `v6` in `.github/workflows/goreleaser.yml`  
- Updated `actions/stale` from `v9` to `v10` in `.github/workflows/stale.yml`  
- Updated `docker/build-push-action` from `v5` to `v6` in `.github/workflows/build-and-push-image.yml`  
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/goreleaser.yml`  
- Updated `golangci/golangci-lint-action` from `v8` to `v9` in `.github/workflows/golangci-lint.yml`  
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/build-and-push-image.yml`  
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/golangci-lint.yml`  
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/golangci-lint.yml`  

These updates ensure that workflows use the latest and most secure versions of GitHub Actions. The changes will be tested in the CI pipeline of the pull request.