### PR TITLE
fix typos in comments

### DIFF
--- a/client/visitor/visitor.go
+++ b/client/visitor/visitor.go
@@ -50,7 +50,7 @@ type Helper interface {
 	RunID() string
 }
 
-// Visitor is used for forward traffics from local port tot remote service.
+// Visitor is used for forward traffics from local port to remote service.
 type Visitor interface {
 	Run() error
 	AcceptConn(conn net.Conn) error

--- a/pkg/config/legacy/proxy.go
+++ b/pkg/config/legacy/proxy.go
@@ -93,15 +93,15 @@ func NewProxyConfFromIni(prefix, name string, section *ini.Section) (ProxyConf, 
 	return conf, nil
 }
 
-// LocalSvrConf configures what location the client will to, or what
+// LocalSvrConf configures what location the client will connect to, or what
 // plugin will be used.
 type LocalSvrConf struct {
-	// LocalIP specifies the IP address or host name to to.
+	// LocalIP specifies the IP address or host name to connect to.
 	LocalIP string `ini:"local_ip" json:"local_ip"`
-	// LocalPort specifies the port to to.
+	// LocalPort specifies the port to connect to.
 	LocalPort int `ini:"local_port" json:"local_port"`
 
-	// Plugin specifies what plugin should be used for ng. If this value
+	// Plugin specifies what plugin should be used for handling connections. If this value
 	// is set, the LocalIp and LocalPort values will be ignored. By default,
 	// this value is "".
 	Plugin string `ini:"plugin" json:"plugin"`

--- a/server/proxy/udp.go
+++ b/server/proxy/udp.go
@@ -235,7 +235,7 @@ func (pxy *UDPProxy) Run() (remoteAddr string, err error) {
 	}()
 
 	// Read from user connections and send wrapped udp message to sendCh (forwarded by workConn).
-	// Client will transfor udp message to local udp service and waiting for response for a while.
+	// Client will transform udp message to local udp service and waiting for response for a while.
 	// Response will be wrapped to be forwarded by work connection to server.
 	// Close readCh and sendCh at the end.
 	go func() {


### PR DESCRIPTION
### WHY
Fix several typos in code comments across three files.

- server/proxy/udp.go: "transfor" → "transform"
- client/visitor/visitor.go: "tot" → "to"
- pkg/config/legacy/proxy.go: fix truncated/malformed comments in LocalSvrConf
  ("will to" → "will connect to", "to to" × 2, "for ng" → "for handling connections")
