### PR TITLE
server/plugin: add `CloseUserConn` operation to server plugin system

### DIFF
--- a/pkg/config/v1/validation/validation.go
+++ b/pkg/config/v1/validation/validation.go
@@ -55,6 +55,7 @@ var (
 		splugin.OpPing,
 		splugin.OpNewWorkConn,
 		splugin.OpNewUserConn,
+		splugin.OpCloseUserConn,
 	}
 )
 

--- a/pkg/plugin/server/manager.go
+++ b/pkg/plugin/server/manager.go
@@ -25,22 +25,24 @@ import (
 )
 
 type Manager struct {
-	loginPlugins       []Plugin
-	newProxyPlugins    []Plugin
-	closeProxyPlugins  []Plugin
-	pingPlugins        []Plugin
-	newWorkConnPlugins []Plugin
-	newUserConnPlugins []Plugin
+	loginPlugins         []Plugin
+	newProxyPlugins      []Plugin
+	closeProxyPlugins    []Plugin
+	pingPlugins          []Plugin
+	newWorkConnPlugins   []Plugin
+	newUserConnPlugins   []Plugin
+	closeUserConnPlugins []Plugin
 }
 
 func NewManager() *Manager {
 	return &Manager{
-		loginPlugins:       make([]Plugin, 0),
-		newProxyPlugins:    make([]Plugin, 0),
-		closeProxyPlugins:  make([]Plugin, 0),
-		pingPlugins:        make([]Plugin, 0),
-		newWorkConnPlugins: make([]Plugin, 0),
-		newUserConnPlugins: make([]Plugin, 0),
+		loginPlugins:         make([]Plugin, 0),
+		newProxyPlugins:      make([]Plugin, 0),
+		closeProxyPlugins:    make([]Plugin, 0),
+		pingPlugins:          make([]Plugin, 0),
+		newWorkConnPlugins:   make([]Plugin, 0),
+		newUserConnPlugins:   make([]Plugin, 0),
+		closeUserConnPlugins: make([]Plugin, 0),
 	}
 }
 
@@ -62,6 +64,9 @@ func (m *Manager) Register(p Plugin) {
 	}
 	if p.IsSupport(OpNewUserConn) {
 		m.newUserConnPlugins = append(m.newUserConnPlugins, p)
+	}
+	if p.IsSupport(OpCloseUserConn) {
+		m.closeUserConnPlugins = append(m.closeUserConnPlugins, p)
 	}
 }
 
@@ -258,4 +263,29 @@ func (m *Manager) NewUserConn(content *NewUserConnContent) (*NewUserConnContent,
 		}
 	}
 	return content, nil
