### PR TITLE
fix: return buffers to pool on error paths to reduce GC pressure

### DIFF
--- a/pkg/nathole/nathole.go
+++ b/pkg/nathole/nathole.go
@@ -298,11 +298,13 @@ func waitDetectMessage(
 		n, raddr, err := conn.ReadFromUDP(buf)
 		_ = conn.SetReadDeadline(time.Time{})
 		if err != nil {
+			pool.PutBuf(buf)
 			return nil, err
 		}
 		xl.Debugf("get udp message local %s, from %s", conn.LocalAddr(), raddr)
 		var m msg.NatHoleSid
 		if err := DecodeMessageInto(buf[:n], key, &m); err != nil {
+			pool.PutBuf(buf)
 			xl.Warnf("decode sid message error: %v", err)
 			continue
 		}

--- a/pkg/proto/udp/udp.go
+++ b/pkg/proto/udp/udp.go
@@ -85,6 +85,7 @@ func Forwarder(dstAddr *net.UDPAddr, readCh <-chan *msg.UDPPacket, sendCh chan<-
 		}()
 
 		buf := pool.GetBuf(bufSize)
+		defer pool.PutBuf(buf)
 		for {
 			_ = udpConn.SetReadDeadline(time.Now().Add(30 * time.Second))
 			n, _, err := udpConn.ReadFromUDP(buf)


### PR DESCRIPTION
## Summary

- **pkg/nathole/nathole.go**: `waitDetectMessage` allocates a buffer via `pool.GetBuf` each loop iteration but never returns it on error paths (`ReadFromUDP` failure and `DecodeMessageInto` failure). Added `pool.PutBuf(buf)` on both paths.
- **pkg/proto/udp/udp.go**: `writerFn` in `Forwarder` allocates a buffer via `pool.GetBuf` but never returns it when the goroutine exits. Added `defer pool.PutBuf(buf)`.

These are `sync.Pool` buffer leaks — not permanent memory leaks, but they increase GC pressure and allocation rate under sustained load.

## Verification

- `json.Unmarshal` creates independent string copies, so returning `buf` to pool after `DecodeMessageInto` is safe (no aliasing).
- `NewUDPPacket` copies `buf[:n]` into a new slice, so returning `buf` via defer in `writerFn` is safe.
- No double-free paths exist in either fix.
- Build and unit tests pass.

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [x] Manual code review confirmed no aliasing or double-free issues
- [x] Codex deep analysis confirmed safety of both fixes