### PR TITLE
搞错了分支, 抱歉

### DIFF
--- a/pkg/transport/mix/udp_demux.go
+++ b/pkg/transport/mix/udp_demux.go
@@ -1,0 +1,227 @@
+package mix
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+const (
+	udpPeerRouteTTL           = 5 * time.Minute
+	udpPeerRoutePruneInterval = 1 * time.Minute
+)
+
+type packet struct {
+	data []byte
+	addr net.Addr
+}
+
+type demuxPacketConn struct {
+	parent *UDPDemux
+	name   string
+	ch     chan packet
+
+	mu           sync.RWMutex
+	readDeadline time.Time
+	closed       bool
+}
+
+func (c *demuxPacketConn) ReadFrom(p []byte) (int, net.Addr, error) {
+	for {
+		c.mu.RLock()
+		deadline := c.readDeadline
+		closed := c.closed
+		c.mu.RUnlock()
+		if closed {
+			return 0, nil, net.ErrClosed
+		}
+
+		var timer <-chan time.Time
+		if !deadline.IsZero() {
+			d := time.Until(deadline)
+			if d <= 0 {
+				return 0, nil, net.ErrClosed
+			}
+			timer = time.After(d)
+		}
+
+		select {
+		case pkt, ok := <-c.ch:
+			if !ok {
+				return 0, nil, net.ErrClosed
+			}
+			n := copy(p, pkt.data)
+			return n, pkt.addr, nil
+		case <-timer:
+			return 0, nil, net.ErrClosed
+		}
+	}
+}
+
+func (c *demuxPacketConn) WriteTo(p []byte, addr net.Addr) (int, error) {
+	return c.parent.conn.WriteTo(p, addr)
+}
+
+func (c *demuxPacketConn) enqueue(pkt packet) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.closed {
+		return false
+	}
+	select {
+	case c.ch <- pkt:
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *demuxPacketConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	close(c.ch)
+	return nil
+}
+
+func (c *demuxPacketConn) LocalAddr() net.Addr {
+	return c.parent.conn.LocalAddr()
+}
+
+func (c *demuxPacketConn) SetDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.readDeadline = t
+	return nil
+}
+
+func (c *demuxPacketConn) SetReadDeadline(t time.Time) error {
+	return c.SetDeadline(t)
+}
+
+func (c *demuxPacketConn) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+type UDPDemux struct {
+	conn net.PacketConn
+
+	mu                sync.RWMutex
+	routeFn           func([]byte) string
+	peers             map[string]peerRoute
+	conns             map[string]*demuxPacketConn
+	lastPeerPruneTime time.Time
+	closed            bool
+}
+
+type peerRoute struct {
+	child    *demuxPacketConn
+	lastSeen time.Time
+}
+
+func NewUDPDemux(conn net.PacketConn, routeFn func([]byte) string, names ...string) *UDPDemux {
+	d := &UDPDemux{
+		conn:              conn,
+		routeFn:           routeFn,
+		peers:             make(map[string]peerRoute),
+		conns:             make(map[string]*demuxPacketConn, len(names)),
+		lastPeerPruneTime: time.Now(),
+	}
+	for _, name := range names {
+		d.conns[name] = &demuxPacketConn{
+			parent: d,
+			name:   name,
+			ch:     make(chan packet, 256),
+		}
+	}
+	return d
+}
+
+func (d *UDPDemux) Conn(name string) net.PacketConn {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.conns[name]
+}
+
+func (d *UDPDemux) Serve() error {
+	buf := make([]byte, 64*1024)
+	for {
+		n, addr, err := d.conn.ReadFrom(buf)
+		if err != nil {
+			return err
+		}
+		key := addr.String()
+		now := time.Now()
+
+		d.mu.Lock()
+		if now.Sub(d.lastPeerPruneTime) >= udpPeerRoutePruneInterval {
+			d.pruneStalePeersLocked(now)
+			d.lastPeerPruneTime = now
+		}
+
+		route := d.peers[key]
+		child := route.child
+		if child == nil {
+			name := d.routeFn(buf[:n])
+			child = d.conns[name]
+			if child == nil {
+				d.mu.Unlock()
+				continue
+			}
+			route.child = child
+		}
+		route.lastSeen = now
+		d.peers[key] = route
+		d.mu.Unlock()
+
+		pkt := packet{
+			data: append([]byte(nil), buf[:n]...),
+			addr: addr,
+		}
+		_ = child.enqueue(pkt)
+	}
+}
+
+func (d *UDPDemux) pruneStalePeersLocked(now time.Time) {
+	for key, route := range d.peers {
+		if now.Sub(route.lastSeen) > udpPeerRouteTTL {
+			delete(d.peers, key)
+		}
+	}
+}
+
+func (d *UDPDemux) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return nil
+	}
+	d.closed = true
+	for _, child := range d.conns {
+		_ = child.Close()
+	}
+	return d.conn.Close()
+}
+
+func RouteQUICThenKCP(packet []byte) string {
+	if len(packet) == 0 {
+		return ""
+	}
+	// QUIC Initial packets always carry both Header Form (0x80) and Fixed Bit (0x40).
+	if packet[0]&0x80 != 0 && packet[0]&0x40 != 0 {
+		return "quic"
+	}
+	return "kcp"
+}
+
+func MustPacketConn(d *UDPDemux, name string) net.PacketConn {
+	conn := d.Conn(name)
+	if conn == nil {
+		panic(fmt.Sprintf("missing demux packet conn %q", name))
+	}
+	return conn
+}

