### PR TITLE
add toml editor support for frpc dashboard

### DIFF
--- a/web/frpc/components.d.ts
+++ b/web/frpc/components.d.ts
@@ -35,6 +35,7 @@ declare module 'vue' {
     RouterView: typeof import('vue-router')['RouterView']
     StatusPills: typeof import('./src/components/StatusPills.vue')['default']
     StringListEditor: typeof import('./src/components/StringListEditor.vue')['default']
+    TomlEditor: typeof import('./src/components/TomlEditor.vue')['default']
     VisitorBaseSection: typeof import('./src/components/visitor-form/VisitorBaseSection.vue')['default']
     VisitorConnectionSection: typeof import('./src/components/visitor-form/VisitorConnectionSection.vue')['default']
     VisitorFormLayout: typeof import('./src/components/visitor-form/VisitorFormLayout.vue')['default']

--- a/web/frpc/package.json
+++ b/web/frpc/package.json
@@ -12,9 +12,14 @@
     "lint": "eslint --fix"
   },
   "dependencies": {
+    "@codemirror/language": "^6.12.3",
+    "@codemirror/legacy-modes": "^6.5.2",
+    "@codemirror/theme-one-dark": "^6.1.3",
+    "codemirror": "^6.0.2",
     "element-plus": "^2.13.0",
     "pinia": "^3.0.4",
     "vue": "^3.5.26",
+    "vue-codemirror": "^6.1.1",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {

--- a/web/frpc/src/components/TomlEditor.vue
+++ b/web/frpc/src/components/TomlEditor.vue
@@ -1,0 +1,190 @@
+<template>
+  <div ref="editorRef" class="toml-editor"></div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, onMounted, onUnmounted, computed } from 'vue'
+import { useDark } from '@vueuse/core'
+import { basicSetup, EditorView } from 'codemirror'
+import { EditorState, Extension, Compartment } from '@codemirror/state'
+import { oneDark } from '@codemirror/theme-one-dark'
+import { StreamLanguage } from '@codemirror/language'
+import { toml } from '@codemirror/legacy-modes/mode/toml'
+import { placeholder as placeholderExt } from '@codemirror/view'
+import { keymap } from '@codemirror/view'
+import { defaultKeymap, indentWithTab } from '@codemirror/commands'
+
+const props = defineProps<{
+  modelValue: string
+  placeholder?: string
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const editorRef = ref<HTMLDivElement>()
+const editorView = ref<EditorView>()
+const isDark = useDark()
+const themeCompartment = new Compartment()
+
+const content = computed(() => props.modelValue)
+
+const lightTheme = EditorView.theme(
+  {
+    '&': {
+      backgroundColor: 'var(--color-bg-tertiary)',
+      color: 'var(--color-text-primary)',
+    },
+    '.cm-content': {
+      caretColor: 'var(--color-text-primary)',
+    },
+    '&.cm-focused .cm-cursor': {
+      borderLeftColor: 'var(--color-text-primary)',
+    },
+    '&.cm-focused .cm-selectionBackground, ::selection': {
+      backgroundColor: 'var(--color-primary-light)',
+    },
+    '.cm-gutters': {
+      backgroundColor: 'var(--color-bg-muted)',
+      color: 'var(--color-text-muted)',
+      borderRight: '1px solid var(--color-border-light)',
+    },
+    '.cm-activeLineGutter': {
+      backgroundColor: 'var(--color-bg-hover)',
+    },
+    '.cm-activeLine': {
+      backgroundColor: 'var(--color-bg-hover)',
+    },
+    '.cm-lineNumbers': {
+      color: 'var(--color-text-muted)',
+    },
+  },
+  { dark: false }
+)
+
+const darkThemeOverride = EditorView.theme(
+  {
+    '&': {
+      backgroundColor: 'var(--color-bg-tertiary)',
+    },
+    '.cm-gutters': {
+      backgroundColor: 'var(--color-bg-muted)',
+      borderRight: '1px solid var(--color-border-light)',
+    },
+  },
+  { dark: true }
+)
+
+const createThemeExtensions = (): Extension[] => {
+  return isDark.value ? [oneDark, darkThemeOverride] : [lightTheme]
+}
+
+const createExtensions = (): Extension[] => {
+  const exts: Extension[] = [
+    basicSetup,
+    keymap.of([...defaultKeymap, indentWithTab]),
+    StreamLanguage.define(toml),
+    EditorView.updateListener.of((v) => {
+      if (v.docChanged) {
+        emit('update:modelValue', v.state.doc.toString())
+      }
+    }),
+    EditorView.lineWrapping,
+    themeCompartment.of(createThemeExtensions()),
+  ]
+
+  if (props.placeholder) {
+    exts.push(placeholderExt(props.placeholder))
+  }
+
+  return exts
+}
+
+const initEditor = () => {
+  if (!editorRef.value) return
+
+  const state = EditorState.create({
+    doc: content.value,
+    extensions: createExtensions(),
+  })
+
+  editorView.value = new EditorView({
+    state,
+    parent: editorRef.value,
+  })
+}
+
+const destroyEditor = () => {
+  editorView.value?.destroy()
+  editorView.value = undefined
+}
+
+const reconfigureTheme = () => {
+  if (!editorView.value) return
+  editorView.value.dispatch({
+    effects: themeCompartment.reconfigure(createThemeExtensions()),
+  })
+}
+
+watch(
+  () => content.value,
+  (newValue) => {
+    if (!editorView.value) {
+      initEditor()
+      return
+    }
+    if (newValue === editorView.value.state.doc.toString()) {
+      return
+    }
+    editorView.value.dispatch({
+      changes: {
+        from: 0,
+        to: editorView.value.state.doc.length,
+        insert: newValue,
+      },
+      scrollIntoView: false,
+    })
+  },
+  { immediate: true }
+)
+
+watch(isDark, () => {
+  reconfigureTheme()
+})
+
+onMounted(() => {
+  if (!editorView.value) {
+    initEditor()
+  }
+})
+
+onUnmounted(() => {
+  destroyEditor()
+})
+</script>
+
+<style scoped lang="scss">
+.toml-editor {
+  height: 100%;
+
+  :deep(.cm-editor) {
+    height: 100%;
+    border-radius: $radius-md;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: $font-size-sm;
+    line-height: 1.6;
+    border: 1px solid var(--color-border-light);
+    overflow: hidden;
+  }
+
+  :deep(.cm-editor.cm-focused) {
+    border-color: var(--color-text-light);
+    outline: none;
+  }
+
+  :deep(.cm-scroller) {
+    border-radius: $radius-md;
+  }
+}
+</style>

--- a/web/frpc/src/views/ClientConfigure.vue
+++ b/web/frpc/src/views/ClientConfigure.vue
@@ -23,16 +23,13 @@
     </div>
 
     <div class="editor-wrapper">
-      <el-input
-        type="textarea"
-        :autosize="false"
+      <TomlEditor
         v-model="configContent"
         placeholder="# frpc configuration file content...
 
 serverAddr = &quot;127.0.0.1&quot;
 serverPort = 7000"
-        class="code-editor"
-      ></el-input>
+      />
     </div>
 
     <ConfirmDialog
@@ -54,6 +51,7 @@ import { Link } from '@element-plus/icons-vue'
 import { useClientStore } from '../stores/client'
 import ActionButton from '@shared/components/ActionButton.vue'
 import ConfirmDialog from '@shared/components/ConfirmDialog.vue'
+import TomlEditor from '../components/TomlEditor.vue'
 import { useResponsive } from '../composables/useResponsive'
 
 const { isMobile } = useResponsive()
@@ -155,28 +153,6 @@ fetchData()
 
   &:hover {
     color: $color-text-primary;
-  }
-}
-
-.code-editor {
-  height: 100%;
-
-  :deep(.el-textarea__inner) {
-    height: 100% !important;
-    overflow-y: auto;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    font-size: $font-size-sm;
-    line-height: 1.6;
-    padding: $spacing-lg;
-    border-radius: $radius-md;
-    background: $color-bg-tertiary;
-    border: 1px solid $color-border-light;
-    resize: none;
-
-    &:focus {
-      border-color: $color-text-light;
-      box-shadow: none;
-    }
   }
 }
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,9 +15,14 @@
       "name": "frpc-dashboard",
       "version": "0.0.1",
       "dependencies": {
+        "@codemirror/language": "^6.12.3",
+        "@codemirror/legacy-modes": "^6.5.2",
+        "@codemirror/theme-one-dark": "^6.1.3",
+        "codemirror": "^6.0.2",
         "element-plus": "^2.13.0",
         "pinia": "^3.0.4",
         "vue": "^3.5.26",
+        "vue-codemirror": "^6.1.1",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
@@ -126,6 +131,108 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.2.tgz",
+      "integrity": "sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.2.tgz",
+      "integrity": "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.6.tgz",
+      "integrity": "sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
+      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.42.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.42.1.tgz",
+      "integrity": "sha512-ToN3oFc0nsxNUYVF5P0ztLgbC4UPPjPtA9aKYhkOKQaZASpOUo6ISXyQLP66ctVwlDc+j6Jv0uK5IFALkiXztg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@ctrl/tinycolor": {
@@ -915,6 +1022,36 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2797,6 +2934,21 @@
         "consola": "^3.2.3"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2862,6 +3014,12 @@
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6567,6 +6725,12 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/superjson": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
@@ -7605,6 +7769,22 @@
         }
       }
     },
