### PR TITLE
pkg/metrics/mem: remove redundant map write-backs and optimize proxy lookup

### DIFF
--- a/pkg/metrics/mem/server.go
+++ b/pkg/metrics/mem/server.go
@@ -143,7 +143,6 @@ func (m *serverMetrics) OpenConnection(name string, _ string) {
 	proxyStats, ok := m.info.ProxyStatistics[name]
 	if ok {
 		proxyStats.CurConns.Inc(1)
-		m.info.ProxyStatistics[name] = proxyStats
 	}
 }
 
@@ -155,7 +154,6 @@ func (m *serverMetrics) CloseConnection(name string, _ string) {
 	proxyStats, ok := m.info.ProxyStatistics[name]
 	if ok {
 		proxyStats.CurConns.Dec(1)
-		m.info.ProxyStatistics[name] = proxyStats
 	}
 }
 
@@ -168,7 +166,6 @@ func (m *serverMetrics) AddTrafficIn(name string, _ string, trafficBytes int64) 
 	proxyStats, ok := m.info.ProxyStatistics[name]
 	if ok {
 		proxyStats.TrafficIn.Inc(trafficBytes)
-		m.info.ProxyStatistics[name] = proxyStats
 	}
 }
 
@@ -181,7 +178,6 @@ func (m *serverMetrics) AddTrafficOut(name string, _ string, trafficBytes int64)
 	proxyStats, ok := m.info.ProxyStatistics[name]
 	if ok {
 		proxyStats.TrafficOut.Inc(trafficBytes)
-		m.info.ProxyStatistics[name] = proxyStats
 	}
 }
 
@@ -240,15 +236,9 @@ func (m *serverMetrics) GetProxiesByTypeAndName(proxyType string, proxyName stri
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	for name, proxyStats := range m.info.ProxyStatistics {
-		if proxyStats.ProxyType != proxyType {
-			continue
-		}
-		if name != proxyName {
-			continue
-		}
-		res = toProxyStats(name, proxyStats)
-		break
+	proxyStats, ok := m.info.ProxyStatistics[proxyName]
+	if ok && proxyStats.ProxyType == proxyType {
+		res = toProxyStats(proxyName, proxyStats)
 	}
 	return
 }


### PR DESCRIPTION
## Summary
- Remove 4 redundant pointer map write-backs in `OpenConnection`, `CloseConnection`, `AddTrafficIn`, and `AddTrafficOut` — the map stores `*ProxyStatistics`, so mutations through the pointer are already visible without reassignment.
- Optimize `GetProxiesByTypeAndName` from O(n) full map scan to O(1) direct map lookup by proxy name.

## Test plan
- [x] `make test` passes
- [x] `golangci-lint run` passes
- [x] Cross-reviewed by Codex — no correctness issues found