### PR TITLE
refactor: use maps.Clone and slices.Concat

### DIFF
--- a/pkg/policy/featuregate/feature_gate.go
+++ b/pkg/policy/featuregate/feature_gate.go
@@ -93,8 +93,7 @@ type featureGate struct {
 
 // NewFeatureGate creates a new feature gate with the default features
 func NewFeatureGate() MutableFeatureGate {
-	known := map[Feature]FeatureSpec{}
-	maps.Copy(known, defaultFeatures)
+	known := maps.Clone(defaultFeatures)
 
 	f := &featureGate{}
 	f.known.Store(known)
@@ -108,10 +107,8 @@ func (f *featureGate) SetFromMap(m map[string]bool) error {
 	defer f.lock.Unlock()
 
 	// Copy existing state
-	known := map[Feature]FeatureSpec{}
-	maps.Copy(known, f.known.Load().(map[Feature]FeatureSpec))
-	enabled := map[Feature]bool{}
-	maps.Copy(enabled, f.enabled.Load().(map[Feature]bool))
+	known := maps.Clone(f.known.Load().(map[Feature]FeatureSpec))
+	enabled := maps.Clone(f.enabled.Load().(map[Feature]bool))
 
 	// Apply the new settings
 	for k, v := range m {
@@ -142,8 +139,7 @@ func (f *featureGate) Add(features map[Feature]FeatureSpec) error {
 	}
 
 	// Copy existing state
-	known := map[Feature]FeatureSpec{}
-	maps.Copy(known, f.known.Load().(map[Feature]FeatureSpec))
+	known := maps.Clone(f.known.Load().(map[Feature]FeatureSpec))
 
 	// Add new features
 	for name, spec := range features {

--- a/test/e2e/framework/process.go
+++ b/test/e2e/framework/process.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
 	flog "github.com/fatedier/frp/pkg/util/log"
@@ -14,9 +15,7 @@ import (
 // RunProcesses run multiple processes from templates.
 // The first template should always be frps.
 func (f *Framework) RunProcesses(serverTemplates []string, clientTemplates []string) ([]*process.Process, []*process.Process) {
-	templates := make([]string, 0, len(serverTemplates)+len(clientTemplates))
-	templates = append(templates, serverTemplates...)
-	templates = append(templates, clientTemplates...)
+	templates := slices.Concat(serverTemplates, clientTemplates)
 	outs, ports, err := f.RenderTemplates(templates)
 	ExpectNoError(err)
 	ExpectTrue(len(templates) > 0)


### PR DESCRIPTION
### WHY

This PR refactors usages of `maps.Copy` to `maps.Clone`; combines a few appends into `slices.Concat`.

Follows #5215