### PR TITLE
pkg: use modern Go stdlib functions to simplify code

### DIFF
--- a/pkg/config/legacy/conversion.go
+++ b/pkg/config/legacy/conversion.go
@@ -171,15 +171,14 @@ func Convert_ServerCommonConf_To_v1(conf *ServerCommonConf) *v1.ServerConfig {
 func transformHeadersFromPluginParams(params map[string]string) v1.HeaderOperations {
 	out := v1.HeaderOperations{}
 	for k, v := range params {
-		if !strings.HasPrefix(k, "plugin_header_") {
+		k, ok := strings.CutPrefix(k, "plugin_header_")
+		if !ok || k == "" {
 			continue
 		}
-		if k = strings.TrimPrefix(k, "plugin_header_"); k != "" {
-			if out.Set == nil {
-				out.Set = make(map[string]string)
-			}
-			out.Set[k] = v
+		if out.Set == nil {
+			out.Set = make(map[string]string)
 		}
+		out.Set[k] = v
 	}
 	return out
 }

--- a/pkg/config/legacy/utils.go
+++ b/pkg/config/legacy/utils.go
@@ -22,8 +22,8 @@ func GetMapWithoutPrefix(set map[string]string, prefix string) map[string]string
 	m := make(map[string]string)
 
 	for key, value := range set {
-		if strings.HasPrefix(key, prefix) {
-			m[strings.TrimPrefix(key, prefix)] = value
+		if trimmed, ok := strings.CutPrefix(key, prefix); ok {
+			m[trimmed] = value
 		}
 	}
 

--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -16,9 +16,8 @@ func StripUserPrefix(user, name string) string {
 	if user == "" {
 		return name
 	}
-	prefix := user + "."
-	if strings.HasPrefix(name, prefix) {
-		return strings.TrimPrefix(name, prefix)
+	if trimmed, ok := strings.CutPrefix(name, user+"."); ok {
+		return trimmed
 	}
 	return name
 }

--- a/pkg/nathole/classify.go
+++ b/pkg/nathole/classify.go
@@ -70,12 +70,8 @@ func ClassifyNATFeature(addresses []string, localIPs []string) (*NatFeature, err
 			continue
 		}
 
-		if portNum > portMax {
-			portMax = portNum
-		}
-		if portNum < portMin {
-			portMin = portNum
-		}
+		portMax = max(portMax, portNum)
+		portMin = min(portMin, portNum)
 		if baseIP != ip {
 			ipChanged = true
 		}

--- a/pkg/plugin/server/http.go
+++ b/pkg/plugin/server/http.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"slices"
 	"strings"
 
 	v1 "github.com/fatedier/frp/pkg/config/v1"
@@ -64,12 +65,7 @@ func (p *httpPlugin) Name() string {
 }
 
 func (p *httpPlugin) IsSupport(op string) bool {
-	for _, v := range p.options.Ops {
-		if v == op {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(p.options.Ops, op)
 }
 
 func (p *httpPlugin) Handle(ctx context.Context, op string, content any) (*Response, any, error) {


### PR DESCRIPTION
## Summary
- `strings.CutPrefix` instead of `HasPrefix`+`TrimPrefix` (`pkg/naming`, `pkg/config/legacy`)
- `slices.Contains` instead of manual for loop (`pkg/plugin/server`)
- `min`/`max` builtins instead of manual if comparisons (`pkg/nathole`)

5 files changed, net -10 lines. All behavior-preserving, verified by Codex review.