### PR TITLE
fix: validate CA cert parsing and add missing ReadHeaderTimeout

### DIFF
--- a/pkg/plugin/client/http2http.go
+++ b/pkg/plugin/client/http2http.go
@@ -21,6 +21,7 @@ import (
 	stdlog "log"
 	"net/http"
 	"net/http/httputil"
+	"time"
 
 	"github.com/fatedier/golib/pool"
 
@@ -68,7 +69,7 @@ func NewHTTP2HTTPPlugin(_ PluginContext, options v1.ClientPluginOptions) (Plugin
 
 	p.s = &http.Server{
 		Handler:           rp,
-		ReadHeaderTimeout: 0,
+		ReadHeaderTimeout: 60 * time.Second,
 	}
 
 	go func() {

--- a/pkg/plugin/client/http2https.go
+++ b/pkg/plugin/client/http2https.go
@@ -22,6 +22,7 @@ import (
 	stdlog "log"
 	"net/http"
 	"net/http/httputil"
+	"time"
 
 	"github.com/fatedier/golib/pool"
 
@@ -77,7 +78,7 @@ func NewHTTP2HTTPSPlugin(_ PluginContext, options v1.ClientPluginOptions) (Plugi
 
 	p.s = &http.Server{
 		Handler:           rp,
-		ReadHeaderTimeout: 0,
+		ReadHeaderTimeout: 60 * time.Second,
 	}
 
 	go func() {

--- a/pkg/transport/tls.go
+++ b/pkg/transport/tls.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"os"
 	"time"
@@ -85,7 +86,9 @@ func newCertPool(caPath string) (*x509.CertPool, error) {
 		return nil, err
 	}
 
-	pool.AppendCertsFromPEM(caCrt)
+	if !pool.AppendCertsFromPEM(caCrt) {
+		return nil, fmt.Errorf("failed to parse CA certificate from file %q: no valid PEM certificates found", caPath)
+	}
 
 	return pool, nil
 }


### PR DESCRIPTION
## Summary

- **pkg/transport/tls.go**: `newCertPool` ignores `AppendCertsFromPEM` return value. If the CA file is malformed (DER-encoded, empty, corrupted), the cert pool is empty and TLS verification silently fails with a confusing error later. Now returns a clear error immediately.
- **pkg/plugin/client/http2http.go**: `ReadHeaderTimeout` was explicitly set to 0 (no timeout), while all other plugins in the same directory use 60s. Fixed to 60s for consistency and slowloris protection.
- **pkg/plugin/client/http2https.go**: Same `ReadHeaderTimeout` fix.

## Context

- `ReadHeaderTimeout` only controls request header read time, not backend processing or response time (confirmed via Go source code). Setting 60s has no impact on long-running requests.
- The same `AppendCertsFromPEM` check already exists correctly in `pkg/auth/oidc.go:53`.

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [x] Codex review: no regressions identified