### PR TITLE
feat(ui): add xtcp tab to frps dashboard

### DIFF
--- a/web/frps/src/views/Proxies.vue
+++ b/web/frps/src/views/Proxies.vue
@@ -137,6 +137,7 @@ const proxyTypes = [
   { label: 'HTTPS', value: 'https' },
   { label: 'TCPMUX', value: 'tcpmux' },
   { label: 'STCP', value: 'stcp' },
+  { label: 'XTCP', value: 'xtcp' },
   { label: 'SUDP', value: 'sudp' },
 ]
 


### PR DESCRIPTION
## Summary
- add an independent XTCP tab on the frps dashboard Proxies page
- reuse the existing /api/proxy/xtcp endpoint
- reuse the existing BaseProxy fallback for XTCP rows instead of adding a dedicated XTCPProxy class

## Validation
- git diff --check
- cd web && npm run type-check -w frps-dashboard && npm run build -w frps-dashboard
- cd web && npm run build -w frpc-dashboard && cd .. && golangci-lint run
- Codex /review on uncommitted changes: Findings: none

## Demo
- local demo was run and user confirmed the XTCP tab looked good
- demo processes were stopped before commit/PR