### PR TITLE
fix: using variable interpolation `${{ in build-and-push-image.yml (y...

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -31,11 +31,13 @@ jobs:
 
       # get image tag name
       - name: Get Image Tag Name
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          if [ x${{ github.event.inputs.tag }} == x"" ]; then
+          if [ x"$INPUT_TAG" == x"" ]; then
             echo "TAG_NAME=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
           else
-            echo "TAG_NAME=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+            echo "TAG_NAME=$INPUT_TAG" >> $GITHUB_ENV
           fi
       - name: Login to DockerHub
         uses: docker/login-action@v4


### PR DESCRIPTION
## Summary
Fix high severity security issue in `.github/workflows/build-and-push-image.yml`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | yaml.github-actions.security.run-shell-injection.run-shell-injection |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `yaml.github-actions.security.run-shell-injection.run-shell-injection` |
| **File** | `.github/workflows/build-and-push-image.yml:34` |

**Description**: Using variable interpolation `${{...}}` with `github` context data in a `run:` step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. `github` context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with `env:` to store the data and use the environment variable in the `run:` script. Be sure to use double-quotes the environment variable, like this: "$ENVVAR".

## Changes
- `.github/workflows/build-and-push-image.yml`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] Code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
