### PR TITLE
server/proxy: simplify HTTP proxy domain registration by removing duplicate loop

### DIFF
--- a/server/proxy/http.go
+++ b/server/proxy/http.go
@@ -75,16 +75,21 @@ func (pxy *HTTPProxy) Run() (remoteAddr string, err error) {
 		}
 	}()
 
-	addrs := make([]string, 0)
-	for _, domain := range pxy.cfg.CustomDomains {
-		if domain == "" {
-			continue
+	domains := make([]string, 0, len(pxy.cfg.CustomDomains)+1)
+	for _, d := range pxy.cfg.CustomDomains {
+		if d != "" {
+			domains = append(domains, d)
 		}
+	}
+	if pxy.cfg.SubDomain != "" {
+		domains = append(domains, pxy.cfg.SubDomain+"."+pxy.serverCfg.SubDomainHost)
+	}
 
+	addrs := make([]string, 0)
+	for _, domain := range domains {
 		routeConfig.Domain = domain
 		for _, location := range locations {
 			routeConfig.Location = location
-
 			tmpRouteConfig := routeConfig
 
 			// handle group
@@ -93,12 +98,10 @@ func (pxy *HTTPProxy) Run() (remoteAddr string, err error) {
 				if err != nil {
 					return
 				}
-
 				pxy.closeFuncs = append(pxy.closeFuncs, func() {
 					pxy.rc.HTTPGroupCtl.UnRegister(pxy.name, pxy.cfg.LoadBalancer.Group, tmpRouteConfig)
 				})
 			} else {
-				// no group
 				err = pxy.rc.HTTPReverseProxy.Register(routeConfig)
 				if err != nil {
 					return
@@ -108,39 +111,6 @@ func (pxy *HTTPProxy) Run() (remoteAddr string, err error) {
 				})
 			}
 			addrs = append(addrs, util.CanonicalAddr(routeConfig.Domain, pxy.serverCfg.VhostHTTPPort))
-			xl.Infof("http proxy listen for host [%s] location [%s] group [%s], routeByHTTPUser [%s]",
-				routeConfig.Domain, routeConfig.Location, pxy.cfg.LoadBalancer.Group, pxy.cfg.RouteByHTTPUser)
-		}
-	}
-
-	if pxy.cfg.SubDomain != "" {
-		routeConfig.Domain = pxy.cfg.SubDomain + "." + pxy.serverCfg.SubDomainHost
-		for _, location := range locations {
-			routeConfig.Location = location
-
-			tmpRouteConfig := routeConfig
-
-			// handle group
-			if pxy.cfg.LoadBalancer.Group != "" {
-				err = pxy.rc.HTTPGroupCtl.Register(pxy.name, pxy.cfg.LoadBalancer.Group, pxy.cfg.LoadBalancer.GroupKey, routeConfig)
-				if err != nil {
-					return
-				}
-
-				pxy.closeFuncs = append(pxy.closeFuncs, func() {
-					pxy.rc.HTTPGroupCtl.UnRegister(pxy.name, pxy.cfg.LoadBalancer.Group, tmpRouteConfig)
-				})
-			} else {
-				err = pxy.rc.HTTPReverseProxy.Register(routeConfig)
-				if err != nil {
-					return
-				}
-				pxy.closeFuncs = append(pxy.closeFuncs, func() {
-					pxy.rc.HTTPReverseProxy.UnRegister(tmpRouteConfig)
-				})
-			}
-			addrs = append(addrs, util.CanonicalAddr(tmpRouteConfig.Domain, pxy.serverCfg.VhostHTTPPort))
-
 			xl.Infof("http proxy listen for host [%s] location [%s] group [%s], routeByHTTPUser [%s]",
 				routeConfig.Domain, routeConfig.Location, pxy.cfg.LoadBalancer.Group, pxy.cfg.RouteByHTTPUser)
 		}


### PR DESCRIPTION
## Summary

- Consolidate two nearly identical loop blocks in `HTTPProxy.Run()` (custom domains + subdomain) into a single loop
- Collect all domains into a slice first, then iterate once with shared registration logic
- Removes ~30 lines of duplicated group/non-group registration code
- Fixes minor inconsistency where custom domain block used `routeConfig.Domain` but subdomain block used `tmpRouteConfig.Domain` in `CanonicalAddr`

## Test plan

- [x] `go build ./server/...` passes
- [x] `go vet ./server/proxy/...` passes
- [x] Codex deep review confirmed: no issues found, behavior-preserving refactor