### PR TITLE
fix: dashboard 'Clear Offline' fails with JSON parse error

### DIFF
--- a/pkg/util/http/handler.go
+++ b/pkg/util/http/handler.go
@@ -48,7 +48,7 @@ func MakeHTTPHandlerFunc(handler APIHandler) http.HandlerFunc {
 		}
 
 		if res == nil {
-			w.WriteHeader(http.StatusOK)
+			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -226,7 +226,7 @@ func (c *Controller) DeleteProxies(ctx *httppkg.Context) (any, error) {
 	}
 	cleared, total := mem.StatsCollector.ClearOfflineProxies()
 	log.Infof("cleared [%d] offline proxies, total [%d] proxies", cleared, total)
-	return httppkg.GeneralResponse{Code: 200, Msg: "success"}, nil
+	return nil, nil
 }
 
 func (c *Controller) getProxyStatsByType(proxyType string) (proxyInfos []*model.ProxyStatsInfo) {

--- a/web/frps/src/api/http.ts
+++ b/web/frps/src/api/http.ts
@@ -27,11 +27,24 @@ async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
   }
 
   // Handle empty response (e.g. 204 No Content)
-  if (response.status === 204) {
+  if (
+    response.status === 204 ||
+    response.headers.get('Content-Length') === '0'
+  ) {
     return {} as T
   }
 
-  return response.json()
+  const contentType = response.headers.get('Content-Type') || ''
+  if (contentType.includes('application/json')) {
+    return response.json()
+  }
+
+  // Fallback: try to parse as JSON, return empty object if body is empty
+  const text = await response.text()
+  if (!text) {
+    return {} as T
+  }
+  return JSON.parse(text)
 }
 
 export const http = {


### PR DESCRIPTION
## Summary

Fixes the "Clear Offline" button on the frps dashboard crashing with:
> Failed to execute 'json' on 'Response': Unexpected end of JSON input

This is a confirmed bug reported independently by multiple users (#5233, #5236).

## Root Cause

Two issues work together to cause this:

1. **Backend (`pkg/util/http/handler.go`)**: `MakeHTTPHandlerFunc` returns HTTP 200 with an **empty body** when a handler returns `nil`. The frontend only skips JSON parsing for 204 responses, so an empty-body 200 causes `response.json()` to throw.

2. **Frontend (`web/frps/src/api/http.ts`)**: The `request()` function unconditionally calls `response.json()` on any non-204 response without checking `Content-Type` or body content. The frpc dashboard's `http.ts` already had this check — the frps version was missing it.

## Changes

- **`pkg/util/http/handler.go`**: Return `204 No Content` (instead of 200 with empty body) when a handler returns `nil`. This is the correct REST semantics.
- **`server/http/controller.go`**: `DeleteProxies` now returns `nil` (no body needed) — the 204 status code communicates success.
- **`web/frps/src/api/http.ts`**: Added `Content-Type` check and empty-body handling before calling `response.json()`, consistent with the frpc dashboard implementation.

## Test Plan

- [x] `go test ./server/...` — all tests pass
- [x] Go code compiles cleanly
- [ ] Manual: open frps dashboard → Proxies → Clear Offline → should succeed without error

Fixes #5242
Related: #5233, #5236