### PR TITLE
added a websocket path to config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ node_modules/
 .claude/
 .sisyphus/
 .superpowers/
+
+#Macos
+.DS_Store
+

--- a/client/connector.go
+++ b/client/connector.go
@@ -215,7 +215,8 @@ func (c *defaultConnectorImpl) realConnect() (net.Conn, error) {
 	switch protocol {
 	case "websocket":
 		protocol = "tcp"
-		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{Hook: netpkg.DialHookWebsocket(protocol, "")}))
+		path := c.cfg.Transport.WebSocket.Path
+		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{Hook: netpkg.DialHookWebsocket(protocol, "", path)}))
 		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{
 			Hook: netpkg.DialHookCustomTLSHeadByte(tlsConfig != nil, lo.FromPtr(c.cfg.Transport.TLS.DisableCustomTLSFirstByte)),
 		}))
@@ -224,7 +225,8 @@ func (c *defaultConnectorImpl) realConnect() (net.Conn, error) {
 		protocol = "tcp"
 		dialOptions = append(dialOptions, libnet.WithTLSConfigAndPriority(100, tlsConfig))
 		// Make sure that if it is wss, the websocket hook is executed after the tls hook.
-		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{Hook: netpkg.DialHookWebsocket(protocol, tlsConfig.ServerName), Priority: 110}))
+		path := c.cfg.Transport.WebSocket.Path
+		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{Hook: netpkg.DialHookWebsocket(protocol, tlsConfig.ServerName, path), Priority: 110}))
 	default:
 		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{
 			Hook: netpkg.DialHookCustomTLSHeadByte(tlsConfig != nil, lo.FromPtr(c.cfg.Transport.TLS.DisableCustomTLSFirstByte)),

--- a/pkg/config/v1/client.go
+++ b/pkg/config/v1/client.go
@@ -132,6 +132,8 @@ type ClientTransportConfig struct {
 	TCPMuxKeepaliveInterval int64 `json:"tcpMuxKeepaliveInterval,omitempty"`
 	// QUIC protocol options.
 	QUIC QUICOptions `json:"quic,omitempty"`
+	// Websocket protocol options.
+	WebSocket WebSocketOptions `json:"websocket,omitempty"`
 	// HeartBeatInterval specifies at what interval heartbeats are sent to the
 	// server, in seconds. It is not recommended to change this value. By
 	// default, this value is 30. Set negative value to disable it.
@@ -162,6 +164,7 @@ func (c *ClientTransportConfig) Complete() {
 		c.HeartbeatTimeout = util.EmptyOr(c.HeartbeatTimeout, 90)
 	}
 	c.QUIC.Complete()
+	c.WebSocket.Complete()
 	c.TLS.Complete()
 }
 

--- a/pkg/config/v1/common.go
+++ b/pkg/config/v1/common.go
@@ -56,7 +56,7 @@ func (c *WebSocketOptions) Complete() {
 	if c.Path[0] != '/' {
 		c.Path = "/" + c.Path
 	}
-	if c.Path[len(c.Path)-1] == '/' {
+	if len(c.Path) > 1 && c.Path[len(c.Path)-1] == '/' {
 		c.Path = c.Path[:len(c.Path)-1]
 	}
 }

--- a/pkg/config/v1/common.go
+++ b/pkg/config/v1/common.go
@@ -47,6 +47,20 @@ func (c *QUICOptions) Complete() {
 	c.MaxIncomingStreams = util.EmptyOr(c.MaxIncomingStreams, 100000)
 }
 
+type WebSocketOptions struct {
+	Path string `json:"path,omitempty"`
+}
+
+func (c *WebSocketOptions) Complete() {
+	c.Path = util.EmptyOr(c.Path, "/~!frp")
+	if c.Path[0] != '/' {
+		c.Path = "/" + c.Path
+	}
+	if c.Path[len(c.Path)-1] == '/' {
+		c.Path = c.Path[:len(c.Path)-1]
+	}
+}
+
 type WebServerConfig struct {
 	// This is the network address to bind on for serving the web interface and API.
 	// By default, this value is "127.0.0.1".

--- a/pkg/config/v1/server.go
+++ b/pkg/config/v1/server.go
@@ -175,6 +175,8 @@ type ServerTransportConfig struct {
 	HeartbeatTimeout int64 `json:"heartbeatTimeout,omitempty"`
 	// QUIC options.
 	QUIC QUICOptions `json:"quic,omitempty"`
+	// Websocket options
+	WebSocket WebSocketOptions `json:"websocket,omitempty"`
 	// TLS specifies TLS settings for the connection from the client.
 	TLS TLSServerConfig `json:"tls,omitempty"`
 }
@@ -191,6 +193,7 @@ func (c *ServerTransportConfig) Complete() {
 		c.HeartbeatTimeout = util.EmptyOr(c.HeartbeatTimeout, 90)
 	}
 	c.QUIC.Complete()
+	c.WebSocket.Complete()
 	if c.TLS.TrustedCaFile != "" {
 		c.TLS.Force = true
 	}

--- a/pkg/util/net/dial.go
+++ b/pkg/util/net/dial.go
@@ -21,7 +21,7 @@ func DialHookCustomTLSHeadByte(enableTLS bool, disableCustomTLSHeadByte bool) li
 	}
 }
 
-func DialHookWebsocket(protocol string, host string) libnet.AfterHookFunc {
+func DialHookWebsocket(protocol string, host string, path string) libnet.AfterHookFunc {
 	return func(ctx context.Context, c net.Conn, addr string) (context.Context, net.Conn, error) {
 		if protocol != "wss" {
 			protocol = "ws"
@@ -29,7 +29,7 @@ func DialHookWebsocket(protocol string, host string) libnet.AfterHookFunc {
 		if host == "" {
 			host = addr
 		}
-		addr = protocol + "://" + host + FrpWebsocketPath
+		addr = protocol + "://" + host + path
 		uri, err := url.Parse(addr)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/util/net/websocket.go
+++ b/pkg/util/net/websocket.go
@@ -11,10 +11,6 @@ import (
 
 var ErrWebsocketListenerClosed = errors.New("websocket listener closed")
 
-const (
-	FrpWebsocketPath = "/~!frp"
-)
-
 type WebsocketListener struct {
 	ln       net.Listener
 	acceptCh chan net.Conn
@@ -24,14 +20,14 @@ type WebsocketListener struct {
 
 // NewWebsocketListener to handle websocket connections
 // ln: tcp listener for websocket connections
-func NewWebsocketListener(ln net.Listener) (wl *WebsocketListener) {
+func NewWebsocketListener(ln net.Listener, path string) (wl *WebsocketListener) {
 	wl = &WebsocketListener{
 		ln:       ln,
 		acceptCh: make(chan net.Conn),
 	}
 
 	muxer := http.NewServeMux()
-	muxer.Handle(FrpWebsocketPath, websocket.Handler(func(c *websocket.Conn) {
+	muxer.Handle(path, websocket.Handler(func(c *websocket.Conn) {
 		notifyCh := make(chan struct{})
 		conn := WrapCloseNotifyConn(c, func(_ error) {
 			close(notifyCh)

--- a/server/service.go
+++ b/server/service.go
@@ -283,11 +283,11 @@ func NewService(cfg *v1.ServerConfig) (*Service, error) {
 	}
 
 	// Listen for accepting connections from client using websocket protocol.
-	websocketPrefix := []byte("GET " + netpkg.FrpWebsocketPath)
+	websocketPrefix := []byte("GET " + cfg.Transport.WebSocket.Path)
 	websocketLn := svr.muxer.Listen(0, uint32(len(websocketPrefix)), func(data []byte) bool {
 		return bytes.Equal(data, websocketPrefix)
 	})
-	svr.websocketListener = netpkg.NewWebsocketListener(websocketLn)
+	svr.websocketListener = netpkg.NewWebsocketListener(websocketLn, cfg.Transport.WebSocket.Path)
 
 	// Create http vhost muxer.
 	if cfg.VhostHTTPPort > 0 {


### PR DESCRIPTION
### WHY

Because this service may be used to for reaching a server behind CDN. 
People may want it as a proxy_pass in their nginx or similar service.
This feature makes it easier to avoid ambiguity of which path is to be proxied. 