### PR TITLE
feat: add configurable websocket path support

### DIFF
--- a/client/connector.go
+++ b/client/connector.go
@@ -179,7 +179,7 @@ func (c *defaultConnectorImpl) realConnect() (net.Conn, error) {
 	switch protocol {
 	case "websocket":
 		protocol = "tcp"
-		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{Hook: netpkg.DialHookWebsocket(protocol, "")}))
+		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{Hook: netpkg.DialHookWebsocket(protocol, "", c.cfg.Transport.WebsocketPath)}))
 		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{
 			Hook: netpkg.DialHookCustomTLSHeadByte(tlsConfig != nil, lo.FromPtr(c.cfg.Transport.TLS.DisableCustomTLSFirstByte)),
 		}))
@@ -188,7 +188,7 @@ func (c *defaultConnectorImpl) realConnect() (net.Conn, error) {
 		protocol = "tcp"
 		dialOptions = append(dialOptions, libnet.WithTLSConfigAndPriority(100, tlsConfig))
 		// Make sure that if it is wss, the websocket hook is executed after the tls hook.
-		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{Hook: netpkg.DialHookWebsocket(protocol, tlsConfig.ServerName), Priority: 110}))
+		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{Hook: netpkg.DialHookWebsocket(protocol, tlsConfig.ServerName, c.cfg.Transport.WebsocketPath), Priority: 110}))
 	default:
 		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{
 			Hook: netpkg.DialHookCustomTLSHeadByte(tlsConfig != nil, lo.FromPtr(c.cfg.Transport.TLS.DisableCustomTLSFirstByte)),

--- a/conf/frpc_full_example.toml
+++ b/conf/frpc_full_example.toml
@@ -136,6 +136,11 @@ transport.tls.enable = true
 # transport.heartbeatInterval = 30
 # transport.heartbeatTimeout = 90
 
+# Websocket path for connecting to server.
+# By default, this value is "/~!frp".
+# This should be the same as server's websocketPath configuration.
+# transport.websocketPath = "/~!frp"
+
 # Specify a dns server, so frpc will use this instead of default one
 # dnsServer = "8.8.8.8"
 

--- a/conf/frps_full_example.toml
+++ b/conf/frps_full_example.toml
@@ -148,6 +148,10 @@ udpPacketSize = 1500
 # Retention time for NAT hole punching strategy data.
 natholeAnalysisDataReserveHours = 168
 
+# Websocket path for client connections.
+# By default, this value is "/~!frp".
+# websocketPath = "/~!frp"
+
 # ssh tunnel gateway
 # If you want to enable this feature, the bindPort parameter is required, while others are optional.
 # By default, this feature is disabled. It will be enabled if bindPort is greater than 0.

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -165,6 +165,7 @@ func RegisterClientCommonConfigFlags(cmd *cobra.Command, c *v1.ClientCommonConfi
 		cmd.PersistentFlags().StringVarP(&c.Transport.TLS.ServerName, "tls_server_name", "", "", "specify the custom server name of tls certificate")
 		cmd.PersistentFlags().StringVarP(&c.DNSServer, "dns_server", "", "", "specify dns server instead of using system default one")
 		c.Transport.TLS.Enable = cmd.PersistentFlags().BoolP("tls_enable", "", true, "enable frpc tls")
+		cmd.PersistentFlags().StringVarP(&c.Transport.WebsocketPath, "websocket_path", "", "/~!frp", "websocket path")
 	}
 	cmd.PersistentFlags().StringVarP(&c.User, "user", "u", "", "user")
 	cmd.PersistentFlags().StringVarP(&c.Auth.Token, "token", "t", "", "auth token")
@@ -248,6 +249,7 @@ func RegisterServerConfigFlags(cmd *cobra.Command, c *v1.ServerConfig, opts ...R
 	cmd.PersistentFlags().VarP(&PortsRangeSliceFlag{V: &c.AllowPorts}, "allow_ports", "", "allow ports")
 	cmd.PersistentFlags().Int64VarP(&c.MaxPortsPerClient, "max_ports_per_client", "", 0, "max ports per client")
 	cmd.PersistentFlags().BoolVarP(&c.Transport.TLS.Force, "tls_only", "", false, "frps tls only")
+	cmd.PersistentFlags().StringVarP(&c.WebsocketPath, "websocket_path", "", "/~!frp", "websocket path")
 
 	webServerTLS := v1.TLSConfig{}
 	cmd.PersistentFlags().StringVarP(&webServerTLS.CertFile, "dashboard_tls_cert_file", "", "", "dashboard tls cert file")

--- a/pkg/config/v1/client.go
+++ b/pkg/config/v1/client.go
@@ -136,6 +136,9 @@ type ClientTransportConfig struct {
 	HeartbeatTimeout int64 `json:"heartbeatTimeout,omitempty"`
 	// TLS specifies TLS settings for the connection to the server.
 	TLS TLSClientConfig `json:"tls,omitempty"`
+	// WebsocketPath specifies the path for websocket connections.
+	// By default, this value is "/~!frp".
+	WebsocketPath string `json:"websocketPath,omitempty"`
 }
 
 func (c *ClientTransportConfig) Complete() {
@@ -156,6 +159,7 @@ func (c *ClientTransportConfig) Complete() {
 	}
 	c.QUIC.Complete()
 	c.TLS.Complete()
+	c.WebsocketPath = util.EmptyOr(c.WebsocketPath, "/~!frp")
 }
 
 type TLSClientConfig struct {

--- a/pkg/config/v1/server.go
+++ b/pkg/config/v1/server.go
@@ -99,6 +99,9 @@ type ServerConfig struct {
 	AllowPorts []types.PortsRange `json:"allowPorts,omitempty"`
 
 	HTTPPlugins []HTTPPluginOptions `json:"httpPlugins,omitempty"`
+	// WebsocketPath specifies the path for websocket connections.
+	// By default, this value is "/~!frp".
+	WebsocketPath string `json:"websocketPath,omitempty"`
 }
 
 func (c *ServerConfig) Complete() error {
@@ -125,6 +128,7 @@ func (c *ServerConfig) Complete() error {
 	c.UserConnTimeout = util.EmptyOr(c.UserConnTimeout, 10)
 	c.UDPPacketSize = util.EmptyOr(c.UDPPacketSize, 1500)
 	c.NatHoleAnalysisDataReserveHours = util.EmptyOr(c.NatHoleAnalysisDataReserveHours, 7*24)
+	c.WebsocketPath = util.EmptyOr(c.WebsocketPath, "/~!frp")
 	return nil
 }
 

--- a/pkg/util/net/dial.go
+++ b/pkg/util/net/dial.go
@@ -21,7 +21,7 @@ func DialHookCustomTLSHeadByte(enableTLS bool, disableCustomTLSHeadByte bool) li
 	}
 }
 
-func DialHookWebsocket(protocol string, host string) libnet.AfterHookFunc {
+func DialHookWebsocket(protocol string, host string, path string) libnet.AfterHookFunc {
 	return func(ctx context.Context, c net.Conn, addr string) (context.Context, net.Conn, error) {
 		if protocol != "wss" {
 			protocol = "ws"
@@ -29,7 +29,10 @@ func DialHookWebsocket(protocol string, host string) libnet.AfterHookFunc {
 		if host == "" {
 			host = addr
 		}
-		addr = protocol + "://" + host + FrpWebsocketPath
+		if path == "" {
+			path = FrpWebsocketPath
+		}
+		addr = protocol + "://" + host + path
 		uri, err := url.Parse(addr)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/util/net/websocket.go
+++ b/pkg/util/net/websocket.go
@@ -11,9 +11,13 @@ import (
 
 var ErrWebsocketListenerClosed = errors.New("websocket listener closed")
 
-const (
+var (
 	FrpWebsocketPath = "/~!frp"
 )
+
+func SetFrpWebsocketPath(path string) {
+	FrpWebsocketPath = path
+}
 
 type WebsocketListener struct {
 	ln       net.Listener

--- a/server/service.go
+++ b/server/service.go
@@ -270,7 +270,8 @@ func NewService(cfg *v1.ServerConfig) (*Service, error) {
 	}
 
 	// Listen for accepting connections from client using websocket protocol.
-	websocketPrefix := []byte("GET " + netpkg.FrpWebsocketPath)
+	netpkg.SetFrpWebsocketPath(cfg.WebsocketPath)
+	websocketPrefix := []byte("GET " + cfg.WebsocketPath)
 	websocketLn := svr.muxer.Listen(0, uint32(len(websocketPrefix)), func(data []byte) bool {
 		return bytes.Equal(data, websocketPrefix)
 	})


### PR DESCRIPTION
- Add websocketPath configuration option in server and client config
- Add --websocket_path command line parameter for both frps and frpc
- Modify DialHookWebsocket to accept custom path parameter
- Update server to use configured path for websocket connections
- Maintain backward compatibility with default path /~!frp

Closes #XXXX

### WHY

<!-- author to complete -->
