### PR TITLE
Fix the docker image not working as expected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1311,6 +1311,47 @@ frpc tcp --proxy_name "test-tcp" --local_ip 127.0.0.1 --local_port 8080 --remote
 
 Please refer to this [document](/doc/ssh_tunnel_gateway.md) for more information.
 
+### Using in docker compose
+#### frps
+* Start up the **frps** server side first.
+```yaml
+name: frps
+
+services:
+  frps:
+    image: fatedier/frps:latest        # check the version dockerfiles folder if the entry point is `frps -c /etc/frp/frps.toml`
+    ports: 
+      - 7000:7000        # the main connection port for client
+      - 7500:7500        # the web ui
+      - 9000:9000        # .... any application port you forwarding to
+    volumes:
+      - ./frps.toml:/etc/frp/frps.toml
+    networks:
+      - frp
+networks:
+  frp:
+    driver: bridge
+```
+
+
+#### frpc
+* Configure you frpc.toml for the proxy content.
+```yaml
+name: frpc
+
+services:
+  frps:
+    image: fatedier/frpc:latest       # check the version dockerfiles folder if the entry point is `frpc -c /etc/frp/frpc.toml`
+    restart: always
+    volumes:
+      - ./frpc.toml:/etc/frp/frpc.toml
+    networks:
+      - frp
+  frp:
+    driver: bridge
+```
+
+
 ### Virtual Network (VirtualNet)
 
 *Alpha feature added in v0.62.0*

--- a/dockerfiles/Dockerfile-for-frpc
+++ b/dockerfiles/Dockerfile-for-frpc
@@ -22,4 +22,4 @@ RUN apk add --no-cache tzdata
 
 COPY --from=building /building/bin/frpc /usr/bin/frpc
 
-ENTRYPOINT ["/usr/bin/frpc"]
+ENTRYPOINT ["/usr/bin/frpc", "-c", "/etc/frp/frpc.toml"]

--- a/dockerfiles/Dockerfile-for-frps
+++ b/dockerfiles/Dockerfile-for-frps
@@ -22,4 +22,4 @@ RUN apk add --no-cache tzdata
 
 COPY --from=building /building/bin/frps /usr/bin/frps
 
-ENTRYPOINT ["/usr/bin/frps"]
+ENTRYPOINT ["/usr/bin/frps", "-c", "/etc/frp/frps.toml"]


### PR DESCRIPTION
I not sure how to make the docker image work **without** explicit mention the configuration. 

Related to issue: https://github.com/fatedier/frp/issues/4559

### WHY

The current docker image doesn't work, because it doesn't load the correct configuration file by default.
Suggest to explicitly request user to define their configuration under `/etc/frp/{frps.toml|frpc.toml}`. 
Welcome a better solution, but right now it doesn't works.
The current project doesn't mention how to use the **frps** and **frpc** in docker or docker compose. Also added few line of description in the Readme.md