### PR TITLE
refactor: fix modernize lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
   - lll
   - makezero
   - misspell
+  - modernize
   - prealloc
   - predeclared
   - revive
@@ -47,6 +48,9 @@ linters:
       ignore-rules:
       - cancelled
       - marshalled
+    modernize:
+      disable:
+      - omitzero
     unparam:
       check-exported: false
   exclusions:

--- a/client/proxy/sudp.go
+++ b/client/proxy/sudp.go
@@ -32,7 +32,7 @@ import (
 )
 
 func init() {
-	RegisterProxyFactory(reflect.TypeOf(&v1.SUDPProxyConfig{}), NewSUDPProxy)
+	RegisterProxyFactory(reflect.TypeFor[*v1.SUDPProxyConfig](), NewSUDPProxy)
 }
 
 type SUDPProxy struct {

--- a/client/proxy/udp.go
+++ b/client/proxy/udp.go
@@ -31,7 +31,7 @@ import (
 )
 
 func init() {
-	RegisterProxyFactory(reflect.TypeOf(&v1.UDPProxyConfig{}), NewUDPProxy)
+	RegisterProxyFactory(reflect.TypeFor[*v1.UDPProxyConfig](), NewUDPProxy)
 }
 
 type UDPProxy struct {

--- a/client/proxy/xtcp.go
+++ b/client/proxy/xtcp.go
@@ -34,7 +34,7 @@ import (
 )
 
 func init() {
-	RegisterProxyFactory(reflect.TypeOf(&v1.XTCPProxyConfig{}), NewXTCPProxy)
+	RegisterProxyFactory(reflect.TypeFor[*v1.XTCPProxyConfig](), NewXTCPProxy)
 }
 
 type XTCPProxy struct {

--- a/pkg/config/legacy/proxy.go
+++ b/pkg/config/legacy/proxy.go
@@ -39,14 +39,14 @@ const (
 // Proxy
 var (
 	proxyConfTypeMap = map[ProxyType]reflect.Type{
-		ProxyTypeTCP:    reflect.TypeOf(TCPProxyConf{}),
-		ProxyTypeUDP:    reflect.TypeOf(UDPProxyConf{}),
-		ProxyTypeTCPMUX: reflect.TypeOf(TCPMuxProxyConf{}),
-		ProxyTypeHTTP:   reflect.TypeOf(HTTPProxyConf{}),
-		ProxyTypeHTTPS:  reflect.TypeOf(HTTPSProxyConf{}),
-		ProxyTypeSTCP:   reflect.TypeOf(STCPProxyConf{}),
-		ProxyTypeXTCP:   reflect.TypeOf(XTCPProxyConf{}),
-		ProxyTypeSUDP:   reflect.TypeOf(SUDPProxyConf{}),
+		ProxyTypeTCP:    reflect.TypeFor[TCPProxyConf](),
+		ProxyTypeUDP:    reflect.TypeFor[UDPProxyConf](),
+		ProxyTypeTCPMUX: reflect.TypeFor[TCPMuxProxyConf](),
+		ProxyTypeHTTP:   reflect.TypeFor[HTTPProxyConf](),
+		ProxyTypeHTTPS:  reflect.TypeFor[HTTPSProxyConf](),
+		ProxyTypeSTCP:   reflect.TypeFor[STCPProxyConf](),
+		ProxyTypeXTCP:   reflect.TypeFor[XTCPProxyConf](),
+		ProxyTypeSUDP:   reflect.TypeFor[SUDPProxyConf](),
 	}
 )
 

--- a/pkg/config/legacy/visitor.go
+++ b/pkg/config/legacy/visitor.go
@@ -32,9 +32,9 @@ const (
 // Visitor
 var (
 	visitorConfTypeMap = map[VisitorType]reflect.Type{
-		VisitorTypeSTCP: reflect.TypeOf(STCPVisitorConf{}),
-		VisitorTypeXTCP: reflect.TypeOf(XTCPVisitorConf{}),
-		VisitorTypeSUDP: reflect.TypeOf(SUDPVisitorConf{}),
+		VisitorTypeSTCP: reflect.TypeFor[STCPVisitorConf](),
+		VisitorTypeXTCP: reflect.TypeFor[XTCPVisitorConf](),
+		VisitorTypeSUDP: reflect.TypeFor[SUDPVisitorConf](),
 	}
 )
 

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -38,7 +38,7 @@ func parseNumberRangePair(firstRangeStr, secondRangeStr string) ([]NumberPair, e
 		return nil, fmt.Errorf("first and second range numbers are not in pairs")
 	}
 	pairs := make([]NumberPair, 0, len(firstRangeNumbers))
-	for i := 0; i < len(firstRangeNumbers); i++ {
+	for i := range firstRangeNumbers {
 		pairs = append(pairs, NumberPair{
 			First:  firstRangeNumbers[i],
 			Second: secondRangeNumbers[i],

--- a/pkg/config/types/types.go
+++ b/pkg/config/types/types.go
@@ -137,8 +137,8 @@ func (p PortsRangeSlice) String() string {
 func NewPortsRangeSliceFromString(str string) ([]PortsRange, error) {
 	str = strings.TrimSpace(str)
 	out := []PortsRange{}
-	numRanges := strings.Split(str, ",")
-	for _, numRangeStr := range numRanges {
+	numRanges := strings.SplitSeq(str, ",")
+	for numRangeStr := range numRanges {
 		// 1000-2000 or 2001
 		numArray := strings.Split(numRangeStr, "-")
 		// length: only 1 or 2 is correct

--- a/pkg/config/v1/proxy.go
+++ b/pkg/config/v1/proxy.go
@@ -239,14 +239,14 @@ const (
 )
 
 var proxyConfigTypeMap = map[ProxyType]reflect.Type{
-	ProxyTypeTCP:    reflect.TypeOf(TCPProxyConfig{}),
-	ProxyTypeUDP:    reflect.TypeOf(UDPProxyConfig{}),
-	ProxyTypeHTTP:   reflect.TypeOf(HTTPProxyConfig{}),
-	ProxyTypeHTTPS:  reflect.TypeOf(HTTPSProxyConfig{}),
-	ProxyTypeTCPMUX: reflect.TypeOf(TCPMuxProxyConfig{}),
-	ProxyTypeSTCP:   reflect.TypeOf(STCPProxyConfig{}),
-	ProxyTypeXTCP:   reflect.TypeOf(XTCPProxyConfig{}),
-	ProxyTypeSUDP:   reflect.TypeOf(SUDPProxyConfig{}),
+	ProxyTypeTCP:    reflect.TypeFor[TCPProxyConfig](),
+	ProxyTypeUDP:    reflect.TypeFor[UDPProxyConfig](),
+	ProxyTypeHTTP:   reflect.TypeFor[HTTPProxyConfig](),
+	ProxyTypeHTTPS:  reflect.TypeFor[HTTPSProxyConfig](),
+	ProxyTypeTCPMUX: reflect.TypeFor[TCPMuxProxyConfig](),
+	ProxyTypeSTCP:   reflect.TypeFor[STCPProxyConfig](),
+	ProxyTypeXTCP:   reflect.TypeFor[XTCPProxyConfig](),
+	ProxyTypeSUDP:   reflect.TypeFor[SUDPProxyConfig](),
 }
 
 func NewProxyConfigurerByType(proxyType ProxyType) ProxyConfigurer {

--- a/pkg/config/v1/proxy_plugin.go
+++ b/pkg/config/v1/proxy_plugin.go
@@ -37,16 +37,16 @@ const (
 )
 
 var clientPluginOptionsTypeMap = map[string]reflect.Type{
-	PluginHTTP2HTTPS:       reflect.TypeOf(HTTP2HTTPSPluginOptions{}),
-	PluginHTTPProxy:        reflect.TypeOf(HTTPProxyPluginOptions{}),
-	PluginHTTPS2HTTP:       reflect.TypeOf(HTTPS2HTTPPluginOptions{}),
-	PluginHTTPS2HTTPS:      reflect.TypeOf(HTTPS2HTTPSPluginOptions{}),
-	PluginHTTP2HTTP:        reflect.TypeOf(HTTP2HTTPPluginOptions{}),
-	PluginSocks5:           reflect.TypeOf(Socks5PluginOptions{}),
-	PluginStaticFile:       reflect.TypeOf(StaticFilePluginOptions{}),
-	PluginUnixDomainSocket: reflect.TypeOf(UnixDomainSocketPluginOptions{}),
-	PluginTLS2Raw:          reflect.TypeOf(TLS2RawPluginOptions{}),
-	PluginVirtualNet:       reflect.TypeOf(VirtualNetPluginOptions{}),
+	PluginHTTP2HTTPS:       reflect.TypeFor[HTTP2HTTPSPluginOptions](),
+	PluginHTTPProxy:        reflect.TypeFor[HTTPProxyPluginOptions](),
+	PluginHTTPS2HTTP:       reflect.TypeFor[HTTPS2HTTPPluginOptions](),
+	PluginHTTPS2HTTPS:      reflect.TypeFor[HTTPS2HTTPSPluginOptions](),
+	PluginHTTP2HTTP:        reflect.TypeFor[HTTP2HTTPPluginOptions](),
+	PluginSocks5:           reflect.TypeFor[Socks5PluginOptions](),
+	PluginStaticFile:       reflect.TypeFor[StaticFilePluginOptions](),
+	PluginUnixDomainSocket: reflect.TypeFor[UnixDomainSocketPluginOptions](),
+	PluginTLS2Raw:          reflect.TypeFor[TLS2RawPluginOptions](),
+	PluginVirtualNet:       reflect.TypeFor[VirtualNetPluginOptions](),
 }
 
 type ClientPluginOptions interface {

--- a/pkg/config/v1/visitor.go
+++ b/pkg/config/v1/visitor.go
@@ -79,9 +79,9 @@ const (
 )
 
 var visitorConfigTypeMap = map[VisitorType]reflect.Type{
-	VisitorTypeSTCP: reflect.TypeOf(STCPVisitorConfig{}),
-	VisitorTypeXTCP: reflect.TypeOf(XTCPVisitorConfig{}),
-	VisitorTypeSUDP: reflect.TypeOf(SUDPVisitorConfig{}),
+	VisitorTypeSTCP: reflect.TypeFor[STCPVisitorConfig](),
+	VisitorTypeXTCP: reflect.TypeFor[XTCPVisitorConfig](),
+	VisitorTypeSUDP: reflect.TypeFor[SUDPVisitorConfig](),
 }
 
 type TypedVisitorConfig struct {

--- a/pkg/config/v1/visitor_plugin.go
+++ b/pkg/config/v1/visitor_plugin.go
@@ -25,7 +25,7 @@ const (
 )
 
 var visitorPluginOptionsTypeMap = map[string]reflect.Type{
-	VisitorPluginVirtualNet: reflect.TypeOf(VirtualNetVisitorPluginOptions{}),
+	VisitorPluginVirtualNet: reflect.TypeFor[VirtualNetVisitorPluginOptions](),
 }
 
 type VisitorPluginOptions interface {

--- a/pkg/msg/msg.go
+++ b/pkg/msg/msg.go
@@ -61,7 +61,7 @@ var msgTypeMap = map[byte]any{
 	TypeNatHoleReport:      NatHoleReport{},
 }
 
-var TypeNameNatHoleResp = reflect.TypeOf(&NatHoleResp{}).Elem().Name()
+var TypeNameNatHoleResp = reflect.TypeFor[NatHoleResp]().Name()
 
 type ClientSpec struct {
 	// Due to the support of VirtualClient, frps needs to know the client type in order to

--- a/pkg/nathole/analysis.go
+++ b/pkg/nathole/analysis.go
@@ -151,7 +151,7 @@ func getBehaviorScoresByMode(mode int, defaultScore int) []*BehaviorScore {
 func getBehaviorScoresByMode2(mode int, senderScore, receiverScore int) []*BehaviorScore {
 	behaviors := getBehaviorByMode(mode)
 	scores := make([]*BehaviorScore, 0, len(behaviors))
-	for i := 0; i < len(behaviors); i++ {
+	for i := range behaviors {
 		score := receiverScore
 		if behaviors[i].A.Role == DetectRoleSender {
 			score = senderScore

--- a/pkg/nathole/nathole.go
+++ b/pkg/nathole/nathole.go
@@ -410,7 +410,7 @@ func sendSidMessageToRandomPorts(
 	xl := xlog.FromContextSafe(ctx)
 	used := sets.New[int]()
 	getUnusedPort := func() int {
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			port := rand.IntN(65535-1024) + 1024
 			if !used.Has(port) {
 				used.Insert(port)
@@ -420,7 +420,7 @@ func sendSidMessageToRandomPorts(
 		return 0
 	}
 
-	for i := 0; i < count; i++ {
+	for range count {
 		select {
 		case <-ctx.Done():
 			return

--- a/pkg/plugin/visitor/virtual_net.go
+++ b/pkg/plugin/visitor/virtual_net.go
@@ -153,10 +153,7 @@ func (p *VirtualNetPlugin) run() {
 
 				// Exponential backoff: 60s, 120s, 240s, 300s (capped)
 				baseDelay := 60 * time.Second
-				reconnectDelay = baseDelay * time.Duration(1<<uint(p.consecutiveErrors-1))
-				if reconnectDelay > 300*time.Second {
-					reconnectDelay = 300 * time.Second
-				}
+				reconnectDelay = min(baseDelay*time.Duration(1<<uint(p.consecutiveErrors-1)), 300*time.Second)
 			} else {
 				// Reset consecutive errors on successful connection
 				if p.consecutiveErrors > 0 {

--- a/pkg/policy/featuregate/feature_gate.go
+++ b/pkg/policy/featuregate/feature_gate.go
@@ -16,6 +16,7 @@ package featuregate
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"sync"
@@ -93,9 +94,7 @@ type featureGate struct {
 // NewFeatureGate creates a new feature gate with the default features
 func NewFeatureGate() MutableFeatureGate {
 	known := map[Feature]FeatureSpec{}
-	for k, v := range defaultFeatures {
-		known[k] = v
-	}
+	maps.Copy(known, defaultFeatures)
 
 	f := &featureGate{}
 	f.known.Store(known)
@@ -110,13 +109,9 @@ func (f *featureGate) SetFromMap(m map[string]bool) error {
 
 	// Copy existing state
 	known := map[Feature]FeatureSpec{}
-	for k, v := range f.known.Load().(map[Feature]FeatureSpec) {
-		known[k] = v
-	}
+	maps.Copy(known, f.known.Load().(map[Feature]FeatureSpec))
 	enabled := map[Feature]bool{}
-	for k, v := range f.enabled.Load().(map[Feature]bool) {
-		enabled[k] = v
-	}
+	maps.Copy(enabled, f.enabled.Load().(map[Feature]bool))
 
 	// Apply the new settings
 	for k, v := range m {
@@ -148,9 +143,7 @@ func (f *featureGate) Add(features map[Feature]FeatureSpec) error {
 
 	// Copy existing state
 	known := map[Feature]FeatureSpec{}
-	for k, v := range f.known.Load().(map[Feature]FeatureSpec) {
-		known[k] = v
-	}
+	maps.Copy(known, f.known.Load().(map[Feature]FeatureSpec))
 
 	// Add new features
 	for name, spec := range features {

--- a/pkg/util/http/http.go
+++ b/pkg/util/http/http.go
@@ -89,11 +89,11 @@ func ParseBasicAuth(auth string) (username, password string, ok bool) {
 		return
 	}
 	cs := string(c)
-	s := strings.IndexByte(cs, ':')
-	if s < 0 {
+	before, after, found := strings.Cut(cs, ":")
+	if !found {
 		return
 	}
-	return cs[:s], cs[s+1:], true
+	return before, after, true
 }
 
 func BasicAuth(username, passwd string) string {

--- a/pkg/util/net/udp.go
+++ b/pkg/util/net/udp.go
@@ -86,11 +86,7 @@ func (c *FakeUDPConn) Read(b []byte) (n int, err error) {
 	c.lastActive = time.Now()
 	c.mu.Unlock()
 
-	if len(b) < len(content) {
-		n = len(b)
-	} else {
-		n = len(content)
-	}
+	n = min(len(b), len(content))
 	copy(b, content)
 	return n, nil
 }

--- a/pkg/util/util/util.go
+++ b/pkg/util/util/util.go
@@ -68,8 +68,8 @@ func ParseRangeNumbers(rangeStr string) (numbers []int64, err error) {
 	rangeStr = strings.TrimSpace(rangeStr)
 	numbers = make([]int64, 0)
 	// e.g. 1000-2000,2001,2002,3000-4000
-	numRanges := strings.Split(rangeStr, ",")
-	for _, numRangeStr := range numRanges {
+	numRanges := strings.SplitSeq(rangeStr, ",")
+	for numRangeStr := range numRanges {
 		// 1000-2000 or 2001
 		numArray := strings.Split(numRangeStr, "-")
 		// length: only 1 or 2 is correct

--- a/server/control.go
+++ b/server/control.go
@@ -158,10 +158,7 @@ type Control struct {
 }
 
 func NewControl(ctx context.Context, sessionCtx *SessionContext) (*Control, error) {
-	poolCount := sessionCtx.LoginMsg.PoolCount
-	if poolCount > int(sessionCtx.ServerCfg.Transport.MaxPoolCount) {
-		poolCount = int(sessionCtx.ServerCfg.Transport.MaxPoolCount)
-	}
+	poolCount := min(sessionCtx.LoginMsg.PoolCount, int(sessionCtx.ServerCfg.Transport.MaxPoolCount))
 	ctl := &Control{
 		sessionCtx:   sessionCtx,
 		workConnCh:   make(chan net.Conn, poolCount+10),

--- a/server/proxy/http.go
+++ b/server/proxy/http.go
@@ -31,7 +31,7 @@ import (
 )
 
 func init() {
-	RegisterProxyFactory(reflect.TypeOf(&v1.HTTPProxyConfig{}), NewHTTPProxy)
+	RegisterProxyFactory(reflect.TypeFor[*v1.HTTPProxyConfig](), NewHTTPProxy)
 }
 
 type HTTPProxy struct {

--- a/server/proxy/https.go
+++ b/server/proxy/https.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	RegisterProxyFactory(reflect.TypeOf(&v1.HTTPSProxyConfig{}), NewHTTPSProxy)
+	RegisterProxyFactory(reflect.TypeFor[*v1.HTTPSProxyConfig](), NewHTTPSProxy)
 }
 
 type HTTPSProxy struct {

--- a/server/proxy/stcp.go
+++ b/server/proxy/stcp.go
@@ -21,7 +21,7 @@ import (
 )
 
 func init() {
-	RegisterProxyFactory(reflect.TypeOf(&v1.STCPProxyConfig{}), NewSTCPProxy)
+	RegisterProxyFactory(reflect.TypeFor[*v1.STCPProxyConfig](), NewSTCPProxy)
 }
 
 type STCPProxy struct {

--- a/server/proxy/sudp.go
+++ b/server/proxy/sudp.go
@@ -21,7 +21,7 @@ import (
 )
 
 func init() {
-	RegisterProxyFactory(reflect.TypeOf(&v1.SUDPProxyConfig{}), NewSUDPProxy)
+	RegisterProxyFactory(reflect.TypeFor[*v1.SUDPProxyConfig](), NewSUDPProxy)
 }
 
 type SUDPProxy struct {

--- a/server/proxy/tcp.go
+++ b/server/proxy/tcp.go
@@ -24,7 +24,7 @@ import (
 )
 
 func init() {
-	RegisterProxyFactory(reflect.TypeOf(&v1.TCPProxyConfig{}), NewTCPProxy)
+	RegisterProxyFactory(reflect.TypeFor[*v1.TCPProxyConfig](), NewTCPProxy)
 }
 
 type TCPProxy struct {

--- a/server/proxy/tcpmux.go
+++ b/server/proxy/tcpmux.go
@@ -26,7 +26,7 @@ import (
 )
 
 func init() {
-	RegisterProxyFactory(reflect.TypeOf(&v1.TCPMuxProxyConfig{}), NewTCPMuxProxy)
+	RegisterProxyFactory(reflect.TypeFor[*v1.TCPMuxProxyConfig](), NewTCPMuxProxy)
 }
 
 type TCPMuxProxy struct {

--- a/server/proxy/udp.go
+++ b/server/proxy/udp.go
@@ -35,7 +35,7 @@ import (
 )
 
 func init() {
-	RegisterProxyFactory(reflect.TypeOf(&v1.UDPProxyConfig{}), NewUDPProxy)
+	RegisterProxyFactory(reflect.TypeFor[*v1.UDPProxyConfig](), NewUDPProxy)
 }
 
 type UDPProxy struct {

--- a/server/proxy/xtcp.go
+++ b/server/proxy/xtcp.go
@@ -24,7 +24,7 @@ import (
 )
 
 func init() {
-	RegisterProxyFactory(reflect.TypeOf(&v1.XTCPProxyConfig{}), NewXTCPProxy)
+	RegisterProxyFactory(reflect.TypeFor[*v1.XTCPProxyConfig](), NewXTCPProxy)
 }
 
 type XTCPProxy struct {

--- a/test/e2e/framework/process.go
+++ b/test/e2e/framework/process.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"time"
@@ -20,9 +21,7 @@ func (f *Framework) RunProcesses(serverTemplates []string, clientTemplates []str
 	ExpectNoError(err)
 	ExpectTrue(len(templates) > 0)
 
-	for name, port := range ports {
-		f.usedPorts[name] = port
-	}
+	maps.Copy(f.usedPorts, ports)
 
 	currentServerProcesses := make([]*process.Process, 0, len(serverTemplates))
 	for i := range serverTemplates {

--- a/test/e2e/legacy/basic/basic.go
+++ b/test/e2e/legacy/basic/basic.go
@@ -26,7 +26,8 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 			proxyType := t
 			ginkgo.It(fmt.Sprintf("Expose a %s echo server", strings.ToUpper(proxyType)), func() {
 				serverConf := consts.LegacyDefaultServerConfig
-				clientConf := consts.LegacyDefaultClientConfig
+				var clientConf strings.Builder
+				clientConf.WriteString(consts.LegacyDefaultClientConfig)
 
 				localPortName := ""
 				protocol := "tcp"
@@ -78,10 +79,10 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 
 				// build all client config
 				for _, test := range tests {
-					clientConf += getProxyConf(test.proxyName, test.portName, test.extraConfig) + "\n"
+					clientConf.WriteString(getProxyConf(test.proxyName, test.portName, test.extraConfig) + "\n")
 				}
 				// run frps and frpc
-				f.RunProcesses([]string{serverConf}, []string{clientConf})
+				f.RunProcesses([]string{serverConf}, []string{clientConf.String()})
 
 				for _, test := range tests {
 					framework.NewRequestExpect(f).
@@ -102,7 +103,8 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 			vhost_http_port = %d
 			`, vhostHTTPPort)
 
-			clientConf := consts.LegacyDefaultClientConfig
+			var clientConf strings.Builder
+			clientConf.WriteString(consts.LegacyDefaultClientConfig)
 
 			getProxyConf := func(proxyName string, customDomains string, extra string) string {
 				return fmt.Sprintf(`
@@ -147,13 +149,13 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 				if tests[i].customDomains == "" {
 					tests[i].customDomains = test.proxyName + ".example.com"
 				}
-				clientConf += getProxyConf(test.proxyName, tests[i].customDomains, test.extraConfig) + "\n"
+				clientConf.WriteString(getProxyConf(test.proxyName, tests[i].customDomains, test.extraConfig) + "\n")
 			}
 			// run frps and frpc
-			f.RunProcesses([]string{serverConf}, []string{clientConf})
+			f.RunProcesses([]string{serverConf}, []string{clientConf.String()})
 
 			for _, test := range tests {
-				for _, domain := range strings.Split(test.customDomains, ",") {
+				for domain := range strings.SplitSeq(test.customDomains, ",") {
 					domain = strings.TrimSpace(domain)
 					framework.NewRequestExpect(f).
 						Explain(test.proxyName + "-" + domain).
@@ -185,7 +187,8 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 			`, vhostHTTPSPort)
 
 			localPort := f.AllocPort()
-			clientConf := consts.LegacyDefaultClientConfig
+			var clientConf strings.Builder
+			clientConf.WriteString(consts.LegacyDefaultClientConfig)
 			getProxyConf := func(proxyName string, customDomains string, extra string) string {
 				return fmt.Sprintf(`
 				[%s]
@@ -229,10 +232,10 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 				if tests[i].customDomains == "" {
 					tests[i].customDomains = test.proxyName + ".example.com"
 				}
-				clientConf += getProxyConf(test.proxyName, tests[i].customDomains, test.extraConfig) + "\n"
+				clientConf.WriteString(getProxyConf(test.proxyName, tests[i].customDomains, test.extraConfig) + "\n")
 			}
 			// run frps and frpc
-			f.RunProcesses([]string{serverConf}, []string{clientConf})
+			f.RunProcesses([]string{serverConf}, []string{clientConf.String()})
 
 			tlsConfig, err := transport.NewServerTLSConfig("", "", "")
 			framework.ExpectNoError(err)
@@ -244,7 +247,7 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 			f.RunServer("", localServer)
 
 			for _, test := range tests {
-				for _, domain := range strings.Split(test.customDomains, ",") {
+				for domain := range strings.SplitSeq(test.customDomains, ",") {
 					domain = strings.TrimSpace(domain)
 					framework.NewRequestExpect(f).
 						Explain(test.proxyName + "-" + domain).
@@ -282,9 +285,12 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 			proxyType := t
 			ginkgo.It(fmt.Sprintf("Expose echo server with %s", strings.ToUpper(proxyType)), func() {
 				serverConf := consts.LegacyDefaultServerConfig
-				clientServerConf := consts.LegacyDefaultClientConfig + "\nuser = user1"
-				clientVisitorConf := consts.LegacyDefaultClientConfig + "\nuser = user1"
-				clientUser2VisitorConf := consts.LegacyDefaultClientConfig + "\nuser = user2"
+				var clientServerConf strings.Builder
+				clientServerConf.WriteString(consts.LegacyDefaultClientConfig + "\nuser = user1")
+				var clientVisitorConf strings.Builder
+				clientVisitorConf.WriteString(consts.LegacyDefaultClientConfig + "\nuser = user1")
+				var clientUser2VisitorConf strings.Builder
+				clientUser2VisitorConf.WriteString(consts.LegacyDefaultClientConfig + "\nuser = user2")
 
 				localPortName := ""
 				protocol := "tcp"
@@ -400,20 +406,20 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 
 				// build all client config
 				for _, test := range tests {
-					clientServerConf += getProxyServerConf(test.proxyName, test.commonExtraConfig+"\n"+test.proxyExtraConfig) + "\n"
+					clientServerConf.WriteString(getProxyServerConf(test.proxyName, test.commonExtraConfig+"\n"+test.proxyExtraConfig) + "\n")
 				}
 				for _, test := range tests {
 					config := getProxyVisitorConf(
 						test.proxyName, test.bindPortName, test.visitorSK, test.commonExtraConfig+"\n"+test.visitorExtraConfig,
 					) + "\n"
 					if test.deployUser2Client {
-						clientUser2VisitorConf += config
+						clientUser2VisitorConf.WriteString(config)
 					} else {
-						clientVisitorConf += config
+						clientVisitorConf.WriteString(config)
 					}
 				}
 				// run frps and frpc
-				f.RunProcesses([]string{serverConf}, []string{clientServerConf, clientVisitorConf, clientUser2VisitorConf})
+				f.RunProcesses([]string{serverConf}, []string{clientServerConf.String(), clientVisitorConf.String(), clientUser2VisitorConf.String()})
 
 				for _, test := range tests {
 					timeout := time.Second
@@ -440,7 +446,8 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 	ginkgo.Describe("TCPMUX", func() {
 		ginkgo.It("Type tcpmux", func() {
 			serverConf := consts.LegacyDefaultServerConfig
-			clientConf := consts.LegacyDefaultClientConfig
+			var clientConf strings.Builder
+			clientConf.WriteString(consts.LegacyDefaultClientConfig)
 
 			tcpmuxHTTPConnectPortName := port.GenName("TCPMUX")
 			serverConf += fmt.Sprintf(`
@@ -483,14 +490,14 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 
 			// build all client config
 			for _, test := range tests {
-				clientConf += getProxyConf(test.proxyName, test.extraConfig) + "\n"
+				clientConf.WriteString(getProxyConf(test.proxyName, test.extraConfig) + "\n")
 
 				localServer := streamserver.New(streamserver.TCP, streamserver.WithBindPort(f.AllocPort()), streamserver.WithRespContent([]byte(test.proxyName)))
 				f.RunServer(port.GenName(test.proxyName), localServer)
 			}
 
 			// run frps and frpc
-			f.RunProcesses([]string{serverConf}, []string{clientConf})
+			f.RunProcesses([]string{serverConf}, []string{clientConf.String()})
 
 			// Request without HTTP connect should get error
 			framework.NewRequestExpect(f).

--- a/test/e2e/legacy/features/group.go
+++ b/test/e2e/legacy/features/group.go
@@ -48,12 +48,10 @@ var _ = ginkgo.Describe("[Feature: Group]", func() {
 					return true
 				})
 		}
-		for i := 0; i < 10; i++ {
-			wait.Add(1)
-			go func() {
-				defer wait.Done()
+		for range 10 {
+			wait.Go(func() {
 				expectFn()
-			}()
+			})
 		}
 
 		wait.Wait()
@@ -94,7 +92,7 @@ var _ = ginkgo.Describe("[Feature: Group]", func() {
 
 			fooCount := 0
 			barCount := 0
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				framework.NewRequestExpect(f).Explain("times " + strconv.Itoa(i)).Port(remotePort).Ensure(func(resp *request.Response) bool {
 					switch string(resp.Content) {
 					case "foo":
@@ -150,7 +148,7 @@ var _ = ginkgo.Describe("[Feature: Group]", func() {
 
 			// check foo and bar is ok
 			results := []string{}
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				framework.NewRequestExpect(f).Port(remotePort).Ensure(validateFooBarResponse, func(resp *request.Response) bool {
 					results = append(results, string(resp.Content))
 					return true
@@ -161,7 +159,7 @@ var _ = ginkgo.Describe("[Feature: Group]", func() {
 			// close bar server, check foo is ok
 			barServer.Close()
 			time.Sleep(2 * time.Second)
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				framework.NewRequestExpect(f).Port(remotePort).ExpectResp([]byte("foo")).Ensure()
 			}
 
@@ -169,7 +167,7 @@ var _ = ginkgo.Describe("[Feature: Group]", func() {
 			f.RunServer("", barServer)
 			time.Sleep(2 * time.Second)
 			results = []string{}
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				framework.NewRequestExpect(f).Port(remotePort).Ensure(validateFooBarResponse, func(resp *request.Response) bool {
 					results = append(results, string(resp.Content))
 					return true

--- a/test/e2e/legacy/plugin/client.go
+++ b/test/e2e/legacy/plugin/client.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/onsi/ginkgo/v2"
 
@@ -22,7 +23,8 @@ var _ = ginkgo.Describe("[Feature: Client-Plugins]", func() {
 	ginkgo.Describe("UnixDomainSocket", func() {
 		ginkgo.It("Expose a unix domain socket echo server", func() {
 			serverConf := consts.LegacyDefaultServerConfig
-			clientConf := consts.LegacyDefaultClientConfig
+			var clientConf strings.Builder
+			clientConf.WriteString(consts.LegacyDefaultClientConfig)
 
 			getProxyConf := func(proxyName string, portName string, extra string) string {
 				return fmt.Sprintf(`
@@ -65,10 +67,10 @@ var _ = ginkgo.Describe("[Feature: Client-Plugins]", func() {
 
 			// build all client config
 			for _, test := range tests {
-				clientConf += getProxyConf(test.proxyName, test.portName, test.extraConfig) + "\n"
+				clientConf.WriteString(getProxyConf(test.proxyName, test.portName, test.extraConfig) + "\n")
 			}
 			// run frps and frpc
-			f.RunProcesses([]string{serverConf}, []string{clientConf})
+			f.RunProcesses([]string{serverConf}, []string{clientConf.String()})
 
 			for _, test := range tests {
 				framework.NewRequestExpect(f).Port(f.PortByName(test.portName)).Ensure()

--- a/test/e2e/pkg/port/port.go
+++ b/test/e2e/pkg/port/port.go
@@ -52,7 +52,7 @@ func (pa *Allocator) GetByName(portName string) int {
 	pa.mu.Lock()
 	defer pa.mu.Unlock()
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		port := pa.getByRange(builder.rangePortFrom, builder.rangePortTo)
 		if port == 0 {
 			return 0

--- a/test/e2e/v1/basic/basic.go
+++ b/test/e2e/v1/basic/basic.go
@@ -26,7 +26,8 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 			proxyType := t
 			ginkgo.It(fmt.Sprintf("Expose a %s echo server", strings.ToUpper(proxyType)), func() {
 				serverConf := consts.DefaultServerConfig
-				clientConf := consts.DefaultClientConfig
+				var clientConf strings.Builder
+				clientConf.WriteString(consts.DefaultClientConfig)
 
 				localPortName := ""
 				protocol := "tcp"
@@ -79,10 +80,10 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 
 				// build all client config
 				for _, test := range tests {
-					clientConf += getProxyConf(test.proxyName, test.portName, test.extraConfig) + "\n"
+					clientConf.WriteString(getProxyConf(test.proxyName, test.portName, test.extraConfig) + "\n")
 				}
 				// run frps and frpc
-				f.RunProcesses([]string{serverConf}, []string{clientConf})
+				f.RunProcesses([]string{serverConf}, []string{clientConf.String()})
 
 				for _, test := range tests {
 					framework.NewRequestExpect(f).
@@ -103,7 +104,8 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 			vhostHTTPPort = %d
 			`, vhostHTTPPort)
 
-			clientConf := consts.DefaultClientConfig
+			var clientConf strings.Builder
+			clientConf.WriteString(consts.DefaultClientConfig)
 
 			getProxyConf := func(proxyName string, customDomains string, extra string) string {
 				return fmt.Sprintf(`
@@ -149,13 +151,13 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 				if tests[i].customDomains == "" {
 					tests[i].customDomains = fmt.Sprintf(`["%s"]`, test.proxyName+".example.com")
 				}
-				clientConf += getProxyConf(test.proxyName, tests[i].customDomains, test.extraConfig) + "\n"
+				clientConf.WriteString(getProxyConf(test.proxyName, tests[i].customDomains, test.extraConfig) + "\n")
 			}
 			// run frps and frpc
-			f.RunProcesses([]string{serverConf}, []string{clientConf})
+			f.RunProcesses([]string{serverConf}, []string{clientConf.String()})
 
 			for _, test := range tests {
-				for _, domain := range strings.Split(test.customDomains, ",") {
+				for domain := range strings.SplitSeq(test.customDomains, ",") {
 					domain = strings.TrimSpace(domain)
 					domain = strings.TrimLeft(domain, "[\"")
 					domain = strings.TrimRight(domain, "]\"")
@@ -189,7 +191,8 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 			`, vhostHTTPSPort)
 
 			localPort := f.AllocPort()
-			clientConf := consts.DefaultClientConfig
+			var clientConf strings.Builder
+			clientConf.WriteString(consts.DefaultClientConfig)
 			getProxyConf := func(proxyName string, customDomains string, extra string) string {
 				return fmt.Sprintf(`
 				[[proxies]]
@@ -234,10 +237,10 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 				if tests[i].customDomains == "" {
 					tests[i].customDomains = fmt.Sprintf(`["%s"]`, test.proxyName+".example.com")
 				}
-				clientConf += getProxyConf(test.proxyName, tests[i].customDomains, test.extraConfig) + "\n"
+				clientConf.WriteString(getProxyConf(test.proxyName, tests[i].customDomains, test.extraConfig) + "\n")
 			}
 			// run frps and frpc
-			f.RunProcesses([]string{serverConf}, []string{clientConf})
+			f.RunProcesses([]string{serverConf}, []string{clientConf.String()})
 
 			tlsConfig, err := transport.NewServerTLSConfig("", "", "")
 			framework.ExpectNoError(err)
@@ -249,7 +252,7 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 			f.RunServer("", localServer)
 
 			for _, test := range tests {
-				for _, domain := range strings.Split(test.customDomains, ",") {
+				for domain := range strings.SplitSeq(test.customDomains, ",") {
 					domain = strings.TrimSpace(domain)
 					domain = strings.TrimLeft(domain, "[\"")
 					domain = strings.TrimRight(domain, "]\"")
@@ -289,9 +292,12 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 			proxyType := t
 			ginkgo.It(fmt.Sprintf("Expose echo server with %s", strings.ToUpper(proxyType)), func() {
 				serverConf := consts.DefaultServerConfig
-				clientServerConf := consts.DefaultClientConfig + "\nuser = \"user1\""
-				clientVisitorConf := consts.DefaultClientConfig + "\nuser = \"user1\""
-				clientUser2VisitorConf := consts.DefaultClientConfig + "\nuser = \"user2\""
+				var clientServerConf strings.Builder
+				clientServerConf.WriteString(consts.DefaultClientConfig + "\nuser = \"user1\"")
+				var clientVisitorConf strings.Builder
+				clientVisitorConf.WriteString(consts.DefaultClientConfig + "\nuser = \"user1\"")
+				var clientUser2VisitorConf strings.Builder
+				clientUser2VisitorConf.WriteString(consts.DefaultClientConfig + "\nuser = \"user2\"")
 
 				localPortName := ""
 				protocol := "tcp"
@@ -407,20 +413,20 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 
 				// build all client config
 				for _, test := range tests {
-					clientServerConf += getProxyServerConf(test.proxyName, test.commonExtraConfig+"\n"+test.proxyExtraConfig) + "\n"
+					clientServerConf.WriteString(getProxyServerConf(test.proxyName, test.commonExtraConfig+"\n"+test.proxyExtraConfig) + "\n")
 				}
 				for _, test := range tests {
 					config := getProxyVisitorConf(
 						test.proxyName, test.bindPortName, test.visitorSK, test.commonExtraConfig+"\n"+test.visitorExtraConfig,
 					) + "\n"
 					if test.deployUser2Client {
-						clientUser2VisitorConf += config
+						clientUser2VisitorConf.WriteString(config)
 					} else {
-						clientVisitorConf += config
+						clientVisitorConf.WriteString(config)
 					}
 				}
 				// run frps and frpc
-				f.RunProcesses([]string{serverConf}, []string{clientServerConf, clientVisitorConf, clientUser2VisitorConf})
+				f.RunProcesses([]string{serverConf}, []string{clientServerConf.String(), clientVisitorConf.String(), clientUser2VisitorConf.String()})
 
 				for _, test := range tests {
 					timeout := time.Second
@@ -447,7 +453,8 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 	ginkgo.Describe("TCPMUX", func() {
 		ginkgo.It("Type tcpmux", func() {
 			serverConf := consts.DefaultServerConfig
-			clientConf := consts.DefaultClientConfig
+			var clientConf strings.Builder
+			clientConf.WriteString(consts.DefaultClientConfig)
 
 			tcpmuxHTTPConnectPortName := port.GenName("TCPMUX")
 			serverConf += fmt.Sprintf(`
@@ -491,14 +498,14 @@ var _ = ginkgo.Describe("[Feature: Basic]", func() {
 
 			// build all client config
 			for _, test := range tests {
-				clientConf += getProxyConf(test.proxyName, test.extraConfig) + "\n"
+				clientConf.WriteString(getProxyConf(test.proxyName, test.extraConfig) + "\n")
 
 				localServer := streamserver.New(streamserver.TCP, streamserver.WithBindPort(f.AllocPort()), streamserver.WithRespContent([]byte(test.proxyName)))
 				f.RunServer(port.GenName(test.proxyName), localServer)
 			}
 
 			// run frps and frpc
-			f.RunProcesses([]string{serverConf}, []string{clientConf})
+			f.RunProcesses([]string{serverConf}, []string{clientConf.String()})
 
 			// Request without HTTP connect should get error
 			framework.NewRequestExpect(f).

--- a/test/e2e/v1/features/group.go
+++ b/test/e2e/v1/features/group.go
@@ -50,12 +50,10 @@ var _ = ginkgo.Describe("[Feature: Group]", func() {
 					return true
 				})
 		}
-		for i := 0; i < 10; i++ {
-			wait.Add(1)
-			go func() {
-				defer wait.Done()
+		for range 10 {
+			wait.Go(func() {
 				expectFn()
-			}()
+			})
 		}
 
 		wait.Wait()
@@ -98,7 +96,7 @@ var _ = ginkgo.Describe("[Feature: Group]", func() {
 
 			fooCount := 0
 			barCount := 0
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				framework.NewRequestExpect(f).Explain("times " + strconv.Itoa(i)).Port(remotePort).Ensure(func(resp *request.Response) bool {
 					switch string(resp.Content) {
 					case "foo":
@@ -163,7 +161,7 @@ var _ = ginkgo.Describe("[Feature: Group]", func() {
 
 			fooCount := 0
 			barCount := 0
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				framework.NewRequestExpect(f).
 					Explain("times " + strconv.Itoa(i)).
 					Port(vhostHTTPSPort).
@@ -230,7 +228,7 @@ var _ = ginkgo.Describe("[Feature: Group]", func() {
 
 			// check foo and bar is ok
 			results := []string{}
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				framework.NewRequestExpect(f).Port(remotePort).Ensure(validateFooBarResponse, func(resp *request.Response) bool {
 					results = append(results, string(resp.Content))
 					return true
@@ -241,7 +239,7 @@ var _ = ginkgo.Describe("[Feature: Group]", func() {
 			// close bar server, check foo is ok
 			barServer.Close()
 			time.Sleep(2 * time.Second)
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				framework.NewRequestExpect(f).Port(remotePort).ExpectResp([]byte("foo")).Ensure()
 			}
 
@@ -249,7 +247,7 @@ var _ = ginkgo.Describe("[Feature: Group]", func() {
 			f.RunServer("", barServer)
 			time.Sleep(2 * time.Second)
 			results = []string{}
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				framework.NewRequestExpect(f).Port(remotePort).Ensure(validateFooBarResponse, func(resp *request.Response) bool {
 					results = append(results, string(resp.Content))
 					return true

--- a/test/e2e/v1/plugin/client.go
+++ b/test/e2e/v1/plugin/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/onsi/ginkgo/v2"
 
@@ -23,7 +24,8 @@ var _ = ginkgo.Describe("[Feature: Client-Plugins]", func() {
 	ginkgo.Describe("UnixDomainSocket", func() {
 		ginkgo.It("Expose a unix domain socket echo server", func() {
 			serverConf := consts.DefaultServerConfig
-			clientConf := consts.DefaultClientConfig
+			var clientConf strings.Builder
+			clientConf.WriteString(consts.DefaultClientConfig)
 
 			getProxyConf := func(proxyName string, portName string, extra string) string {
 				return fmt.Sprintf(`
@@ -69,10 +71,10 @@ var _ = ginkgo.Describe("[Feature: Client-Plugins]", func() {
 
 			// build all client config
 			for _, test := range tests {
-				clientConf += getProxyConf(test.proxyName, test.portName, test.extraConfig) + "\n"
+				clientConf.WriteString(getProxyConf(test.proxyName, test.portName, test.extraConfig) + "\n")
 			}
 			// run frps and frpc
-			f.RunProcesses([]string{serverConf}, []string{clientConf})
+			f.RunProcesses([]string{serverConf}, []string{clientConf.String()})
 
 			for _, test := range tests {
 				framework.NewRequestExpect(f).Port(f.PortByName(test.portName)).Ensure()


### PR DESCRIPTION
### WHY

Encourage up-to-date Go idioms and cleaner code by adding the [`modernize`](https://golangci-lint.run/docs/linters/configuration/#modernize) linter.

I decided to disable the `omitzero` rule because fixing it leads to some behavioural changes. It can be fixed in a separate PR.

`modernize` issues were fixed via running the following command:

```console
$ golangci-lint run --enable-only modernize --fix
```