### PR TITLE
pkg/util/xlog: fix AddPrefix not updating existing prefix

### DIFF
--- a/pkg/util/xlog/xlog.go
+++ b/pkg/util/xlog/xlog.go
@@ -63,11 +63,12 @@ func (l *Logger) AddPrefix(prefix LogPrefix) *Logger {
 	if prefix.Priority <= 0 {
 		prefix.Priority = 10
 	}
-	for _, p := range l.prefixes {
+	for i, p := range l.prefixes {
 		if p.Name == prefix.Name {
 			found = true
-			p.Value = prefix.Value
-			p.Priority = prefix.Priority
+			l.prefixes[i].Value = prefix.Value
+			l.prefixes[i].Priority = prefix.Priority
+			break
 		}
 	}
 	if !found {


### PR DESCRIPTION
## Summary

- Fix `AddPrefix` range value copy bug: `for _, p := range l.prefixes` creates a copy of each element, so assignments to `p.Value` and `p.Priority` only modify the local copy, not the original slice element
- Updates to existing prefixes were silently lost
- Use index-based access `l.prefixes[i]` to modify the original slice element, and add `break` since prefix names are unique

## Impact

`client/service.go:361` calls `AddPrefix(Name:"runID")` on every reconnection using the same logger instance. When `runID` changes, the old value would persist in log output instead of being updated.

## Test plan

- [x] `go vet ./pkg/util/xlog/...` passes
- [x] `go build ./pkg/util/xlog/...` passes
- [x] Codex review confirmed fix is correct