### PR TITLE
server: add proxy protocol support for bind and vhost HTTP/HTTPS listeners

### DIFF
--- a/pkg/config/v1/server.go
+++ b/pkg/config/v1/server.go
@@ -51,6 +51,14 @@ type ServerConfig struct {
 	// Vhost requests. If this value is 0, the server will not listen for HTTPS
 	// requests.
 	VhostHTTPSPort int `json:"vhostHTTPSPort,omitempty"`
+	// VhostHTTPSProxyProtocol enables PROXY protocol (v1 and v2) parsing
+	// on the HTTPS vhost listener. When true, the real client IP is
+	// extracted from the PROXY protocol header and used as the source
+	// address for proxied connections. By default, this is false.
+	VhostHTTPSProxyProtocol bool `json:"vhostHTTPSProxyProtocol,omitempty"`
+	// VhostHTTPProxyProtocol is the same as VhostHTTPSProxyProtocol but
+	// for the HTTP vhost listener.
+	VhostHTTPProxyProtocol bool `json:"vhostHTTPProxyProtocol,omitempty"`
 	// TCPMuxHTTPConnectPort specifies the port that the server listens for TCP
 	// HTTP CONNECT requests. If the value is 0, the server will not multiplex TCP
 	// requests on one single port. If it's not - it will listen on this value for

--- a/pkg/config/v1/server.go
+++ b/pkg/config/v1/server.go
@@ -31,6 +31,12 @@ type ServerConfig struct {
 	// BindPort specifies the port that the server listens on. By default, this
 	// value is 7000.
 	BindPort int `json:"bindPort,omitempty"`
+	// BindProxyProtocol enables PROXY protocol (v1 and v2) parsing on the
+	// bind port listener. When true, the real client IP is extracted from
+	// the PROXY protocol header before protocol multiplexing. This is
+	// useful when frps is behind a load balancer that sends PROXY protocol.
+	// By default, this is false.
+	BindProxyProtocol bool `json:"bindProxyProtocol,omitempty"`
 	// KCPBindPort specifies the KCP port that the server listens on. If this
 	// value is 0, the server will not listen for KCP connections.
 	KCPBindPort int `json:"kcpBindPort,omitempty"`

--- a/server/service.go
+++ b/server/service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/fatedier/golib/crypto"
 	"github.com/fatedier/golib/net/mux"
 	fmux "github.com/hashicorp/yamux"
+	pp "github.com/pires/go-proxyproto"
 	quic "github.com/quic-go/quic-go"
 	"github.com/samber/lo"
 
@@ -308,6 +309,10 @@ func NewService(cfg *v1.ServerConfig) (*Service, error) {
 				return nil, fmt.Errorf("create vhost http listener error, %v", err)
 			}
 		}
+		if cfg.VhostHTTPProxyProtocol {
+			log.Infof("http vhost proxy protocol enabled")
+			l = &pp.Listener{Listener: l}
+		}
 		go func() {
 			_ = server.Serve(l)
 		}()
@@ -326,6 +331,11 @@ func NewService(cfg *v1.ServerConfig) (*Service, error) {
 				return nil, fmt.Errorf("create server listener error, %v", err)
 			}
 			log.Infof("https service listen on %s", address)
+		}
+
+		if cfg.VhostHTTPSProxyProtocol {
+			log.Infof("https vhost proxy protocol enabled")
+			l = &pp.Listener{Listener: l}
 		}
 
 		svr.rc.VhostHTTPSMuxer, err = vhost.NewHTTPSMuxer(l, vhostReadWriteTimeout)

--- a/server/service.go
+++ b/server/service.go
@@ -235,6 +235,10 @@ func NewService(cfg *v1.ServerConfig) (*Service, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create server listener error, %v", err)
 	}
+	if cfg.BindProxyProtocol {
+		log.Infof("bindPort proxy protocol enabled")
+		ln = &pp.Listener{Listener: ln}
+	}
 
 	svr.muxer = mux.NewMux(ln)
 	svr.muxer.SetKeepAlive(time.Duration(cfg.Transport.TCPKeepAlive) * time.Second)


### PR DESCRIPTION
Add vhostHTTPSProxyProtocol and vhostHTTPProxyProtocol config options that enable PROXY protocol (v1/v2) parsing on the bind and vhost listeners.

When enabled, the real client IP is extracted from the PROXY protocol header sent by an upstream load balancer and used as the source address for proxied connections. The IP flows through the existing StartWorkConn.SrcAddr mechanism to frpc, making it available in X-Forwarded-For headers (https2http/https2https plugins) and via transport.proxyProtocolVersion for raw TCP proxies.

Uses the existing github.com/pires/go-proxyproto dependency (already used by frpc for sending proxy protocol to local services).