### PR TITLE
nathole: return error when SetTTL fails in sendSidMessage

### DIFF
--- a/pkg/nathole/nathole.go
+++ b/pkg/nathole/nathole.go
@@ -372,6 +372,7 @@ func sendSidMessage(
 		err = uConn.SetTTL(ttl)
 		if err != nil {
 			xl.Tracef("set ttl error %v", err)
+			return err
 		} else {
 			defer func() {
 				_ = uConn.SetTTL(original)


### PR DESCRIPTION
## Summary
- Propagate `SetTTL` errors in `sendSidMessage` instead of only logging and continuing, so UDP is not sent with an unintended TTL when TTL setup fails.
- Matches existing behavior for `TTL()` failures in the same path.

## Context
Per [Contributing](https://github.com/fatedier/frp/blob/dev/README.md#contributing), PR targets **dev**.