### PR TITLE
client: close TCP connection when fmux session creation fails

### DIFF
--- a/client/connector.go
+++ b/client/connector.go
@@ -119,6 +119,7 @@ func (c *defaultConnectorImpl) Open() error {
 	fmuxCfg.MaxStreamWindowSize = 6 * 1024 * 1024
 	session, err := fmux.Client(conn, fmuxCfg)
 	if err != nil {
+		conn.Close()
 		return err
 	}
 	c.muxSession = session


### PR DESCRIPTION
## Summary
- Close the TCP connection when `fmux.Client` fails after `realConnect()` succeeds, since the connector does not retain the conn and it would otherwise leak.

PR targets **dev** per project contributing guidelines.