### PR TITLE
fix: concurrent map crash, error shadowing, and unchecked ListenUDP error

### DIFF
--- a/pkg/nathole/controller.go
+++ b/pkg/nathole/controller.go
@@ -152,7 +152,9 @@ func (c *Controller) GenSid() string {
 
 func (c *Controller) HandleVisitor(m *msg.NatHoleVisitor, transporter transport.MessageTransporter, visitorUser string) {
 	if m.PreCheck {
+		c.mu.RLock()
 		cfg, ok := c.clientCfgs[m.ProxyName]
+		c.mu.RUnlock()
 		if !ok {
 			_ = transporter.Send(c.GenNatHoleResponse(m.TransactionID, nil, fmt.Sprintf("xtcp server for [%s] doesn't exist", m.ProxyName)))
 			return

--- a/pkg/util/net/udp.go
+++ b/pkg/util/net/udp.go
@@ -168,11 +168,15 @@ func ListenUDP(bindAddr string, bindPort int) (l *UDPListener, err error) {
 		return l, err
 	}
 	readConn, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		return l, err
+	}
 
 	l = &UDPListener{
 		addr:      udpAddr,
 		acceptCh:  make(chan net.Conn),
 		writeCh:   make(chan *UDPPacket, 1000),
+		readConn:  readConn,
 		fakeConns: make(map[string]*FakeUDPConn),
 	}
 

--- a/server/proxy/proxy.go
+++ b/server/proxy/proxy.go
@@ -150,7 +150,7 @@ func (pxy *BaseProxy) GetWorkConnFromPool(src, dst net.Addr) (workConn net.Conn,
 			dstAddr, dstPortStr, _ = net.SplitHostPort(dst.String())
 			dstPort, _ = strconv.ParseUint(dstPortStr, 10, 16)
 		}
-		err := msg.WriteMsg(workConn, &msg.StartWorkConn{
+		err = msg.WriteMsg(workConn, &msg.StartWorkConn{
 			ProxyName: pxy.GetName(),
 			SrcAddr:   srcAddr,
 			SrcPort:   uint16(srcPort),
@@ -161,6 +161,7 @@ func (pxy *BaseProxy) GetWorkConnFromPool(src, dst net.Addr) (workConn net.Conn,
 		if err != nil {
 			xl.Warnf("failed to send message to work connection from pool: %v, times: %d", err, i)
 			workConn.Close()
+			workConn = nil
 		} else {
 			break
 		}


### PR DESCRIPTION
## Summary

Fixes three high-severity bugs found via static analysis and cross-verified by Codex:

- **pkg/nathole: concurrent map read/write crash** — `HandleVisitor` PreCheck path reads `c.clientCfgs` without lock while `ListenClient`/`CloseClient` modify it under `c.mu`. Since the handler runs via `msg.AsyncHandler` (goroutine), this is a data race that can crash the server with `concurrent map read and map write`. Fix: add `c.mu.RLock()` around the map read.

- **server/proxy: closed connection returned with nil error** — `GetWorkConnFromPool` uses `err := msg.WriteMsg(...)` (short variable declaration) which shadows the outer named return `err`. When `poolCount` is 0 and `WriteMsg` fails, the outer `err` stays nil, causing the function to return a closed `workConn` with no error. Fix: use `err =` instead of `err :=`, and set `workConn = nil` after closing.

- **pkg/util/net: nil pointer panic on ListenUDP failure** — `net.ListenUDP` error was not checked before spawning goroutines that call `readConn.ReadFromUDP`. If listen fails, `readConn` is nil → panic. Also `l.readConn` was never assigned, making `Close()` a no-op. Fix: check error and return early, assign `readConn` to struct field.

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [x] Codex review — no issues found