### PR TITLE
fix: close connections on error paths to prevent resource leaks

### DIFF
--- a/client/proxy/proxy.go
+++ b/client/proxy/proxy.go
@@ -209,6 +209,7 @@ func (pxy *BaseProxy) HandleTCPWorkConnection(workConn net.Conn, m *msg.StartWor
 	if connInfo.ProxyProtocolHeader != nil {
 		if _, err := connInfo.ProxyProtocolHeader.WriteTo(localConn); err != nil {
 			workConn.Close()
+			localConn.Close()
 			xl.Errorf("write proxy protocol header to local conn error: %v", err)
 			return
 		}

--- a/client/visitor/sudp.go
+++ b/client/visitor/sudp.go
@@ -217,6 +217,7 @@ func (sv *SUDPVisitor) getNewVisitorConn() (net.Conn, error) {
 	}
 	err = msg.WriteMsg(visitorConn, newVisitorConnMsg)
 	if err != nil {
+		visitorConn.Close()
 		return nil, fmt.Errorf("frpc send newVisitorConnMsg to frps error: %v", err)
 	}
 
@@ -224,11 +225,13 @@ func (sv *SUDPVisitor) getNewVisitorConn() (net.Conn, error) {
 	_ = visitorConn.SetReadDeadline(time.Now().Add(10 * time.Second))
 	err = msg.ReadMsgInto(visitorConn, &newVisitorConnRespMsg)
 	if err != nil {
+		visitorConn.Close()
 		return nil, fmt.Errorf("frpc read newVisitorConnRespMsg error: %v", err)
 	}
 	_ = visitorConn.SetReadDeadline(time.Time{})
 
 	if newVisitorConnRespMsg.Error != "" {
+		visitorConn.Close()
 		return nil, fmt.Errorf("start new visitor connection error: %s", newVisitorConnRespMsg.Error)
 	}
 
@@ -238,6 +241,7 @@ func (sv *SUDPVisitor) getNewVisitorConn() (net.Conn, error) {
 		remote, err = libio.WithEncryption(remote, []byte(sv.cfg.SecretKey))
 		if err != nil {
 			xl.Errorf("create encryption stream error: %v", err)
+			visitorConn.Close()
 			return nil, err
 		}
 	}

--- a/client/visitor/xtcp.go
+++ b/client/visitor/xtcp.go
@@ -211,6 +211,7 @@ func (sv *XTCPVisitor) handleConn(userConn net.Conn) {
 		muxConnRWCloser, err = libio.WithEncryption(muxConnRWCloser, []byte(sv.cfg.SecretKey))
 		if err != nil {
 			xl.Errorf("create encryption stream error: %v", err)
+			tunnelConn.Close()
 			tunnelErr = err
 			return
 		}
@@ -373,6 +374,7 @@ func (ks *KCPTunnelSession) Init(listenConn *net.UDPConn, raddr *net.UDPAddr) er
 	}
 	remote, err := netpkg.NewKCPConnFromUDP(lConn, true, raddr.String())
 	if err != nil {
+		lConn.Close()
 		return fmt.Errorf("create kcp connection from udp connection error: %v", err)
 	}
 

--- a/pkg/plugin/client/tls2raw.go
+++ b/pkg/plugin/client/tls2raw.go
@@ -62,11 +62,13 @@ func (p *TLS2RawPlugin) Handle(ctx context.Context, connInfo *ConnectionInfo) {
 
 	if err := tlsConn.Handshake(); err != nil {
 		xl.Warnf("tls handshake error: %v", err)
+		tlsConn.Close()
 		return
 	}
 	rawConn, err := net.Dial("tcp", p.opts.LocalAddr)
 	if err != nil {
 		xl.Warnf("dial to local addr error: %v", err)
+		tlsConn.Close()
 		return
 	}
 

--- a/pkg/plugin/client/unix_domain_socket.go
+++ b/pkg/plugin/client/unix_domain_socket.go
@@ -54,10 +54,13 @@ func (uds *UnixDomainSocketPlugin) Handle(ctx context.Context, connInfo *Connect
 	localConn, err := net.DialUnix("unix", nil, uds.UnixAddr)
 	if err != nil {
 		xl.Warnf("dial to uds %s error: %v", uds.UnixAddr, err)
+		connInfo.Conn.Close()
 		return
 	}
 	if connInfo.ProxyProtocolHeader != nil {
 		if _, err := connInfo.ProxyProtocolHeader.WriteTo(localConn); err != nil {
+			localConn.Close()
+			connInfo.Conn.Close()
 			return
 		}
 	}

--- a/server/proxy/http.go
+++ b/server/proxy/http.go
@@ -168,6 +168,7 @@ func (pxy *HTTPProxy) GetRealConn(remoteAddr string) (workConn net.Conn, err err
 		rwc, err = libio.WithEncryption(rwc, pxy.encryptionKey)
 		if err != nil {
 			xl.Errorf("create encryption stream error: %v", err)
+			tmpConn.Close()
 			return
 		}
 	}


### PR DESCRIPTION
## Summary
- Fix connection/resource leaks in 7 error paths across 6 files
- Each fix adds a missing `Close()` call before returning on error, preventing file descriptor and memory leaks

### Fixed locations
| File | Leaked Resource | Error Path |
|------|----------------|------------|
| `server/proxy/http.go` | `tmpConn` | `WithEncryption` failure |
| `client/proxy/proxy.go` | `localConn` | ProxyProtocol `WriteTo` failure |
| `client/visitor/sudp.go` | `visitorConn` | 4 error paths in `getNewVisitorConn` |
| `client/visitor/xtcp.go` | `tunnelConn` | `WithEncryption` failure |
| `client/visitor/xtcp.go` | `lConn` (UDP) | `NewKCPConnFromUDP` failure |
| `pkg/plugin/client/unix_domain_socket.go` | `localConn` | `WriteTo` failure |
| `pkg/plugin/client/tls2raw.go` | `tlsConn` | TLS Handshake / Dial failure |

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [x] Codex review confirmed no correctness issues