### PR TITLE
pkg/msg: change UDPPacket.Content from string to []byte to avoid redundant base64 encode/decode

### DIFF
--- a/client/proxy/udp.go
+++ b/client/proxy/udp.go
@@ -129,7 +129,7 @@ func (pxy *UDPProxy) InWorkConn(conn net.Conn, _ *msg.StartWorkConn) {
 				return
 			}
 			if errRet := errors.PanicToError(func() {
-				xl.Tracef("get udp package from workConn: %s", udpMsg.Content)
+				xl.Tracef("get udp package from workConn, len: %d", len(udpMsg.Content))
 				readCh <- &udpMsg
 			}); errRet != nil {
 				xl.Infof("reader goroutine for udp work connection closed: %v", errRet)
@@ -145,7 +145,7 @@ func (pxy *UDPProxy) InWorkConn(conn net.Conn, _ *msg.StartWorkConn) {
 		for rawMsg := range sendCh {
 			switch m := rawMsg.(type) {
 			case *msg.UDPPacket:
-				xl.Tracef("send udp package to workConn: %s", m.Content)
+				xl.Tracef("send udp package to workConn, len: %d", len(m.Content))
 			case *msg.Ping:
 				xl.Tracef("send ping message to udp workConn")
 			}

--- a/client/visitor/sudp.go
+++ b/client/visitor/sudp.go
@@ -147,7 +147,7 @@ func (sv *SUDPVisitor) worker(workConn net.Conn, firstPacket *msg.UDPPacket) {
 			case *msg.UDPPacket:
 				if errRet := errors.PanicToError(func() {
 					sv.readCh <- m
-					xl.Tracef("frpc visitor get udp packet from workConn: %s", m.Content)
+					xl.Tracef("frpc visitor get udp packet from workConn, len: %d", len(m.Content))
 				}); errRet != nil {
 					xl.Infof("reader goroutine for udp work connection closed")
 					return
@@ -169,7 +169,7 @@ func (sv *SUDPVisitor) worker(workConn net.Conn, firstPacket *msg.UDPPacket) {
 				xl.Warnf("sender goroutine for udp work connection closed: %v", errRet)
 				return
 			}
-			xl.Tracef("send udp package to workConn: %s", firstPacket.Content)
+			xl.Tracef("send udp package to workConn, len: %d", len(firstPacket.Content))
 		}
 
 		for {
@@ -184,7 +184,7 @@ func (sv *SUDPVisitor) worker(workConn net.Conn, firstPacket *msg.UDPPacket) {
 					xl.Warnf("sender goroutine for udp work connection closed: %v", errRet)
 					return
 				}
-				xl.Tracef("send udp package to workConn: %s", udpMsg.Content)
+				xl.Tracef("send udp package to workConn, len: %d", len(udpMsg.Content))
 			case <-closeCh:
 				return
 			}

--- a/pkg/msg/msg.go
+++ b/pkg/msg/msg.go
@@ -184,7 +184,7 @@ type Pong struct {
 }
 
 type UDPPacket struct {
-	Content    string       `json:"c,omitempty"`
+	Content    []byte       `json:"c,omitempty"`
 	LocalAddr  *net.UDPAddr `json:"l,omitempty"`
 	RemoteAddr *net.UDPAddr `json:"r,omitempty"`
 }

--- a/pkg/proto/udp/udp.go
+++ b/pkg/proto/udp/udp.go
@@ -15,7 +15,6 @@
 package udp
 
 import (
-	"encoding/base64"
 	"net"
 	"sync"
 	"time"
@@ -28,16 +27,17 @@ import (
 )
 
 func NewUDPPacket(buf []byte, laddr, raddr *net.UDPAddr) *msg.UDPPacket {
+	content := make([]byte, len(buf))
+	copy(content, buf)
 	return &msg.UDPPacket{
-		Content:    base64.StdEncoding.EncodeToString(buf),
+		Content:    content,
 		LocalAddr:  laddr,
 		RemoteAddr: raddr,
 	}
 }
 
 func GetContent(m *msg.UDPPacket) (buf []byte, err error) {
-	buf, err = base64.StdEncoding.DecodeString(m.Content)
-	return
+	return m.Content, nil
 }
 
 func ForwardUserConn(udpConn *net.UDPConn, readCh <-chan *msg.UDPPacket, sendCh chan<- *msg.UDPPacket, bufSize int) {
@@ -60,7 +60,7 @@ func ForwardUserConn(udpConn *net.UDPConn, readCh <-chan *msg.UDPPacket, sendCh 
 		if err != nil {
 			return
 		}
-		// buf[:n] will be encoded to string, so the bytes can be reused
+		// NewUDPPacket copies buf[:n], so the read buffer can be reused
 		udpMsg := NewUDPPacket(buf[:n], nil, remoteAddr)
 
 		select {

--- a/server/proxy/udp.go
+++ b/server/proxy/udp.go
@@ -136,7 +136,7 @@ func (pxy *UDPProxy) Run() (remoteAddr string, err error) {
 				continue
 			case *msg.UDPPacket:
 				if errRet := errors.PanicToError(func() {
-					xl.Tracef("get udp message from workConn: %s", m.Content)
+					xl.Tracef("get udp message from workConn, len: %d", len(m.Content))
 					pxy.readCh <- m
 					metrics.Server.AddTrafficOut(
 						pxy.GetName(),
@@ -167,7 +167,7 @@ func (pxy *UDPProxy) Run() (remoteAddr string, err error) {
 					conn.Close()
 					return
 				}
-				xl.Tracef("send message to udp workConn: %s", udpMsg.Content)
+				xl.Tracef("send message to udp workConn, len: %d", len(udpMsg.Content))
 				metrics.Server.AddTrafficIn(
 					pxy.GetName(),
 					pxy.GetConfigurer().GetBaseConfig().Type,


### PR DESCRIPTION
## Summary

- Change `UDPPacket.Content` field type from `string` to `[]byte`, removing the manual `base64.StdEncoding.EncodeToString/DecodeString` calls in the UDP proxy data path.
- Go's `encoding/json` automatically handles `[]byte` as base64, so the wire format is unchanged — fully compatible with older versions.
- Update trace logs from printing raw content to printing `len(Content)` to avoid logging binary data.

## Motivation

Every UDP packet previously went through a redundant encoding cycle: manual base64 encode → JSON marshal (which would handle `[]byte` natively) → JSON unmarshal → manual base64 decode. This change eliminates the intermediate string allocation and explicit base64 encode/decode, reducing GC pressure on the hot path.

## Test plan

- [x] `make build` — compiles successfully
- [x] `make test` — all unit tests pass (including `pkg/proto/udp.TestUdpPacket`)
- [x] `make e2e` — 224 passed, 0 failed, 2 skipped