### PR TITLE
web/frps: restore XTCP support across dashboard views

### DIFF
--- a/web/frps/src/utils/proxy.ts
+++ b/web/frps/src/utils/proxy.ts
@@ -149,6 +149,13 @@ class SUDPProxy extends BaseProxy {
   }
 }
 
+class XTCPProxy extends BaseProxy {
+  constructor(proxyStats: any) {
+    super(proxyStats)
+    this.type = 'xtcp'
+  }
+}
+
 export {
   BaseProxy,
   TCPProxy,
@@ -158,4 +165,5 @@ export {
   HTTPSProxy,
   STCPProxy,
   SUDPProxy,
+  XTCPProxy,
 }

--- a/web/frps/src/views/ClientDetail.vue
+++ b/web/frps/src/views/ClientDetail.vue
@@ -139,6 +139,7 @@ import {
   TCPMuxProxy,
   STCPProxy,
   SUDPProxy,
+  XTCPProxy,
 } from '../utils/proxy'
 import { getServerInfo } from '../api/server'
 import ProxyCard from '../components/ProxyCard.vue'
@@ -213,7 +214,16 @@ const fetchClient = async () => {
 
 const fetchProxies = async () => {
   proxiesLoading.value = true
-  const proxyTypes = ['tcp', 'udp', 'http', 'https', 'tcpmux', 'stcp', 'sudp']
+  const proxyTypes = [
+    'tcp',
+    'udp',
+    'http',
+    'https',
+    'tcpmux',
+    'stcp',
+    'sudp',
+    'xtcp',
+  ]
   const proxies: BaseProxy[] = []
   try {
     const info = await fetchServerInfo()
@@ -254,6 +264,8 @@ const fetchProxies = async () => {
           proxies.push(...json.proxies.map((p: any) => new STCPProxy(p)))
         } else if (type === 'sudp') {
           proxies.push(...json.proxies.map((p: any) => new SUDPProxy(p)))
+        } else if (type === 'xtcp') {
+          proxies.push(...json.proxies.map((p: any) => new XTCPProxy(p)))
         }
       } catch {
         // Ignore

--- a/web/frps/src/views/Proxies.vue
+++ b/web/frps/src/views/Proxies.vue
@@ -113,6 +113,7 @@ import {
   TCPMuxProxy,
   STCPProxy,
   SUDPProxy,
+  XTCPProxy,
 } from '../utils/proxy'
 import ProxyCard from '../components/ProxyCard.vue'
 import PopoverMenu from '@shared/components/PopoverMenu.vue'
@@ -136,6 +137,7 @@ const proxyTypes = [
   { label: 'TCPMUX', value: 'tcpmux' },
   { label: 'STCP', value: 'stcp' },
   { label: 'SUDP', value: 'sudp' },
+  { label: 'XTCP', value: 'xtcp' },
 ]
 
 const activeType = ref((route.params.type as string) || 'tcp')
@@ -288,6 +290,8 @@ const fetchData = async () => {
       proxies.value = json.proxies.map((p: any) => new STCPProxy(p))
     } else if (type === 'sudp') {
       proxies.value = json.proxies.map((p: any) => new SUDPProxy(p))
+    } else if (type === 'xtcp') {
+      proxies.value = json.proxies.map((p: any) => new XTCPProxy(p))
     }
   } catch (error: any) {
     ElMessage({

--- a/web/frps/src/views/ProxyDetail.vue
+++ b/web/frps/src/views/ProxyDetail.vue
@@ -252,6 +252,7 @@ import {
   TCPMuxProxy,
   STCPProxy,
   SUDPProxy,
+  XTCPProxy,
 } from '../utils/proxy'
 import Traffic from '../components/Traffic.vue'
 
@@ -391,6 +392,8 @@ const fetchProxy = async () => {
       proxy.value = new STCPProxy(data)
     } else if (type === 'sudp') {
       proxy.value = new SUDPProxy(data)
+    } else if (type === 'xtcp') {
+      proxy.value = new XTCPProxy(data)
     } else {
       proxy.value = new BaseProxy(data)
       proxy.value.type = type


### PR DESCRIPTION
## Summary
- restore XTCP handling in the frps dashboard proxy list by adding the missing `xtcp` tab and list mapping
- include XTCP proxies in client detail aggregation so they show up alongside the other proxy types
- add an `XTCPProxy` frontend model and use it consistently in proxy detail handling instead of falling back to `BaseProxy`

## Why
The backend API already supports XTCP, and `ProxyDetail.vue` even has XTCP-specific visual treatment, but the current `web/frps` UI still misses explicit XTCP handling in its main entry points. As a result, XTCP proxies are omitted from:
- the global Proxies view
- the per-client proxy list
- the explicit typed model path in the proxy detail view

This restores end-to-end dashboard support for XTCP instead of only patching a single tab.

Closes #5244.

## Verification
- uploaded the updated `web/` workspace to an Ubuntu 22.04 cloud host and ran `npm ci` from `web/`
- ran `npm run type-check` in `web/frps`
- ran `npm run build` in `web/frps`