+    "node_modules/vue-codemirror": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vue-codemirror/-/vue-codemirror-6.1.1.tgz",
+      "integrity": "sha512-rTAYo44owd282yVxKtJtnOi7ERAcXTeviwoPXjIc6K/IQYUsoDkzPvw/JDFtSP6T7Cz/2g3EHaEyeyaQCKoDMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/commands": "6.x",
+        "@codemirror/language": "6.x",
+        "@codemirror/state": "6.x",
+        "@codemirror/view": "6.x"
+      },
+      "peerDependencies": {
+        "codemirror": "6.x",
+        "vue": "3.x"
+      }
+    },
     "node_modules/vue-eslint-parser": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.4.0.tgz",
@@ -7679,6 +7859,12 @@
       "peerDependencies": {
         "typescript": ">=5.0.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",


### PR DESCRIPTION
### Add TOML editor support to the frpc dashboard with line numbers and syntax highlighting for a smoother, more user-friendly online editing experience.

#### before
<img width="1916" height="935" alt="image" src="https://github.com/user-attachments/assets/deeda63d-db9e-42ef-a641-2139544f7bba" />


#### after
<img width="1913" height="929" alt="image" src="https://github.com/user-attachments/assets/207638dc-6958-4881-b78d-f239bd5a1b6b" />
<img width="1917" height="934" alt="image" src="https://github.com/user-attachments/assets/1c00ff86-d448-4a0c-bdca-2a038ae80d45" />


<!-- author to complete -->
