### PR TITLE
docs: trim trailing whitespace in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ Enable dashboard first, then configure `enablePrometheus = true` in `frps.toml`.
 
 ### Authenticating the Client
 
-There are 2 authentication methods to authenticate frpc with frps. 
+There are 2 authentication methods to authenticate frpc with frps.
 
 You can decide which one to use by configuring `auth.method` in `frpc.toml` and `frps.toml`, the default one is token.
 


### PR DESCRIPTION
## Summary

This PR fixes Removes trailing whitespace from 1 line in README.md..

## Change type

- [ ] Documentation
- [ ] Repository hygiene
- [ ] Formatting
- [ ] Dependency maintenance

## Validation

- - 2/2 checks passed

## Scope

This change is intentionally small:
- Files changed: 1
- Lines changed: 2

## Notes

This contribution was prepared with automated tooling and reviewed for minimal scope before submission.
