### PR TITLE
server/group: fix port leak and incorrect Listen port in TCPGroup

### DIFF
--- a/server/group/tcp.go
+++ b/server/group/tcp.go
@@ -100,8 +100,9 @@ func (tg *TCPGroup) Listen(proxyName string, group string, groupKey string, addr
 		if err != nil {
 			return
 		}
-		tcpLn, errRet := net.Listen("tcp", net.JoinHostPort(addr, strconv.Itoa(port)))
+		tcpLn, errRet := net.Listen("tcp", net.JoinHostPort(addr, strconv.Itoa(realPort)))
 		if errRet != nil {
+			tg.ctl.portManager.Release(realPort)
 			err = errRet
 			return
 		}


### PR DESCRIPTION
## Summary

Fix two bugs in `TCPGroup.Listen()` (`server/group/tcp.go`):

- **Port leak**: When `net.Listen` fails after `portManager.Acquire` succeeds, the acquired port was never released, causing it to stay in `usedPorts` permanently until frps restart.
- **Wrong port**: `net.Listen` used the requested `port` parameter instead of `realPort` (the actually allocated port). When `port==0` (random allocation), this caused the system to listen on a different random port than what the port manager recorded.

## Fix

```diff
-  tcpLn, errRet := net.Listen("tcp", net.JoinHostPort(addr, strconv.Itoa(port)))
+  tcpLn, errRet := net.Listen("tcp", net.JoinHostPort(addr, strconv.Itoa(realPort)))
   if errRet != nil {
+      tg.ctl.portManager.Release(realPort)
       err = errRet
       return
   }
```

## Test plan

- [x] `make build` — compiles successfully
- [x] `make test` — all unit tests pass
- [x] `make e2e` — 224 passed, 0 failed, 2 skipped