### PR TITLE
feat: Implement a simple 'strip prefix' feature for http locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1168,6 +1168,24 @@ locations = ["/news", "/about"]
 
 HTTP requests with URL prefix `/news` or `/about` will be forwarded to **web02** and other requests to **web01**.
 
+#### Strip Prefix
+
+Set `stripPrefix = true` on a proxy to remove the matched location prefix from the request path before forwarding it to the backend. This is useful when the backend does not expect the routing prefix to be part of the path.
+
+```toml
+# frpc.toml
+
+[[proxies]]
+name = "api"
+type = "http"
+localPort = 8080
+customDomains = ["web.example.com"]
+locations = ["/api"]
+stripPrefix = true
+```
+
+With this configuration, a request to `web.example.com/api/users` is forwarded to the backend as `/users`.
+
 ### TCP Port Multiplexing
 
 frp supports receiving TCP sockets directed to different proxies on a single port on frps, similar to `vhostHTTPPort` and `vhostHTTPSPort`.

--- a/pkg/config/v1/proxy.go
+++ b/pkg/config/v1/proxy.go
@@ -324,6 +324,7 @@ type HTTPProxyConfig struct {
 	RequestHeaders    HeaderOperations `json:"requestHeaders,omitempty"`
 	ResponseHeaders   HeaderOperations `json:"responseHeaders,omitempty"`
 	RouteByHTTPUser   string           `json:"routeByHTTPUser,omitempty"`
+	StripPrefix       bool             `json:"stripPrefix,omitempty"`
 }
 
 func (c *HTTPProxyConfig) MarshalToMsg(m *msg.NewProxy) {
@@ -338,6 +339,7 @@ func (c *HTTPProxyConfig) MarshalToMsg(m *msg.NewProxy) {
 	m.Headers = c.RequestHeaders.Set
 	m.ResponseHeaders = c.ResponseHeaders.Set
 	m.RouteByHTTPUser = c.RouteByHTTPUser
+	m.StripPrefix = c.StripPrefix
 }
 
 func (c *HTTPProxyConfig) UnmarshalFromMsg(m *msg.NewProxy) {
@@ -352,6 +354,7 @@ func (c *HTTPProxyConfig) UnmarshalFromMsg(m *msg.NewProxy) {
 	c.RequestHeaders.Set = m.Headers
 	c.ResponseHeaders.Set = m.ResponseHeaders
 	c.RouteByHTTPUser = m.RouteByHTTPUser
+	c.StripPrefix = m.StripPrefix
 }
 
 func (c *HTTPProxyConfig) Clone() ProxyConfigurer {

--- a/pkg/msg/msg.go
+++ b/pkg/msg/msg.go
@@ -124,6 +124,7 @@ type NewProxy struct {
 	Headers           map[string]string `json:"headers,omitempty"`
 	ResponseHeaders   map[string]string `json:"response_headers,omitempty"`
 	RouteByHTTPUser   string            `json:"route_by_http_user,omitempty"`
+	StripPrefix       bool              `json:"strip_prefix,omitempty"`
 
 	// stcp, sudp, xtcp
 	Sk         string   `json:"sk,omitempty"`

--- a/pkg/util/vhost/http.go
+++ b/pkg/util/vhost/http.go
@@ -91,8 +91,8 @@ func NewHTTPReverseProxy(option HTTPReverseProxyOptions, vhostRouter *Routers) *
 				// Strip prefix if enabled and location matches at a path-segment boundary
 				if rc.StripPrefix && rc.Location != "" && hasPathPrefix(req.URL.Path, rc.Location) {
 					req.URL.Path = strings.TrimPrefix(req.URL.Path, rc.Location)
-					if req.URL.Path == "" {
-						req.URL.Path = "/"
+					if !strings.HasPrefix(req.URL.Path, "/") {
+						req.URL.Path = "/" + req.URL.Path
 					}
 				}
 

--- a/pkg/util/vhost/http.go
+++ b/pkg/util/vhost/http.go
@@ -25,6 +25,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"time"
+	"strings"
 
 	libio "github.com/fatedier/golib/io"
 	"github.com/fatedier/golib/pool"
@@ -36,6 +37,21 @@ import (
 )
 
 var ErrNoRouteFound = errors.New("no route found")
+
+// hasPathPrefix reports whether path has prefix p at a path-segment boundary.
+// A boundary is satisfied when:
+//   - the prefix itself ends with '/' (e.g. the documented catch-all location "/"),
+//     meaning the separator is already part of the prefix; or
+//   - the path ends exactly at the prefix; or
+//   - the character immediately after the prefix in path is '/'.
+//
+// This ensures that location "/api" matches "/api" and "/api/v1" but not "/apiv2".
+func hasPathPrefix(path, p string) bool {
+	if !strings.HasPrefix(path, p) {
+		return false
+	}
+	return p[len(p)-1] == '/' || len(path) == len(p) || path[len(p)] == '/'
+}
 
 type HTTPReverseProxyOptions struct {
 	ResponseHeaderTimeoutS int64
@@ -72,8 +88,8 @@ func NewHTTPReverseProxy(option HTTPReverseProxyOptions, vhostRouter *Routers) *
 					req.Host = rc.RewriteHost
 				}
 
-				// Strip prefix if enabled and location matches
-				if rc.StripPrefix && rc.Location != "" && strings.HasPrefix(req.URL.Path, rc.Location) {
+				// Strip prefix if enabled and location matches at a path-segment boundary
+				if rc.StripPrefix && rc.Location != "" && hasPathPrefix(req.URL.Path, rc.Location) {
 					req.URL.Path = strings.TrimPrefix(req.URL.Path, rc.Location)
 					if req.URL.Path == "" {
 						req.URL.Path = "/"

--- a/pkg/util/vhost/http.go
+++ b/pkg/util/vhost/http.go
@@ -72,6 +72,14 @@ func NewHTTPReverseProxy(option HTTPReverseProxyOptions, vhostRouter *Routers) *
 					req.Host = rc.RewriteHost
 				}
 
+				// Strip prefix if enabled and location matches
+				if rc.StripPrefix && rc.Location != "" && strings.HasPrefix(req.URL.Path, rc.Location) {
+					req.URL.Path = strings.TrimPrefix(req.URL.Path, rc.Location)
+					if req.URL.Path == "" {
+						req.URL.Path = "/"
+					}
+				}
+
 				var endpoint string
 				if rc.ChooseEndpointFn != nil {
 					// ignore error here, it will use CreateConnFn instead later

--- a/pkg/util/vhost/http_test.go
+++ b/pkg/util/vhost/http_test.go
@@ -154,6 +154,13 @@ func TestStripPrefix(t *testing.T) {
 			requestPath:  "/api/users",
 			expectedPath: "/api/users",
 		},
+		{
+			name:         "don't strip partial prefix match",
+			location:     "/api",
+			stripPrefix:  true,
+			requestPath:  "/apiv2/users",
+			expectedPath: "/apiv2/users",
+		},
 	}
 
 	for _, tt := range tests {
@@ -178,7 +185,7 @@ func TestStripPrefix(t *testing.T) {
 					}
 
 					// Apply the strip prefix logic
-					if rc.StripPrefix && rc.Location != "" && strings.HasPrefix(req.URL.Path, rc.Location) {
+					if rc.StripPrefix && rc.Location != "" && hasPathPrefix(req.URL.Path, rc.Location) {
 						req.URL.Path = strings.TrimPrefix(req.URL.Path, rc.Location)
 						if req.URL.Path == "" {
 							req.URL.Path = "/"

--- a/pkg/util/vhost/http_test.go
+++ b/pkg/util/vhost/http_test.go
@@ -1,7 +1,10 @@
 package vhost
 
 import (
+	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -99,4 +102,102 @@ func TestGetRequestRouteUser(t *testing.T) {
 
 		require.Empty(t, getRequestRouteUser(req))
 	})
+}
+
+func TestStripPrefix(t *testing.T) {
+	tests := []struct {
+		name         string
+		location     string
+		stripPrefix  bool
+		requestPath  string
+		expectedPath string
+	}{
+		{
+			name:         "strip prefix enabled with matching location",
+			location:     "/api",
+			stripPrefix:  true,
+			requestPath:  "/api/users",
+			expectedPath: "/users",
+		},
+		{
+			name:         "strip prefix enabled with exact match",
+			location:     "/api",
+			stripPrefix:  true,
+			requestPath:  "/api",
+			expectedPath: "/",
+		},
+		{
+			name:         "strip prefix enabled with nested path",
+			location:     "/api",
+			stripPrefix:  true,
+			requestPath:  "/api/v1/data",
+			expectedPath: "/v1/data",
+		},
+		{
+			name:         "strip prefix disabled",
+			location:     "/api",
+			stripPrefix:  false,
+			requestPath:  "/api/users",
+			expectedPath: "/api/users",
+		},
+		{
+			name:         "strip prefix enabled but path doesn't match",
+			location:     "/api",
+			stripPrefix:  true,
+			requestPath:  "/other/path",
+			expectedPath: "/other/path",
+		},
+		{
+			name:         "empty location",
+			location:     "",
+			stripPrefix:  true,
+			requestPath:  "/api/users",
+			expectedPath: "/api/users",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a test server that echoes the request path
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(r.URL.Path))
+			}))
+			defer backend.Close()
+
+			// Create the reverse proxy with our rewrite logic
+			proxy := &httputil.ReverseProxy{
+				Rewrite: func(r *httputil.ProxyRequest) {
+					req := r.Out
+					req.URL.Scheme = "http"
+					req.URL.Host = strings.TrimPrefix(backend.URL, "http://")
+
+					// Simulate the RouteConfig being set in context
+					rc := &RouteConfig{
+						Location:    tt.location,
+						StripPrefix: tt.stripPrefix,
+					}
+
+					// Apply the strip prefix logic
+					if rc.StripPrefix && rc.Location != "" && strings.HasPrefix(req.URL.Path, rc.Location) {
+						req.URL.Path = strings.TrimPrefix(req.URL.Path, rc.Location)
+						if req.URL.Path == "" {
+							req.URL.Path = "/"
+						}
+					}
+				},
+			}
+
+			// Create a test request
+			req := httptest.NewRequest("GET", "http://example.com"+tt.requestPath, nil)
+			w := httptest.NewRecorder()
+
+			// Execute the proxy
+			proxy.ServeHTTP(w, req)
+
+			// Check the result
+			if w.Body.String() != tt.expectedPath {
+				t.Errorf("Expected path %q, got %q", tt.expectedPath, w.Body.String())
+			}
+		})
+	}
 }

--- a/pkg/util/vhost/vhost.go
+++ b/pkg/util/vhost/vhost.go
@@ -120,6 +120,7 @@ type RouteConfig struct {
 	Headers         map[string]string
 	ResponseHeaders map[string]string
 	RouteByHTTPUser string
+	StripPrefix     bool
 
 	CreateConnFn           CreateConnFunc
 	ChooseEndpointFn       ChooseEndpointFunc

--- a/server/proxy/http.go
+++ b/server/proxy/http.go
@@ -61,6 +61,7 @@ func (pxy *HTTPProxy) Run() (remoteAddr string, err error) {
 		ResponseHeaders: pxy.cfg.ResponseHeaders.Set,
 		Username:        pxy.cfg.HTTPUser,
 		Password:        pxy.cfg.HTTPPassword,
+		StripPrefix:     pxy.cfg.StripPrefix,
 		CreateConnFn:    pxy.GetRealConn,
 	}
 

--- a/test/e2e/v1/basic/http.go
+++ b/test/e2e/v1/basic/http.go
@@ -493,6 +493,57 @@ var _ = ginkgo.Describe("[Feature: HTTP]", func() {
 		framework.ExpectEqualValues(consts.TestString, string(msg))
 	})
 
+	ginkgo.It("Strip prefix from request path", func() {
+		vhostHTTPPort := f.AllocPort()
+		serverConf := getDefaultServerConf(vhostHTTPPort)
+
+		localPort := f.AllocPort()
+		localServer := httpserver.New(
+			httpserver.WithBindPort(localPort),
+			httpserver.WithHandler(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				_, _ = w.Write([]byte(req.URL.Path))
+			})),
+		)
+		f.RunServer("", localServer)
+
+		clientConf := consts.DefaultClientConfig
+		clientConf += fmt.Sprintf(`
+			[[proxies]]
+			name = "test"
+			type = "http"
+			localPort = %d
+			customDomains = ["normal.example.com"]
+			locations = ["/api"]
+			stripPrefix = true
+			`, localPort)
+
+		f.RunProcesses(serverConf, []string{clientConf})
+
+		// Test that /api/users becomes /users
+		framework.NewRequestExpect(f).Port(vhostHTTPPort).
+			RequestModify(func(r *request.Request) {
+				r.HTTP().HTTPHost("normal.example.com").HTTPPath("/api/users")
+			}).
+			ExpectResp([]byte("/users")).
+			Ensure()
+
+		// Test that /api becomes /
+		framework.NewRequestExpect(f).Port(vhostHTTPPort).
+			RequestModify(func(r *request.Request) {
+				r.HTTP().HTTPHost("normal.example.com").HTTPPath("/api")
+			}).
+			ExpectResp([]byte("/")).
+			Ensure()
+
+		// Test that /api/v1/data becomes /v1/data
+		framework.NewRequestExpect(f).Port(vhostHTTPPort).
+			RequestModify(func(r *request.Request) {
+				r.HTTP().HTTPHost("normal.example.com").HTTPPath("/api/v1/data")
+			}).
+			ExpectResp([]byte("/v1/data")).
+			Ensure()
+	})
+
 	ginkgo.It("vhostHTTPTimeout", func() {
 		vhostHTTPPort := f.AllocPort()
 		serverConf := getDefaultServerConf(vhostHTTPPort)


### PR DESCRIPTION
### WHY

Though frpproxy isn't meant to be a full blown L7 reverse proxy, this particular feature is useful if you use multiple dynamic paths on the server, but you don't want to hassle with url prefix logic on your http client. Especially useful for http clients that serve pure json apis. In my particular case, I cannot use domain based identifiers. Fit's naturally with the "locations" setting, and thus it only strips those particularly prefixes as they are defined.

Example:

```yaml
serverAddr = "example.com"
serverPort = 7000

[[proxies]]
name = "fast"
type = "http"
localIP = "127.0.0.1"
localPort = 5000
customDomains = ["example.com"]
locations = ["/example"]
stripPrefix = true
```

relates to #4981

also see: #5276

I would love to have this feature merged, but the previous PR by (@cayspekko) got stale and closed. 
I added a short section to the README.md file and took a look at the PR suggestions from @kilo-code-bot and tried to mitigate them. 

The bot also showed, that a similar prefix-logic is already used inside `pkg/util/vhost/router.go` but changing that would result in a breaking change so i am not comfortable modifying that.
