### PR TITLE
fix: use ConstantTimeEqString for visitor auth key comparison

### DIFF
--- a/server/visitor/visitor.go
+++ b/server/visitor/visitor.go
@@ -70,7 +70,7 @@ func (vm *Manager) NewConn(name string, conn net.Conn, timestamp int64, signKey 
 	defer vm.mu.RUnlock()
 
 	if l, ok := vm.listeners[name]; ok {
-		if util.GetAuthKey(l.sk, timestamp) != signKey {
+		if !util.ConstantTimeEqString(util.GetAuthKey(l.sk, timestamp), signKey) {
 			err = fmt.Errorf("visitor connection of [%s] auth failed", name)
 			return
 		}


### PR DESCRIPTION
`server/visitor/visitor.go` compares the visitor auth key using `!=`,
while `pkg/auth/token.go` and `pkg/nathole/controller.go` use
`util.ConstantTimeEqString()` for the same `GetAuthKey` comparison.

This aligns the visitor auth path with the existing pattern.