### PR TITLE
server/proxy: simplify HTTPS and TCPMux proxy domain registration

### DIFF
--- a/server/proxy/https.go
+++ b/server/proxy/https.go
@@ -53,23 +53,18 @@ func (pxy *HTTPSProxy) Run() (remoteAddr string, err error) {
 			pxy.Close()
 		}
 	}()
-	addrs := make([]string, 0)
-	for _, domain := range pxy.cfg.CustomDomains {
-		if domain == "" {
-			continue
+	domains := make([]string, 0, len(pxy.cfg.CustomDomains)+1)
+	for _, d := range pxy.cfg.CustomDomains {
+		if d != "" {
+			domains = append(domains, d)
 		}
-
-		l, err := pxy.listenForDomain(routeConfig, domain)
-		if err != nil {
-			return "", err
-		}
-		pxy.listeners = append(pxy.listeners, l)
-		addrs = append(addrs, util.CanonicalAddr(domain, pxy.serverCfg.VhostHTTPSPort))
-		xl.Infof("https proxy listen for host [%s] group [%s]", domain, pxy.cfg.LoadBalancer.Group)
+	}
+	if pxy.cfg.SubDomain != "" {
+		domains = append(domains, pxy.cfg.SubDomain+"."+pxy.serverCfg.SubDomainHost)
 	}
 
-	if pxy.cfg.SubDomain != "" {
-		domain := pxy.cfg.SubDomain + "." + pxy.serverCfg.SubDomainHost
+	addrs := make([]string, 0)
+	for _, domain := range domains {
 		l, err := pxy.listenForDomain(routeConfig, domain)
 		if err != nil {
 			return "", err

--- a/server/proxy/tcpmux.go
+++ b/server/proxy/tcpmux.go
@@ -72,21 +72,19 @@ func (pxy *TCPMuxProxy) httpConnectListen(
 }
 
 func (pxy *TCPMuxProxy) httpConnectRun() (remoteAddr string, err error) {
-	addrs := make([]string, 0)
-	for _, domain := range pxy.cfg.CustomDomains {
-		if domain == "" {
-			continue
-		}
-
-		addrs, err = pxy.httpConnectListen(domain, pxy.cfg.RouteByHTTPUser, pxy.cfg.HTTPUser, pxy.cfg.HTTPPassword, addrs)
-		if err != nil {
-			return "", err
+	domains := make([]string, 0, len(pxy.cfg.CustomDomains)+1)
+	for _, d := range pxy.cfg.CustomDomains {
+		if d != "" {
+			domains = append(domains, d)
 		}
 	}
-
 	if pxy.cfg.SubDomain != "" {
-		addrs, err = pxy.httpConnectListen(pxy.cfg.SubDomain+"."+pxy.serverCfg.SubDomainHost,
-			pxy.cfg.RouteByHTTPUser, pxy.cfg.HTTPUser, pxy.cfg.HTTPPassword, addrs)
+		domains = append(domains, pxy.cfg.SubDomain+"."+pxy.serverCfg.SubDomainHost)
+	}
+
+	addrs := make([]string, 0)
+	for _, domain := range domains {
+		addrs, err = pxy.httpConnectListen(domain, pxy.cfg.RouteByHTTPUser, pxy.cfg.HTTPUser, pxy.cfg.HTTPPassword, addrs)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
## Summary
- Apply the same domain consolidation pattern from #5207 to `HTTPSProxy.Run()` and `TCPMuxProxy.httpConnectRun()`
- Replace separate custom-domain loop + subdomain block with a single unified loop over all domains
- No behavioral change; build and vet pass

## Context
Follow-up to #5207 which applied this simplification to `HTTPProxy`. The HTTPS and TCPMux proxies had the same duplicated pattern.