### PR TITLE
fix: WebsocketListener nil panic and OIDC auth data race

### DIFF
--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"slices"
+	"sync"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
@@ -205,7 +206,8 @@ type OidcAuthConsumer struct {
 	additionalAuthScopes []v1.AuthScope
 
 	verifier          TokenVerifier
-	subjectsFromLogin []string
+	mu                sync.RWMutex
+	subjectsFromLogin map[string]struct{}
 }
 
 func NewTokenVerifier(cfg v1.AuthOIDCServerConfig) TokenVerifier {
@@ -226,7 +228,7 @@ func NewOidcAuthVerifier(additionalAuthScopes []v1.AuthScope, verifier TokenVeri
 	return &OidcAuthConsumer{
 		additionalAuthScopes: additionalAuthScopes,
 		verifier:             verifier,
-		subjectsFromLogin:    []string{},
+		subjectsFromLogin:    make(map[string]struct{}),
 	}
 }
 
@@ -235,9 +237,9 @@ func (auth *OidcAuthConsumer) VerifyLogin(loginMsg *msg.Login) (err error) {
 	if err != nil {
 		return fmt.Errorf("invalid OIDC token in login: %v", err)
 	}
-	if !slices.Contains(auth.subjectsFromLogin, token.Subject) {
-		auth.subjectsFromLogin = append(auth.subjectsFromLogin, token.Subject)
-	}
+	auth.mu.Lock()
+	auth.subjectsFromLogin[token.Subject] = struct{}{}
+	auth.mu.Unlock()
 	return nil
 }
 
@@ -246,11 +248,13 @@ func (auth *OidcAuthConsumer) verifyPostLoginToken(privilegeKey string) (err err
 	if err != nil {
 		return fmt.Errorf("invalid OIDC token in ping: %v", err)
 	}
-	if !slices.Contains(auth.subjectsFromLogin, token.Subject) {
+	auth.mu.RLock()
+	_, ok := auth.subjectsFromLogin[token.Subject]
+	auth.mu.RUnlock()
+	if !ok {
 		return fmt.Errorf("received different OIDC subject in login and ping. "+
-			"original subjects: %s, "+
 			"new subject: %s",
-			auth.subjectsFromLogin, token.Subject)
+			token.Subject)
 	}
 	return nil
 }

--- a/pkg/util/net/websocket.go
+++ b/pkg/util/net/websocket.go
@@ -26,6 +26,7 @@ type WebsocketListener struct {
 // ln: tcp listener for websocket connections
 func NewWebsocketListener(ln net.Listener) (wl *WebsocketListener) {
 	wl = &WebsocketListener{
+		ln:       ln,
 		acceptCh: make(chan net.Conn),
 	}
 


### PR DESCRIPTION
## Summary

- **pkg/util/net/websocket.go**: `NewWebsocketListener` never stored the `ln` parameter in the struct, causing `Addr()` to panic with nil pointer dereference. Added `ln: ln` to the struct literal.
- **pkg/auth/oidc.go**: `OidcAuthConsumer.subjectsFromLogin` was accessed concurrently without synchronization — `VerifyLogin` writes (append) while `verifyPostLoginToken` reads (`slices.Contains`) from separate goroutines. Replaced `[]string` with `map[string]struct{}` protected by `sync.RWMutex`.

## Impact

- **websocket.go**: Latent bug — `Addr()` is not currently called but violates `net.Listener` contract. One-line fix, zero risk.
- **oidc.go**: Production-reachable data race for OIDC users. The verifier is shared globally across all client connections (each in its own goroutine). Worst case: undefined behavior, auth misdecisions, crash.

## Verification

- `make build` passes
- `make test` passes
- `go test ./pkg/auth ./pkg/util/net` passes
- Codex review: no introduced bugs
- No copylock issues (struct accessed via pointer)

## Test plan

- [x] Build and unit tests pass
- [x] Codex deep analysis confirmed both fixes are correct and necessary
- [x] Manual code review verified concurrent access paths