### PR TITLE
docker: copy shared web directory for npm workspace builds

### DIFF
--- a/dockerfiles/Dockerfile-for-frpc
+++ b/dockerfiles/Dockerfile-for-frpc
@@ -1,8 +1,11 @@
 FROM node:22 AS web-builder
 
-WORKDIR /web/frpc
-COPY web/frpc/ ./
+COPY web/package.json /web/package.json
+COPY web/shared/ /web/shared/
+COPY web/frpc/ /web/frpc/
+WORKDIR /web
 RUN npm install
+WORKDIR /web/frpc
 RUN npm run build
 
 FROM golang:1.25 AS building

--- a/dockerfiles/Dockerfile-for-frps
+++ b/dockerfiles/Dockerfile-for-frps
@@ -1,8 +1,11 @@
 FROM node:22 AS web-builder
 
-WORKDIR /web/frps
-COPY web/frps/ ./
+COPY web/package.json /web/package.json
+COPY web/shared/ /web/shared/
+COPY web/frps/ /web/frps/
+WORKDIR /web
 RUN npm install
+WORKDIR /web/frps
 RUN npm run build
 
 FROM golang:1.25 AS building


### PR DESCRIPTION
## Summary
- Fix Docker image build failure caused by missing `web/shared/` directory
- Update both frpc and frps Dockerfiles to copy `web/package.json` and `web/shared/` for npm workspace builds

## Test plan
- [ ] Docker image build workflow passes