--- a/pkg/transport/mix/udp_demux_test.go
+++ b/pkg/transport/mix/udp_demux_test.go
@@ -1,0 +1,51 @@
+package mix
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDemuxPacketConnEnqueueAfterCloseIsDropped(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer pc.Close()
+
+	demux := NewUDPDemux(pc, func([]byte) string { return "kcp" }, "kcp")
+	conn := demux.Conn("kcp").(*demuxPacketConn)
+
+	require.NoError(t, conn.Close())
+	require.False(t, conn.enqueue(packet{
+		data: []byte("payload"),
+		addr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345},
+	}))
+}
+
+func TestUDPDemuxPruneStalePeers(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer pc.Close()
+
+	demux := NewUDPDemux(pc, func([]byte) string { return "kcp" }, "kcp")
+	conn := demux.Conn("kcp").(*demuxPacketConn)
+
+	now := time.Now()
+	demux.mu.Lock()
+	demux.peers["stale"] = peerRoute{
+		child:    conn,
+		lastSeen: now.Add(-udpPeerRouteTTL - time.Second),
+	}
+	demux.peers["fresh"] = peerRoute{
+		child:    conn,
+		lastSeen: now,
+	}
+	demux.pruneStalePeersLocked(now)
+	_, staleExists := demux.peers["stale"]
+	_, freshExists := demux.peers["fresh"]
+	demux.mu.Unlock()
+
+	require.False(t, staleExists)
+	require.True(t, freshExists)
+}


### PR DESCRIPTION
## 变更说明
本 PR 引入 UDP demux 路由表老化清理机制，避免 UDP 源地址映射长期累积导致内存增长与陈旧路由残留。

## 主要修改
- 新增 `peerRoute`，记录 `lastSeen`
- `peers` 从 `map[string]*demuxPacketConn` 调整为带时间戳的路由记录
- 增加定期清理：`udpPeerRouteTTL=5m`，`udpPeerRoutePruneInterval=1m`
- 在 `Serve()` 主循环中按周期 prune 过期 peer route

## 测试
- 新增 `TestUDPDemuxPruneStalePeers`，验证过期条目剔除与活跃条目保留
- 保留并通过 `TestDemuxPacketConnEnqueueAfterCloseIsDropped`

## 备注
该改动不改变现有路由判定逻辑，仅补齐生命周期清理。
