### PR TITLE
add AGENTS.md and CLAUDE.md for AI coding assistants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,5 @@ client.key
 *.swp
 
 # AI
-CLAUDE.md
-AGENTS.md
+.claude/
 .sisyphus/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Development Commands
+
+### Build
+- `make build` - Build both frps and frpc binaries
+- `make frps` - Build server binary only
+- `make frpc` - Build client binary only
+- `make all` - Build everything with formatting
+
+### Testing
+- `make test` - Run unit tests
+- `make e2e` - Run end-to-end tests
+- `make e2e-trace` - Run e2e tests with trace logging
+- `make alltest` - Run all tests including vet, unit tests, and e2e
+
+### Code Quality
+- `make fmt` - Run go fmt
+- `make fmt-more` - Run gofumpt for more strict formatting
+- `make gci` - Run gci import organizer
+- `make vet` - Run go vet
+- `golangci-lint run` - Run comprehensive linting (configured in .golangci.yml)
+
+### Assets
+- `make web` - Build web dashboards (frps and frpc)
+
+### Cleanup
+- `make clean` - Remove built binaries and temporary files
+
+## Testing
+
+- E2E tests using Ginkgo/Gomega framework
+- Mock servers in `/test/e2e/mock/`
+- Run: `make e2e` or `make alltest`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` with development commands and testing info
- Add `CLAUDE.md` as symlink to `AGENTS.md`
- Remove both from `.gitignore`, add `.claude/` instead

## Test plan
- [x] Symlink works: `CLAUDE.md -> AGENTS.md`
- [x] No code changes