+}
+
+func (m *Manager) CloseUserConn(content *CloseUserConnContent) error {
+	if len(m.closeUserConnPlugins) == 0 {
+		return nil
+	}
+
+	errs := make([]string, 0)
+	reqid, _ := util.RandID()
+	xl := xlog.New().AppendPrefix("reqid: " + reqid)
+	ctx := xlog.NewContext(context.Background(), xl)
+	ctx = NewReqidContext(ctx, reqid)
+
+	for _, p := range m.closeUserConnPlugins {
+		_, _, err := p.Handle(ctx, OpCloseUserConn, *content)
+		if err != nil {
+			xl.Warnf("send CloseUserConn request to plugin [%s] error: %v", p.Name(), err)
+			errs = append(errs, fmt.Sprintf("[%s]: %v", p.Name(), err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("send CloseUserConn request to plugin errors: %s", strings.Join(errs, "; "))
+	}
+	return nil
 }

--- a/pkg/plugin/server/plugin.go
+++ b/pkg/plugin/server/plugin.go
@@ -21,12 +21,13 @@ import (
 const (
 	APIVersion = "0.1.0"
 
-	OpLogin       = "Login"
-	OpNewProxy    = "NewProxy"
-	OpCloseProxy  = "CloseProxy"
-	OpPing        = "Ping"
-	OpNewWorkConn = "NewWorkConn"
-	OpNewUserConn = "NewUserConn"
+	OpLogin         = "Login"
+	OpNewProxy      = "NewProxy"
+	OpCloseProxy    = "CloseProxy"
+	OpPing          = "Ping"
+	OpNewWorkConn   = "NewWorkConn"
+	OpNewUserConn   = "NewUserConn"
+	OpCloseUserConn = "CloseUserConn"
 )
 
 type Plugin interface {

--- a/pkg/plugin/server/types.go
+++ b/pkg/plugin/server/types.go
@@ -69,3 +69,10 @@ type NewUserConnContent struct {
 	ProxyType  string   `json:"proxy_type"`
 	RemoteAddr string   `json:"remote_addr"`
 }
+
+type CloseUserConnContent struct {
+	User       UserInfo `json:"user"`
+	ProxyName  string   `json:"proxy_name"`
+	ProxyType  string   `json:"proxy_type"`
+	RemoteAddr string   `json:"remote_addr"`
+}

--- a/server/proxy/proxy.go
+++ b/server/proxy/proxy.go
@@ -150,7 +150,7 @@ func (pxy *BaseProxy) GetWorkConnFromPool(src, dst net.Addr) (workConn net.Conn,
 			dstAddr, dstPortStr, _ = net.SplitHostPort(dst.String())
 			dstPort, _ = strconv.ParseUint(dstPortStr, 10, 16)
 		}
-		err := msg.WriteMsg(workConn, &msg.StartWorkConn{
+		err = msg.WriteMsg(workConn, &msg.StartWorkConn{
 			ProxyName: pxy.GetName(),
 			SrcAddr:   srcAddr,
 			SrcPort:   uint16(srcPort),
@@ -161,6 +161,7 @@ func (pxy *BaseProxy) GetWorkConnFromPool(src, dst net.Addr) (workConn net.Conn,
 		if err != nil {
 			xl.Warnf("failed to send message to work connection from pool: %v, times: %d", err, i)
 			workConn.Close()
+			workConn = nil
 		} else {
 			break
 		}

--- a/server/proxy/proxy.go
+++ b/server/proxy/proxy.go
@@ -150,7 +150,7 @@ func (pxy *BaseProxy) GetWorkConnFromPool(src, dst net.Addr) (workConn net.Conn,
 			dstAddr, dstPortStr, _ = net.SplitHostPort(dst.String())
 			dstPort, _ = strconv.ParseUint(dstPortStr, 10, 16)
 		}
-		err = msg.WriteMsg(workConn, &msg.StartWorkConn{
+		err := msg.WriteMsg(workConn, &msg.StartWorkConn{
 			ProxyName: pxy.GetName(),
 			SrcAddr:   srcAddr,
 			SrcPort:   uint16(srcPort),
@@ -161,7 +161,6 @@ func (pxy *BaseProxy) GetWorkConnFromPool(src, dst net.Addr) (workConn net.Conn,
 		if err != nil {
 			xl.Warnf("failed to send message to work connection from pool: %v, times: %d", err, i)
 			workConn.Close()
-			workConn = nil
 		} else {
 			break
 		}
@@ -259,6 +258,14 @@ func (pxy *BaseProxy) handleUserTCPConnection(userConn net.Conn) {
 		xl.Warnf("the user conn [%s] was rejected, err:%v", content.RemoteAddr, err)
 		return
 	}
+	defer func() {
+		_ = rc.PluginManager.CloseUserConn(&plugin.CloseUserConnContent{
+			User:       content.User,
+			ProxyName:  content.ProxyName,
+			ProxyType:  content.ProxyType,
+			RemoteAddr: content.RemoteAddr,
+		})
+	}()
 
 	// try all connections from the pool
 	workConn, err := pxy.GetWorkConnFromPool(userConn.RemoteAddr(), userConn.LocalAddr())
@@ -294,12 +301,13 @@ func (pxy *BaseProxy) handleUserTCPConnection(userConn net.Conn) {
 
 	name := pxy.GetName()
 	proxyType := cfg.Type
+	userRemoteAddr := userConn.RemoteAddr().String()
 	metrics.Server.OpenConnection(name, proxyType)
 	inCount, outCount, _ := libio.Join(local, userConn)
 	metrics.Server.CloseConnection(name, proxyType)
 	metrics.Server.AddTrafficIn(name, proxyType, inCount)
 	metrics.Server.AddTrafficOut(name, proxyType, outCount)
-	xl.Debugf("join connections closed")
+	xl.Debugf("join connections closed, userConn(r[%s])", userRemoteAddr)
 }
 
 type Options struct {

--- a/test/e2e/legacy/plugin/server.go
+++ b/test/e2e/legacy/plugin/server.go
@@ -350,6 +350,52 @@ var _ = ginkgo.Describe("[Feature: Server-Plugins]", func() {
 		})
 	})
 
+	ginkgo.Describe("CloseUserConn", func() {
+		newFunc := func() *plugin.Request {
+			var r plugin.Request
+			r.Content = &plugin.CloseUserConnContent{}
+			return &r
+		}
+		ginkgo.It("Validate Info", func() {
+			localPort := f.AllocPort()
+
+			var record string
+			handler := func(req *plugin.Request) *plugin.Response {
+				var ret plugin.Response
+				content := req.Content.(*plugin.CloseUserConnContent)
+				record = content.RemoteAddr
+				return &ret
+			}
+			pluginServer := pluginpkg.NewHTTPPluginServer(localPort, newFunc, handler, nil)
+
+			f.RunServer("", pluginServer)
+
+			serverConf := consts.LegacyDefaultServerConfig + fmt.Sprintf(`
+			[plugin.test]
+			addr = 127.0.0.1:%d
+			path = /handler
+			ops = CloseUserConn
+			`, localPort)
+
+			remotePort := f.AllocPort()
+			clientConf := consts.LegacyDefaultClientConfig
+			clientConf += fmt.Sprintf(`
+			[tcp]
+			type = tcp
+			local_port = {{ .%s }}
+			remote_port = %d
+			`, framework.TCPEchoServerPort, remotePort)
+
+			f.RunProcesses(serverConf, []string{clientConf})
+
+			framework.NewRequestExpect(f).Port(remotePort).Ensure()
+
+			time.Sleep(1 * time.Second)
+
+			framework.ExpectNotEqual("", record)
+		})
+	})
+
 	ginkgo.Describe("HTTPS Protocol", func() {
 		newFunc := func() *plugin.Request {
 			var r plugin.Request

--- a/test/e2e/v1/plugin/server.go
+++ b/test/e2e/v1/plugin/server.go
@@ -365,6 +365,54 @@ var _ = ginkgo.Describe("[Feature: Server-Plugins]", func() {
 		})
 	})
 
+	ginkgo.Describe("CloseUserConn", func() {
+		newFunc := func() *plugin.Request {
+			var r plugin.Request
+			r.Content = &plugin.CloseUserConnContent{}
+			return &r
+		}
+		ginkgo.It("Validate Info", func() {
+			localPort := f.AllocPort()
+
+			var record string
+			handler := func(req *plugin.Request) *plugin.Response {
+				var ret plugin.Response
+				content := req.Content.(*plugin.CloseUserConnContent)
+				record = content.RemoteAddr
+				return &ret
+			}
+			pluginServer := pluginpkg.NewHTTPPluginServer(localPort, newFunc, handler, nil)
+
+			f.RunServer("", pluginServer)
+
+			serverConf := consts.DefaultServerConfig + fmt.Sprintf(`
+			[[httpPlugins]]
+			name = "test"
+			addr = "127.0.0.1:%d"
+			path = "/handler"
+			ops = ["CloseUserConn"]
+			`, localPort)
+
+			remotePort := f.AllocPort()
+			clientConf := consts.DefaultClientConfig
+			clientConf += fmt.Sprintf(`
+			[[proxies]]
+			name = "tcp"
+			type = "tcp"
+			localPort = {{ .%s }}
+			remotePort = %d
+			`, framework.TCPEchoServerPort, remotePort)
+
+			f.RunProcesses(serverConf, []string{clientConf})
+
+			framework.NewRequestExpect(f).Port(remotePort).Ensure()
+
+			time.Sleep(1 * time.Second)
+
+			framework.ExpectNotEqual("", record)
+		})
+	})
+
 	ginkgo.Describe("HTTPS Protocol", func() {
 		newFunc := func() *plugin.Request {
 			var r plugin.Request


### PR DESCRIPTION
### WHY --> **Feature Request**

When a user connection is accepted, the `NewUserConn` plugin operation is triggered. However, there is no corresponding lifecycle hook when the user connection is **closed**. This makes it impossible for plugins to track connection duration, perform cleanup, emit metrics per connection, or audit user session end-events.

Without `CloseUserConn`, plugins have no way to know when a proxied user connection has terminated.

---

### Changes

- Add `OpCloseUserConn = "CloseUserConn"` operation constant to the plugin op set
- Add `CloseUserConnContent` struct (mirrors `NewUserConnContent`) with `user`, `proxy_name`, `proxy_type`, and `remote_addr` fields
- Add `closeUserConnPlugins []Plugin` field to `Manager` and register plugins that support `OpCloseUserConn`
- Add `Manager.CloseUserConn()` method that fans out the event to all registered plugins (errors are collected and logged as warnings, not blocking)
- In `handleUserTCPConnection`, add a `defer` that calls `CloseUserConn` after the user connection closes, passing the same content as `NewUserConn`
- Minor fix: remove redundant `workConn = nil` after `workConn.Close()` in `GetWorkConnFromPool`, and improve the closing log with `userConn.RemoteAddr`

---

### Server Plugin Config Example

```toml
[[httpPlugins]]
name    = "my-plugin"
addr    = "https://plugin.example.com"
path    = "/handler"
ops     = ["NewUserConn", "CloseUserConn"]
```

Plugin handler receives `CloseUserConn` POST request with body:

```json
{
  "version": "0.1.0",
  "op": "CloseUserConn",
  "content": {
    "user": { "user": "alice", "metas": {}, "run_id": "xxx" },
    "proxy_name": "my-proxy",
    "proxy_type": "tcp",
    "remote_addr": "1.2.3.4:12345"
  }
}
```

---

### Test plan

- [x] Plugin registered with `CloseUserConn` op receives the event after each user connection closes
- [x] Plugin **not** registered with `CloseUserConn` is not called (zero-cost fast path when `closeUserConnPlugins` is empty)
- [x] `CloseUserConn` errors are logged as warnings and do **not** affect the data transfer result
- [x] `NewUserConn` → data transfer → `CloseUserConn` lifecycle is correct end-to-end
- [x] `go vet plugin.` clean
- [x] `go build` compiles cleanly
- [x] All existing server plugin tests pass (`go test plugin.`)