### PR TITLE
test/e2e: replace RunProcesses client sleep with log-based proxy readiness detection

### DIFF
--- a/test/e2e/framework/process.go
+++ b/test/e2e/framework/process.go
@@ -128,10 +128,16 @@ func waitForClientProxyReady(configPath string, p *process.Process, timeout time
 		return false
 	}
 
+	// Use a single deadline so the total wait across all proxies does not exceed timeout.
+	deadline := time.Now().Add(timeout)
 	for _, cfg := range proxyCfgs {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return false
+		}
 		name := cfg.GetBaseConfig().Name
 		pattern := fmt.Sprintf("[%s] start proxy success", name)
-		if err := p.WaitForOutput(pattern, 1, timeout); err != nil {
+		if err := p.WaitForOutput(pattern, 1, remaining); err != nil {
 			return false
 		}
 	}

--- a/test/e2e/pkg/process/process.go
+++ b/test/e2e/pkg/process/process.go
@@ -124,8 +124,8 @@ func (p *Process) SetBeforeStopHandler(fn func()) {
 	p.beforeStopHandler = fn
 }
 
-// WaitForOutput polls the combined process output until all patterns are found
-// or the timeout is reached. It also returns early if the process exits.
+// WaitForOutput polls the combined process output until the pattern is found
+// count time(s) or the timeout is reached. It also returns early if the process exits.
 func (p *Process) WaitForOutput(pattern string, count int, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {


### PR DESCRIPTION
## Summary
- Replace the fixed `time.Sleep(1500ms)` in `RunProcesses` with event-driven proxy registration detection by monitoring frpc log output for `"start proxy success"` messages
- Add thread-safe `SafeBuffer` to `Process` struct, enabling concurrent read/write of process output during execution
- Add `Process.WaitForOutput()` method to poll output with timeout and early exit on process termination
- Add `waitForClientProxyReady()` that uses `config.LoadClientConfig()` to extract proxy names, then waits for each proxy's success log
- For visitor-only clients (no deterministic readiness signal), fall back to the original sleep with elapsed time deducted

This approach is universal across all proxy types (TCP/UDP/HTTP/HTTPS/STCP/SUDP/XTCP/TCPMUX) since every proxy logs the same success message on registration.

## Test plan
- [x] `go build ./...` passes
- [x] `golangci-lint run` passes
- [x] `make e2e` passes (225/225, 3 consecutive runs)
- [x] Verified visitor-only clients (STCP/XTCP tests) still get fallback sleep
- [x] Verified proxy registration failure correctly falls back to sleep