### PR TITLE
feat: add xudp proxy mode with multi-STUN prediction and decoupled tunnel

### DIFF
--- a/client/proxy/xudp.go
+++ b/client/proxy/xudp.go
@@ -1,0 +1,224 @@
+// Copyright 2024 The frp Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !frps
+
+package proxy
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"time"
+
+	"github.com/quic-go/quic-go"
+
+	v1 "github.com/fatedier/frp/pkg/config/v1"
+	"github.com/fatedier/frp/pkg/msg"
+	"github.com/fatedier/frp/pkg/naming"
+	"github.com/fatedier/frp/pkg/nathole"
+	"github.com/fatedier/frp/pkg/transport"
+	netpkg "github.com/fatedier/frp/pkg/util/net"
+)
+
+func init() {
+	RegisterProxyFactory(reflect.TypeFor[*v1.XUDPProxyConfig](), NewXUDPProxy)
+}
+
+type XUDPProxy struct {
+	*BaseProxy
+
+	cfg *v1.XUDPProxyConfig
+}
+
+func NewXUDPProxy(baseProxy *BaseProxy, cfg v1.ProxyConfigurer) Proxy {
+	unwrapped, ok := cfg.(*v1.XUDPProxyConfig)
+	if !ok {
+		return nil
+	}
+	return &XUDPProxy{
+		BaseProxy: baseProxy,
+		cfg:       unwrapped,
+	}
+}
+
+func (pxy *XUDPProxy) InWorkConn(conn net.Conn, startWorkConnMsg *msg.StartWorkConn) {
+	xl := pxy.xl
+	defer conn.Close()
+
+	var natHoleSidMsg msg.NatHoleSid
+	err := msg.ReadMsgInto(conn, &natHoleSidMsg)
+	if err != nil {
+		xl.Errorf("xudp read from workConn error: %v", err)
+		return
+	}
+
+	xl.Tracef("xudp nathole prepare start")
+
+	// Build STUN server list: primary + additional configured servers
+	stunServers := []string{pxy.clientCfg.NatHoleSTUNServer}
+	if len(pxy.cfg.STUNServers) > 0 {
+		stunServers = append(stunServers, pxy.cfg.STUNServers...)
+	}
+
+	// Multi-STUN discovery for port prediction
+	var portDelta int
+	var multiSTUNLocalAddr string
+	if len(stunServers) > 1 {
+		multiResult, err := nathole.DiscoverMultiSTUN(pxy.ctx, stunServers, "")
+		if err != nil {
+			xl.Warnf("xudp multi-stun discover error (non-fatal): %v", err)
+		} else {
+			portDelta = multiResult.PortDelta
+			if multiResult.LocalAddr != nil {
+				multiSTUNLocalAddr = multiResult.LocalAddr.String()
+			}
+			xl.Infof("xudp multi-stun discovery success, addresses: %v, portDelta: %d",
+				multiResult.Addrs, multiResult.PortDelta)
+		}
+	}
+
+	// Prepare NAT traversal options
+	var opts nathole.PrepareOptions
+	if pxy.cfg.NatTraversal != nil && pxy.cfg.NatTraversal.DisableAssistedAddrs {
+		opts.DisableAssistedAddrs = true
+	}
+	// Reuse the multi-STUN local address for Prepare if available,
+	// so portDelta corresponds to the actual punched socket.
+	opts.LocalAddr = multiSTUNLocalAddr
+
+	pxy.doStandardHolePunch(natHoleSidMsg, stunServers[:1], opts, startWorkConnMsg, portDelta)
+}
+
+func (pxy *XUDPProxy) doStandardHolePunch(
+	natHoleSidMsg msg.NatHoleSid,
+	stunServers []string,
+	opts nathole.PrepareOptions,
+	startWorkConnMsg *msg.StartWorkConn,
+	portDelta int,
+) {
+	xl := pxy.xl
+
+	prepareResult, err := nathole.Prepare(stunServers, opts)
+	if err != nil {
+		xl.Warnf("xudp nathole prepare error: %v", err)
+		return
+	}
+
+	xl.Infof("xudp nathole prepare success, nat type: %s, behavior: %s, addresses: %v, assistedAddresses: %v",
+		prepareResult.NatType, prepareResult.Behavior, prepareResult.Addrs, prepareResult.AssistedAddrs)
+
+	// Send NatHoleClient msg to server for realm rendezvous
+	transactionID := nathole.NewTransactionID()
+	natHoleClientMsg := &msg.NatHoleClient{
+		TransactionID: transactionID,
+		ProxyName:     naming.AddUserPrefix(pxy.clientCfg.User, pxy.cfg.Name),
+		Sid:           natHoleSidMsg.Sid,
+		MappedAddrs:   prepareResult.Addrs,
+		AssistedAddrs: prepareResult.AssistedAddrs,
+	}
+
+	xl.Tracef("xudp rendezvous exchange start")
+	natHoleRespMsg, err := nathole.XUDPRendezvousExchange(
+		pxy.ctx, pxy.msgTransporter, transactionID, natHoleClientMsg, 5*time.Second,
+	)
+	if err != nil {
+		prepareResult.ListenConn.Close()
+		xl.Warnf("xudp rendezvous exchange error: %v", err)
+		return
+	}
+
+	xl.Infof("xudp get natHoleRespMsg, sid [%s], candidate address %v, assisted address %v, detectBehavior: %+v",
+		natHoleRespMsg.Sid, natHoleRespMsg.CandidateAddrs,
+		natHoleRespMsg.AssistedAddrs, natHoleRespMsg.DetectBehavior)
+
+	// Use XUDPMakeHole with port prediction
+	listenConn := prepareResult.ListenConn
+	newListenConn, raddr, err := nathole.XUDPMakeHole(pxy.ctx, listenConn, natHoleRespMsg, []byte(pxy.cfg.Secretkey), portDelta)
+	if err != nil {
+		listenConn.Close()
+		xl.Warnf("xudp make hole error: %v", err)
+		_ = pxy.msgTransporter.Send(&msg.NatHoleReport{
+			Sid:     natHoleRespMsg.Sid,
+			Success: false,
+		})
+		return
+	}
+	listenConn = newListenConn
+	xl.Infof("xudp establishing nat hole connection successful, sid [%s], remoteAddr [%s]", natHoleRespMsg.Sid, raddr)
+
+	_ = pxy.msgTransporter.Send(&msg.NatHoleReport{
+		Sid:     natHoleRespMsg.Sid,
+		Success: true,
+	})
+
+	// Start decoupled QUIC listener - this runs in an isolated goroutine
+	// that survives control channel drops. Ownership of listenConn transfers
+	// to the goroutine (it will close it when done).
+	go pxy.listenByQUICDecoupled(listenConn, raddr, startWorkConnMsg)
+}
+
+// listenByQUICDecoupled starts a QUIC listener in a decoupled goroutine.
+// The goroutine uses an independent context so it survives if the primary
+// frpc-frps control channel drops. It owns listenConn and closes it on exit.
+func (pxy *XUDPProxy) listenByQUICDecoupled(listenConn *net.UDPConn, _ *net.UDPAddr, startWorkConnMsg *msg.StartWorkConn) {
+	xl := pxy.xl
+
+	// Create an independent context for the tunnel lifecycle
+	tunnelCtx, tunnelCancel := context.WithCancel(context.Background())
+	defer tunnelCancel()
+	defer listenConn.Close()
+
+	tlsConfig, err := transport.NewServerTLSConfig("", "", "")
+	if err != nil {
+		xl.Warnf("xudp create tls config error: %v", err)
+		return
+	}
+	tlsConfig.NextProtos = []string{"frp-xudp"}
+
+	quicListener, err := quic.Listen(listenConn, tlsConfig,
+		&quic.Config{
+			MaxIdleTimeout:     time.Duration(pxy.clientCfg.Transport.QUIC.MaxIdleTimeout) * time.Second,
+			MaxIncomingStreams: int64(pxy.clientCfg.Transport.QUIC.MaxIncomingStreams),
+			KeepAlivePeriod:    time.Duration(pxy.clientCfg.Transport.QUIC.KeepalivePeriod) * time.Second,
+		},
+	)
+	if err != nil {
+		xl.Warnf("xudp quic listen error: %v", err)
+		return
+	}
+	defer quicListener.Close()
+
+	xl.Infof("xudp decoupled QUIC tunnel started, waiting for connections")
+
+	// Accept one connection from the visitor
+	c, err := quicListener.Accept(tunnelCtx)
+	if err != nil {
+		xl.Errorf("xudp quic accept connection error: %v", err)
+		return
+	}
+
+	xl.Infof("xudp QUIC connection accepted from visitor")
+
+	// Handle streams in the decoupled goroutine
+	for {
+		stream, err := c.AcceptStream(tunnelCtx)
+		if err != nil {
+			xl.Debugf("xudp quic accept stream error: %v", err)
+			_ = c.CloseWithError(0, "")
+			return
+		}
+		go pxy.HandleTCPWorkConnection(netpkg.QuicStreamToNetConn(stream, c), startWorkConnMsg, []byte(pxy.cfg.Secretkey))
+	}
+}

--- a/client/visitor/visitor.go
+++ b/client/visitor/visitor.go
@@ -108,6 +108,12 @@ func NewVisitor(
 			cfg:          cfg,
 			checkCloseCh: make(chan struct{}),
 		}
+	case *v1.XUDPVisitorConfig:
+		visitor = &XUDPVisitor{
+			BaseVisitor:   &baseVisitor,
+			cfg:           cfg,
+			startTunnelCh: make(chan struct{}),
+		}
 	}
 	return visitor, nil
 }

--- a/client/visitor/xudp.go
+++ b/client/visitor/xudp.go
@@ -1,0 +1,405 @@
+// Copyright 2024 The frp Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package visitor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	libio "github.com/fatedier/golib/io"
+	quic "github.com/quic-go/quic-go"
+	"golang.org/x/time/rate"
+
+	v1 "github.com/fatedier/frp/pkg/config/v1"
+	"github.com/fatedier/frp/pkg/msg"
+	"github.com/fatedier/frp/pkg/naming"
+	"github.com/fatedier/frp/pkg/nathole"
+	"github.com/fatedier/frp/pkg/transport"
+	netpkg "github.com/fatedier/frp/pkg/util/net"
+	"github.com/fatedier/frp/pkg/util/util"
+	"github.com/fatedier/frp/pkg/util/xlog"
+)
+
+type XUDPVisitor struct {
+	*BaseVisitor
+	session       *xudpTunnelSession
+	startTunnelCh chan struct{}
+	retryLimiter  *rate.Limiter
+	cancel        context.CancelFunc
+
+	cfg *v1.XUDPVisitorConfig
+}
+
+func (sv *XUDPVisitor) Run() (err error) {
+	sv.ctx, sv.cancel = context.WithCancel(sv.ctx)
+
+	sv.session = newXUDPTunnelSession(sv.clientCfg)
+
+	if sv.cfg.BindPort > 0 {
+		sv.l, err = net.Listen("tcp", net.JoinHostPort(sv.cfg.BindAddr, strconv.Itoa(sv.cfg.BindPort)))
+		if err != nil {
+			return
+		}
+		go sv.acceptLoop(sv.l, "xudp local", sv.handleConn)
+	}
+
+	go sv.acceptLoop(sv.internalLn, "xudp internal", sv.handleConn)
+	go sv.processTunnelStartEvents()
+	if sv.cfg.KeepTunnelOpen {
+		sv.retryLimiter = rate.NewLimiter(rate.Every(time.Hour/time.Duration(sv.cfg.MaxRetriesAnHour)), sv.cfg.MaxRetriesAnHour)
+		go sv.keepTunnelOpenWorker()
+	}
+
+	if sv.plugin != nil {
+		sv.plugin.Start()
+	}
+	return
+}
+
+func (sv *XUDPVisitor) Close() {
+	sv.mu.Lock()
+	defer sv.mu.Unlock()
+	sv.BaseVisitor.Close()
+	if sv.cancel != nil {
+		sv.cancel()
+	}
+	if sv.session != nil {
+		sv.session.Close()
+	}
+}
+
+func (sv *XUDPVisitor) processTunnelStartEvents() {
+	for {
+		select {
+		case <-sv.ctx.Done():
+			return
+		case <-sv.startTunnelCh:
+			start := time.Now()
+			sv.makeNatHole()
+			duration := time.Since(start)
+			if duration < 10*time.Second {
+				time.Sleep(10*time.Second - duration)
+			}
+		}
+	}
+}
+
+func (sv *XUDPVisitor) keepTunnelOpenWorker() {
+	xl := xlog.FromContextSafe(sv.ctx)
+	ticker := time.NewTicker(time.Duration(sv.cfg.MinRetryInterval) * time.Second)
+	defer ticker.Stop()
+
+	select {
+	case sv.startTunnelCh <- struct{}{}:
+	case <-sv.ctx.Done():
+		return
+	}
+	for {
+		select {
+		case <-sv.ctx.Done():
+			return
+		case <-ticker.C:
+			xl.Debugf("xudp keepTunnelOpenWorker try to check tunnel...")
+			conn, err := sv.getTunnelConn(sv.ctx)
+			if err != nil {
+				xl.Warnf("xudp keepTunnelOpenWorker get tunnel connection error: %v", err)
+				_ = sv.retryLimiter.Wait(sv.ctx)
+				continue
+			}
+			xl.Debugf("xudp keepTunnelOpenWorker check success")
+			if conn != nil {
+				conn.Close()
+			}
+		}
+	}
+}
+
+func (sv *XUDPVisitor) handleConn(userConn net.Conn) {
+	xl := xlog.FromContextSafe(sv.ctx)
+	isConnTransferred := false
+	var tunnelErr error
+	defer func() {
+		if !isConnTransferred {
+			if tunnelErr != nil {
+				if eConn, ok := userConn.(interface{ CloseWithError(error) error }); ok {
+					_ = eConn.CloseWithError(tunnelErr)
+					return
+				}
+			}
+			userConn.Close()
+		}
+	}()
+
+	xl.Debugf("get a new xudp user connection")
+
+	ctx := sv.ctx
+	if sv.cfg.FallbackTo != "" {
+		timeoutCtx, cancel := context.WithTimeout(ctx, time.Duration(sv.cfg.FallbackTimeoutMs)*time.Millisecond)
+		defer cancel()
+		ctx = timeoutCtx
+	}
+	tunnelConn, err := sv.openTunnel(ctx)
+	if err != nil {
+		xl.Errorf("xudp open tunnel error: %v", err)
+		tunnelErr = err
+
+		if sv.cfg.FallbackTo == "" {
+			return
+		}
+
+		xl.Debugf("xudp try to transfer connection to visitor: %s", sv.cfg.FallbackTo)
+		if err := sv.helper.TransferConn(sv.cfg.FallbackTo, userConn); err != nil {
+			xl.Errorf("xudp transfer connection to visitor %s error: %v", sv.cfg.FallbackTo, err)
+			return
+		}
+		isConnTransferred = true
+		return
+	}
+
+	muxConnRWCloser, recycleFn, err := wrapVisitorConn(tunnelConn, sv.cfg.GetBaseConfig())
+	if err != nil {
+		xl.Errorf("xudp %v", err)
+		tunnelConn.Close()
+		tunnelErr = err
+		return
+	}
+	defer recycleFn()
+
+	_, _, errs := libio.Join(userConn, muxConnRWCloser)
+	xl.Debugf("xudp join connections closed")
+	if len(errs) > 0 {
+		xl.Tracef("xudp join connections errors: %v", errs)
+	}
+}
+
+func (sv *XUDPVisitor) openTunnel(ctx context.Context) (conn net.Conn, err error) {
+	xl := xlog.FromContextSafe(sv.ctx)
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-sv.ctx.Done():
+			return nil, sv.ctx.Err()
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return nil, fmt.Errorf("xudp open tunnel timeout")
+			}
+			return nil, ctx.Err()
+		case <-timer.C:
+			conn, err = sv.getTunnelConn(ctx)
+			if err != nil {
+				if !errors.Is(err, ErrNoTunnelSession) {
+					xl.Warnf("xudp get tunnel connection error: %v", err)
+				}
+				timer.Reset(500 * time.Millisecond)
+				continue
+			}
+			return conn, nil
+		}
+	}
+}
+
+func (sv *XUDPVisitor) getTunnelConn(ctx context.Context) (net.Conn, error) {
+	conn, err := sv.session.OpenConn(ctx)
+	if err == nil {
+		return conn, nil
+	}
+	sv.session.Close()
+
+	select {
+	case sv.startTunnelCh <- struct{}{}:
+	default:
+	}
+	return nil, err
+}
+
+// makeNatHole performs the xudp NAT hole punching with multi-STUN prediction.
+// 0. PreCheck
+// 1. Multi-STUN Discover (concurrent queries for port prediction)
+// 2. Prepare
+// 3. Realm Rendezvous Exchange (server relays addresses then exits data flow)
+// 4. XUDPMakeHole (with predicted ports)
+// 5. Create decoupled QUIC tunnel session
+func (sv *XUDPVisitor) makeNatHole() {
+	xl := xlog.FromContextSafe(sv.ctx)
+	targetProxyName := naming.BuildTargetServerProxyName(sv.clientCfg.User, sv.cfg.ServerUser, sv.cfg.ServerName)
+	xl.Tracef("xudp makeNatHole start")
+
+	if err := nathole.PreCheck(sv.ctx, sv.helper.MsgTransporter(), targetProxyName, 5*time.Second); err != nil {
+		xl.Warnf("xudp nathole precheck error: %v", err)
+		return
+	}
+
+	// Build STUN server list
+	stunServers := []string{sv.clientCfg.NatHoleSTUNServer}
+	if len(sv.cfg.STUNServers) > 0 {
+		stunServers = append(stunServers, sv.cfg.STUNServers...)
+	}
+
+	// Multi-STUN discovery for port prediction
+	var portDelta int
+	var multiSTUNLocalAddr string
+	if len(stunServers) > 1 {
+		multiResult, err := nathole.DiscoverMultiSTUN(sv.ctx, stunServers, "")
+		if err != nil {
+			xl.Warnf("xudp multi-stun discover error (non-fatal): %v", err)
+		} else {
+			portDelta = multiResult.PortDelta
+			if multiResult.LocalAddr != nil {
+				multiSTUNLocalAddr = multiResult.LocalAddr.String()
+			}
+			xl.Infof("xudp multi-stun discovery: portDelta=%d, addrs=%v", portDelta, multiResult.Addrs)
+		}
+	}
+
+	xl.Tracef("xudp nathole prepare start")
+
+	// Prepare NAT traversal options
+	var opts nathole.PrepareOptions
+	if sv.cfg.NatTraversal != nil && sv.cfg.NatTraversal.DisableAssistedAddrs {
+		opts.DisableAssistedAddrs = true
+	}
+	// Reuse the multi-STUN local address so portDelta corresponds to the punched socket
+	opts.LocalAddr = multiSTUNLocalAddr
+
+	prepareResult, err := nathole.Prepare(stunServers[:1], opts)
+	if err != nil {
+		xl.Warnf("xudp nathole prepare error: %v", err)
+		return
+	}
+
+	xl.Infof("xudp nathole prepare success, nat type: %s, behavior: %s, addresses: %v, assistedAddresses: %v",
+		prepareResult.NatType, prepareResult.Behavior, prepareResult.Addrs, prepareResult.AssistedAddrs)
+
+	listenConn := prepareResult.ListenConn
+
+	// Realm rendezvous exchange - server relays addresses then exits data flow
+	now := time.Now().Unix()
+	transactionID := nathole.NewTransactionID()
+	natHoleVisitorMsg := &msg.NatHoleVisitor{
+		TransactionID: transactionID,
+		ProxyName:     targetProxyName,
+		Protocol:      sv.cfg.Protocol,
+		SignKey:       util.GetAuthKey(sv.cfg.SecretKey, now),
+		Timestamp:     now,
+		MappedAddrs:   prepareResult.Addrs,
+		AssistedAddrs: prepareResult.AssistedAddrs,
+	}
+
+	xl.Tracef("xudp rendezvous exchange start")
+	natHoleRespMsg, err := nathole.XUDPRendezvousExchange(sv.ctx, sv.helper.MsgTransporter(), transactionID, natHoleVisitorMsg, 5*time.Second)
+	if err != nil {
+		listenConn.Close()
+		xl.Warnf("xudp rendezvous exchange error: %v", err)
+		return
+	}
+
+	xl.Infof("xudp get natHoleRespMsg, sid [%s], protocol [%s], candidate address %v, assisted address %v, detectBehavior: %+v",
+		natHoleRespMsg.Sid, natHoleRespMsg.Protocol, natHoleRespMsg.CandidateAddrs,
+		natHoleRespMsg.AssistedAddrs, natHoleRespMsg.DetectBehavior)
+
+	// XUDPMakeHole with port prediction
+	newListenConn, raddr, err := nathole.XUDPMakeHole(sv.ctx, listenConn, natHoleRespMsg, []byte(sv.cfg.SecretKey), portDelta)
+	if err != nil {
+		listenConn.Close()
+		xl.Warnf("xudp make hole error: %v", err)
+		return
+	}
+	listenConn = newListenConn
+	xl.Infof("xudp establishing nat hole connection successful, sid [%s], remoteAddr [%s]", natHoleRespMsg.Sid, raddr)
+
+	// Initialize the decoupled tunnel session
+	if err := sv.session.Init(listenConn, raddr); err != nil {
+		listenConn.Close()
+		xl.Warnf("xudp init tunnel session error: %v", err)
+		return
+	}
+}
+
+// xudpTunnelSession implements a decoupled QUIC tunnel session for xudp.
+// It runs in an isolated goroutine that survives control channel drops.
+type xudpTunnelSession struct {
+	session    *quic.Conn
+	listenConn *net.UDPConn
+	mu         sync.RWMutex
+
+	clientCfg *v1.ClientCommonConfig
+}
+
+func newXUDPTunnelSession(clientCfg *v1.ClientCommonConfig) *xudpTunnelSession {
+	return &xudpTunnelSession{
+		clientCfg: clientCfg,
+	}
+}
+
+func (xs *xudpTunnelSession) Init(listenConn *net.UDPConn, raddr *net.UDPAddr) error {
+	tlsConfig, err := transport.NewClientTLSConfig("", "", "", raddr.String())
+	if err != nil {
+		return fmt.Errorf("xudp create tls config error: %v", err)
+	}
+	tlsConfig.NextProtos = []string{"frp-xudp"}
+
+	// Use a background context so the QUIC session is decoupled from the control channel
+	quicConn, err := quic.Dial(context.Background(), listenConn, raddr, tlsConfig,
+		&quic.Config{
+			MaxIdleTimeout:     time.Duration(xs.clientCfg.Transport.QUIC.MaxIdleTimeout) * time.Second,
+			MaxIncomingStreams: int64(xs.clientCfg.Transport.QUIC.MaxIncomingStreams),
+			KeepAlivePeriod:    time.Duration(xs.clientCfg.Transport.QUIC.KeepalivePeriod) * time.Second,
+		})
+	if err != nil {
+		return fmt.Errorf("xudp dial quic error: %v", err)
+	}
+	xs.mu.Lock()
+	xs.session = quicConn
+	xs.listenConn = listenConn
+	xs.mu.Unlock()
+	return nil
+}
+
+func (xs *xudpTunnelSession) OpenConn(ctx context.Context) (net.Conn, error) {
+	xs.mu.RLock()
+	defer xs.mu.RUnlock()
+	session := xs.session
+	if session == nil {
+		return nil, ErrNoTunnelSession
+	}
+	stream, err := session.OpenStreamSync(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return netpkg.QuicStreamToNetConn(stream, session), nil
+}
+
+func (xs *xudpTunnelSession) Close() {
+	xs.mu.Lock()
+	defer xs.mu.Unlock()
+	if xs.session != nil {
+		_ = xs.session.CloseWithError(0, "")
+		xs.session = nil
+	}
+	if xs.listenConn != nil {
+		_ = xs.listenConn.Close()
+		xs.listenConn = nil
+	}
+}

--- a/doc/xudp-mode.md
+++ b/doc/xudp-mode.md
@@ -1,0 +1,213 @@
+# XUDP Mode: NAT Traversal with Multi-STUN Prediction
+
+## Overview
+
+`xudp` is a new proxy type that extends frp's NAT hole-punching capabilities to handle **predictable Symmetric NATs** more reliably. It builds on the existing `xtcp` infrastructure with three key improvements:
+
+1. **Multi-STUN Prediction** — Queries multiple STUN servers serially from the same local port to detect port allocation patterns, then predicts the next ports the NAT will assign.
+2. **Realm Rendezvous** — The frps server acts as a lightweight signaling relay using a shared token to exchange peer addresses, then cleanly exits the data flow.
+3. **Decoupled Tunnel Lifecycle** — The resulting QUIC tunnel runs in an isolated goroutine with an independent context, surviving primary frpc-frps control channel drops.
+
+## Problem Statement
+
+The existing `xtcp` mode works well for Easy NATs (where the mapped port stays constant across destinations) but struggles with Symmetric NATs that increment ports predictably (e.g., +2 per new destination). While `xtcp` mode 1-4 behaviors attempt to handle Hard NATs, they rely on brute-force port scanning which is slow and unreliable.
+
+Many enterprise and carrier-grade NATs exhibit **predictable port allocation** — the external port increments by a fixed delta for each new UDP flow. If we can observe this delta, we can predict where the next hole-punch packet will land.
+
+## Architecture
+
+```
+┌─────────┐         ┌─────────┐         ┌─────────┐
+│  Visitor │         │  frps   │         │  Client  │
+│  (xudp)  │         │(rendezvous)│      │  (xudp)  │
+└────┬─────┘         └────┬─────┘         └────┬─────┘
+     │                     │                     │
+     │ 1. Multi-STUN       │                     │ 1. Multi-STUN
+     │    Discovery        │                     │    Discovery
+     │                     │                     │
+     │ 2. NatHoleVisitor ──┤                     │
+     │    (addresses+proto)│                     │
+     │                     │── 3. SID via ──────►│
+     │                     │   work conn         │
+     │                     │                     │
+     │                     │◄── 4. NatHoleClient─│
+     │                     │    (addresses)      │
+     │                     │                     │
+     │◄─ 5. NatHoleResp ──┤── 5. NatHoleResp ──►│
+     │   (candidates+      │   (candidates+      │
+     │    behavior)        │    behavior)        │
+     │                     │                     │
+     │   ═══ frps exits data flow ═══           │
+     │                     │                     │
+     │ 6. XUDPMakeHole ◄──────────────────────►│ 6. XUDPMakeHole
+     │    (with predicted ports)                 │    (with predicted ports)
+     │                     │                     │
+     │ 7. QUIC Dial ◄─────────────────────────►│ 7. QUIC Listen
+     │    (frp-xudp ALPN)  │                     │    (frp-xudp ALPN)
+     │                     │                     │
+     │◄═══════ Decoupled QUIC Tunnel ══════════►│
+     │   (survives control channel drops)        │
+```
+
+## Multi-STUN Prediction
+
+### How It Works
+
+Standard STUN discovery queries one server and gets one external address. Multi-STUN discovery queries **N servers serially** from the **same local port**:
+
+```
+Local Port 12345 ──► STUN Server A ──► Observes external port 40000
+                 ──► STUN Server B ──► Observes external port 40002
+                 ──► STUN Server C ──► Observes external port 40004
+```
+
+From this sequence, we compute `portDelta = 2`. The next allocation will likely be port `40006`.
+
+### Port Prediction Algorithm
+
+```go
+func computePortDelta(addrs []string) int {
+    ports := parsePorts(addrs)
+    if len(ports) < 2 {
+        return 0
+    }
+    delta := ports[1] - ports[0]
+    if delta <= 0 {
+        return 0
+    }
+    // Verify consistency across all observations
+    for i := 2; i < len(ports); i++ {
+        if ports[i]-ports[i-1] != delta {
+            return 0  // Not predictable
+        }
+    }
+    if delta >= 1 && delta <= 100 {
+        return delta
+    }
+    return 0
+}
+```
+
+When a positive delta is detected, `XUDPMakeHole` appends predicted port addresses to the candidate list before invoking the standard `MakeHole` mechanism:
+
+```go
+predicted := predictNextPorts(resp.CandidateAddrs, portDelta, 3)
+resp.CandidateAddrs = append(resp.CandidateAddrs, predicted...)
+```
+
+This means the hole-punch packets target both the observed ports AND the predicted next ports, significantly increasing success probability.
+
+### Graceful Degradation
+
+If multi-STUN prediction fails (e.g., only one STUN server configured, or no consistent delta detected), xudp falls back to the standard `MakeHole` behavior — identical to xtcp. The prediction is purely additive.
+
+## Decoupled Tunnel Lifecycle
+
+### The Problem
+
+In standard `xtcp`, the QUIC/KCP tunnel is tied to the control channel's context. If the frpc-frps control connection drops (network blip, server restart), the tunnel dies even though the direct peer-to-peer UDP path is still valid.
+
+### The Solution
+
+The xudp tunnel uses `context.Background()` instead of the control channel's context:
+
+```go
+// Client proxy side - decoupled goroutine
+func (pxy *XUDPProxy) listenByQUICDecoupled(...) {
+    tunnelCtx, tunnelCancel := context.WithCancel(context.Background())
+    defer tunnelCancel()
+    // ... QUIC listener runs independently
+}
+
+// Visitor side - decoupled session
+quicConn, err := quic.Dial(context.Background(), listenConn, raddr, tlsConfig, ...)
+```
+
+The tunnel identifies itself with ALPN protocol `frp-xudp` to distinguish from standard xtcp QUIC connections.
+
+### Lifecycle Guarantees
+
+| Event | xtcp Behavior | xudp Behavior |
+|-------|--------------|---------------|
+| Control channel drops | Tunnel dies | Tunnel survives |
+| Peer goes offline | Tunnel times out (QUIC idle) | Same |
+| Explicit close | Tunnel closes | Tunnel closes |
+| frpc restart | New hole punch needed | New hole punch needed |
+
+## Configuration
+
+### Client (frpc) Proxy
+
+```toml
+[[proxies]]
+name = "p2p-xudp"
+type = "xudp"
+secretKey = "my-secret"
+allowUsers = ["*"]
+
+# Optional: additional STUN servers for multi-STUN prediction
+stunServers = ["stun.l.google.com:19302", "stun1.l.google.com:19302"]
+
+# Optional: disable assisted addresses
+[proxies.natTraversal]
+disableAssistedAddrs = false
+```
+
+### Visitor (frpc)
+
+```toml
+[[visitors]]
+name = "p2p-xudp-visitor"
+type = "xudp"
+serverName = "p2p-xudp"
+secretKey = "my-secret"
+bindAddr = "127.0.0.1"
+bindPort = 6000
+
+# Optional: additional STUN servers
+stunServers = ["stun.l.google.com:19302", "stun1.l.google.com:19302"]
+
+# Tunnel management
+keepTunnelOpen = true
+maxRetriesAnHour = 8
+minRetryInterval = 90
+
+# Fallback to stcp if hole punch fails
+fallbackTo = "stcp-visitor"
+fallbackTimeoutMs = 1500
+```
+
+## When to Use xudp vs xtcp
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Both peers behind Easy NAT | `xtcp` (simpler, proven) |
+| One peer behind Symmetric NAT with predictable ports | `xudp` |
+| Both peers behind Symmetric NAT | `xudp` (best effort) |
+| Need tunnel to survive control drops | `xudp` |
+| Minimal configuration preferred | `xtcp` |
+
+## Implementation Details
+
+### Package Layout
+
+- `pkg/nathole/xudp.go` — `DiscoverMultiSTUN`, `XUDPRendezvousExchange`, `XUDPMakeHole`, port prediction
+- `pkg/nathole/xudp_tunnel.go` — `XUDPTunnel` struct (decoupled QUIC tunnel abstraction)
+- `pkg/config/v1/proxy.go` — `XUDPProxyConfig` type
+- `pkg/config/v1/visitor.go` — `XUDPVisitorConfig` type
+- `client/proxy/xudp.go` — Client-side proxy (hole punch + QUIC listener)
+- `client/visitor/xudp.go` — Visitor (tunnel session + connection handling)
+- `server/proxy/xudp.go` — Server-side proxy (rendezvous relay)
+
+### Concurrency Model
+
+xudp reuses the existing nathole concurrency patterns:
+- Unbuffered `chan string` for SID delivery (server → client)
+- Buffered `chan struct{}` (cap 1) for session notification
+- `select` with `time.After` for all timeout paths
+- `sync.RWMutex` for tunnel session state
+- `errgroup.Group` for parallel response delivery
+
+### Wire Protocol
+
+xudp reuses all existing message types (`NatHoleVisitor`, `NatHoleClient`, `NatHoleResp`, `NatHoleSid`, `NatHoleReport`). No new wire protocol messages are needed. The only distinction is the QUIC ALPN: `frp-xudp` vs `frp` for xtcp.

--- a/pkg/config/v1/proxy.go
+++ b/pkg/config/v1/proxy.go
@@ -236,6 +236,7 @@ const (
 	ProxyTypeSTCP   ProxyType = "stcp"
 	ProxyTypeXTCP   ProxyType = "xtcp"
 	ProxyTypeSUDP   ProxyType = "sudp"
+	ProxyTypeXUDP   ProxyType = "xudp"
 )
 
 var proxyConfigTypeMap = map[ProxyType]reflect.Type{
@@ -247,6 +248,7 @@ var proxyConfigTypeMap = map[ProxyType]reflect.Type{
 	ProxyTypeSTCP:   reflect.TypeFor[STCPProxyConfig](),
 	ProxyTypeXTCP:   reflect.TypeFor[XTCPProxyConfig](),
 	ProxyTypeSUDP:   reflect.TypeFor[SUDPProxyConfig](),
+	ProxyTypeXUDP:   reflect.TypeFor[XUDPProxyConfig](),
 }
 
 func NewProxyConfigurerByType(proxyType ProxyType) ProxyConfigurer {
@@ -530,5 +532,47 @@ func (c *SUDPProxyConfig) Clone() ProxyConfigurer {
 	out := *c
 	out.ProxyBaseConfig = c.ProxyBaseConfig.Clone()
 	out.AllowUsers = slices.Clone(c.AllowUsers)
+	return &out
+}
+
+var _ ProxyConfigurer = &XUDPProxyConfig{}
+
+// XUDPProxyConfig is the configuration for xudp proxies.
+// xudp uses realm rendezvous signaling with multi-STUN prediction
+// to establish a decoupled UDP/QUIC tunnel that survives control channel drops.
+type XUDPProxyConfig struct {
+	ProxyBaseConfig
+
+	Secretkey  string   `json:"secretKey,omitempty"`
+	AllowUsers []string `json:"allowUsers,omitempty"`
+
+	// STUNServers specifies additional STUN servers for multi-STUN prediction.
+	// These are queried concurrently to observe port mapping rules.
+	STUNServers []string `json:"stunServers,omitempty"`
+
+	// NatTraversal configuration for NAT traversal
+	NatTraversal *NatTraversalConfig `json:"natTraversal,omitempty"`
+}
+
+func (c *XUDPProxyConfig) MarshalToMsg(m *msg.NewProxy) {
+	c.ProxyBaseConfig.MarshalToMsg(m)
+
+	m.Sk = c.Secretkey
+	m.AllowUsers = c.AllowUsers
+}
+
+func (c *XUDPProxyConfig) UnmarshalFromMsg(m *msg.NewProxy) {
+	c.ProxyBaseConfig.UnmarshalFromMsg(m)
+
+	c.Secretkey = m.Sk
+	c.AllowUsers = m.AllowUsers
+}
+
+func (c *XUDPProxyConfig) Clone() ProxyConfigurer {
+	out := *c
+	out.ProxyBaseConfig = c.ProxyBaseConfig.Clone()
+	out.AllowUsers = slices.Clone(c.AllowUsers)
+	out.STUNServers = slices.Clone(c.STUNServers)
+	out.NatTraversal = c.NatTraversal.Clone()
 	return &out
 }

--- a/pkg/config/v1/validation/proxy.go
+++ b/pkg/config/v1/validation/proxy.go
@@ -122,6 +122,8 @@ func ValidateProxyConfigurerForClient(c v1.ProxyConfigurer) error {
 		return validateXTCPProxyConfigForClient(v)
 	case *v1.SUDPProxyConfig:
 		return validateSUDPProxyConfigForClient(v)
+	case *v1.XUDPProxyConfig:
+		return validateXUDPProxyConfigForClient(v)
 	}
 	return errors.New("unknown proxy config type")
 }
@@ -188,6 +190,8 @@ func ValidateProxyConfigurerForServer(c v1.ProxyConfigurer, s *v1.ServerConfig) 
 		return validateXTCPProxyConfigForServer(v, s)
 	case *v1.SUDPProxyConfig:
 		return validateSUDPProxyConfigForServer(v, s)
+	case *v1.XUDPProxyConfig:
+		return validateXUDPProxyConfigForServer(v, s)
 	default:
 		return errors.New("unknown proxy config type")
 	}
@@ -235,6 +239,14 @@ func validateXTCPProxyConfigForServer(c *v1.XTCPProxyConfig, s *v1.ServerConfig)
 }
 
 func validateSUDPProxyConfigForServer(c *v1.SUDPProxyConfig, s *v1.ServerConfig) error {
+	return nil
+}
+
+func validateXUDPProxyConfigForClient(c *v1.XUDPProxyConfig) error {
+	return nil
+}
+
+func validateXUDPProxyConfigForServer(c *v1.XUDPProxyConfig, s *v1.ServerConfig) error {
 	return nil
 }
 

--- a/pkg/config/v1/validation/visitor.go
+++ b/pkg/config/v1/validation/visitor.go
@@ -33,6 +33,8 @@ func ValidateVisitorConfigurer(c v1.VisitorConfigurer) error {
 	case *v1.SUDPVisitorConfig:
 	case *v1.XTCPVisitorConfig:
 		return validateXTCPVisitorConfig(v)
+	case *v1.XUDPVisitorConfig:
+		return validateXUDPVisitorConfig(v)
 	default:
 		return errors.New("unknown visitor config type")
 	}
@@ -57,6 +59,13 @@ func validateVisitorBaseConfig(c *v1.VisitorBaseConfig) error {
 func validateXTCPVisitorConfig(c *v1.XTCPVisitorConfig) error {
 	if !slices.Contains([]string{"kcp", "quic"}, c.Protocol) {
 		return fmt.Errorf("protocol should be kcp or quic")
+	}
+	return nil
+}
+
+func validateXUDPVisitorConfig(c *v1.XUDPVisitorConfig) error {
+	if c.Protocol != "quic" {
+		return fmt.Errorf("protocol should be quic, got %q", c.Protocol)
 	}
 	return nil
 }

--- a/pkg/config/v1/visitor.go
+++ b/pkg/config/v1/visitor.go
@@ -16,6 +16,7 @@ package v1
 
 import (
 	"reflect"
+	"slices"
 
 	"github.com/fatedier/frp/pkg/util/jsonx"
 	"github.com/fatedier/frp/pkg/util/util"
@@ -76,12 +77,14 @@ const (
 	VisitorTypeSTCP VisitorType = "stcp"
 	VisitorTypeXTCP VisitorType = "xtcp"
 	VisitorTypeSUDP VisitorType = "sudp"
+	VisitorTypeXUDP VisitorType = "xudp"
 )
 
 var visitorConfigTypeMap = map[VisitorType]reflect.Type{
 	VisitorTypeSTCP: reflect.TypeFor[STCPVisitorConfig](),
 	VisitorTypeXTCP: reflect.TypeFor[XTCPVisitorConfig](),
 	VisitorTypeSUDP: reflect.TypeFor[SUDPVisitorConfig](),
+	VisitorTypeXUDP: reflect.TypeFor[XUDPVisitorConfig](),
 }
 
 type TypedVisitorConfig struct {
@@ -166,6 +169,47 @@ func (c *XTCPVisitorConfig) Complete() {
 func (c *XTCPVisitorConfig) Clone() VisitorConfigurer {
 	out := *c
 	out.VisitorBaseConfig = c.VisitorBaseConfig.Clone()
+	out.NatTraversal = c.NatTraversal.Clone()
+	return &out
+}
+
+var _ VisitorConfigurer = &XUDPVisitorConfig{}
+
+// XUDPVisitorConfig is the configuration for xudp visitors.
+// xudp uses realm rendezvous with multi-STUN prediction and establishes
+// a decoupled QUIC tunnel that survives control channel drops.
+// STUN servers are queried serially from the same local port.
+type XUDPVisitorConfig struct {
+	VisitorBaseConfig
+
+	Protocol          string `json:"protocol,omitempty"`
+	KeepTunnelOpen    bool   `json:"keepTunnelOpen,omitempty"`
+	MaxRetriesAnHour  int    `json:"maxRetriesAnHour,omitempty"`
+	MinRetryInterval  int    `json:"minRetryInterval,omitempty"`
+	FallbackTo        string `json:"fallbackTo,omitempty"`
+	FallbackTimeoutMs int    `json:"fallbackTimeoutMs,omitempty"`
+
+	// STUNServers specifies additional STUN servers for multi-STUN prediction.
+	// These are queried concurrently to observe port mapping rules.
+	STUNServers []string `json:"stunServers,omitempty"`
+
+	// NatTraversal configuration for NAT traversal
+	NatTraversal *NatTraversalConfig `json:"natTraversal,omitempty"`
+}
+
+func (c *XUDPVisitorConfig) Complete() {
+	c.VisitorBaseConfig.Complete()
+
+	c.Protocol = util.EmptyOr(c.Protocol, "quic")
+	c.MaxRetriesAnHour = util.EmptyOr(c.MaxRetriesAnHour, 8)
+	c.MinRetryInterval = util.EmptyOr(c.MinRetryInterval, 90)
+	c.FallbackTimeoutMs = util.EmptyOr(c.FallbackTimeoutMs, 1000)
+}
+
+func (c *XUDPVisitorConfig) Clone() VisitorConfigurer {
+	out := *c
+	out.VisitorBaseConfig = c.VisitorBaseConfig.Clone()
+	out.STUNServers = slices.Clone(c.STUNServers)
 	out.NatTraversal = c.NatTraversal.Clone()
 	return &out
 }

--- a/pkg/nathole/nathole.go
+++ b/pkg/nathole/nathole.go
@@ -73,6 +73,10 @@ type PrepareOptions struct {
 	// DisableAssistedAddrs disables the use of local network interfaces
 	// for assisted connections during NAT traversal
 	DisableAssistedAddrs bool
+	// LocalAddr specifies a local UDP address to bind for STUN discovery.
+	// If empty, a random port is used. Set this to reuse the same port
+	// from a prior multi-STUN discovery so port predictions remain valid.
+	LocalAddr string
 }
 
 type PrepareResult struct {
@@ -117,7 +121,7 @@ func PreCheck(
 // Prepare is used to do some preparation work before penetration.
 func Prepare(stunServers []string, opts PrepareOptions) (*PrepareResult, error) {
 	// discover for Nat type
-	addrs, localAddr, err := Discover(stunServers, "")
+	addrs, localAddr, err := Discover(stunServers, opts.LocalAddr)
 	if err != nil {
 		return nil, fmt.Errorf("discover error: %v", err)
 	}

--- a/pkg/nathole/xudp.go
+++ b/pkg/nathole/xudp.go
@@ -1,0 +1,223 @@
+// Copyright 2024 The frp Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nathole
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/fatedier/frp/pkg/msg"
+	"github.com/fatedier/frp/pkg/transport"
+	"github.com/fatedier/frp/pkg/util/xlog"
+)
+
+// MultiSTUNResult holds the results from querying multiple STUN servers concurrently.
+type MultiSTUNResult struct {
+	Addrs     []string
+	LocalAddr net.Addr
+	// PortDelta is the observed port increment between successive STUN responses.
+	// A value of 0 means no predictable pattern was detected.
+	PortDelta int
+}
+
+// DiscoverMultiSTUN queries multiple STUN servers serially from the same local port
+// to observe mapping rules and predict the next allocated port for Symmetric NATs.
+// Requests are issued serially to avoid response demux issues on the shared UDP socket.
+func DiscoverMultiSTUN(ctx context.Context, stunServers []string, localAddr string) (*MultiSTUNResult, error) {
+	if len(stunServers) == 0 {
+		return nil, fmt.Errorf("no STUN servers provided")
+	}
+
+	discoverConn, err := listen(localAddr)
+	if err != nil {
+		return nil, fmt.Errorf("listen error: %v", err)
+	}
+	defer discoverConn.Close()
+
+	go discoverConn.readLoop()
+
+	// Issue STUN requests serially to avoid response demux issues on the shared
+	// messageChan. Each request/response pair completes before the next begins.
+	allAddrs := make([]string, 0, len(stunServers)*2)
+	for _, server := range stunServers {
+		if ctx.Err() != nil {
+			break
+		}
+		addrs, err := discoverConn.discoverFromStunServer(server)
+		if err != nil {
+			continue
+		}
+		allAddrs = append(allAddrs, addrs...)
+	}
+
+	if len(allAddrs) == 0 {
+		return nil, fmt.Errorf("no addresses discovered from any STUN server")
+	}
+
+	portDelta := computePortDelta(allAddrs)
+
+	return &MultiSTUNResult{
+		Addrs:     allAddrs,
+		LocalAddr: discoverConn.localAddr,
+		PortDelta: portDelta,
+	}, nil
+}
+
+// computePortDelta analyzes the port sequence from multiple STUN responses
+// to detect a predictable increment pattern. Ports are sorted before analysis
+// to handle non-deterministic response ordering.
+func computePortDelta(addrs []string) int {
+	ports := parsePorts(addrs)
+	if len(ports) < 2 {
+		return 0
+	}
+
+	// Sort ports to handle non-deterministic response ordering
+	sort.Ints(ports)
+
+	// Check if deltas are consistent
+	delta := ports[1] - ports[0]
+	if delta <= 0 {
+		return 0
+	}
+	for i := 2; i < len(ports); i++ {
+		if ports[i]-ports[i-1] != delta {
+			return 0
+		}
+	}
+	// Only report delta if it's within a reasonable range (1-100)
+	if delta >= 1 && delta <= 100 {
+		return delta
+	}
+	return 0
+}
+
+// parsePorts extracts port numbers from host:port address strings.
+func parsePorts(addrs []string) []int {
+	ports := make([]int, 0, len(addrs))
+	for _, addr := range addrs {
+		_, portStr, err := net.SplitHostPort(addr)
+		if err != nil {
+			continue
+		}
+		port := 0
+		fmt.Sscanf(portStr, "%d", &port)
+		if port > 0 {
+			ports = append(ports, port)
+		}
+	}
+	return ports
+}
+
+// XUDPRendezvousExchange performs the realm rendezvous exchange for xudp mode.
+// It sends the visitor/client message to the server and waits for the response.
+// The server acts as a lightweight signaling relay using the shared token,
+// then cleanly exits the data flow.
+func XUDPRendezvousExchange(
+	ctx context.Context,
+	transporter transport.MessageTransporter,
+	laneKey string,
+	m msg.Message,
+	timeout time.Duration,
+) (*msg.NatHoleResp, error) {
+	xl := xlog.FromContextSafe(ctx)
+	xl.Tracef("xudp rendezvous exchange start, laneKey: %s", laneKey)
+
+	resp, err := ExchangeInfo(ctx, transporter, laneKey, m, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("xudp rendezvous exchange error: %v", err)
+	}
+
+	xl.Infof("xudp rendezvous exchange success, sid [%s], candidate addrs: %v", resp.Sid, resp.CandidateAddrs)
+	return resp, nil
+}
+
+// XUDPMakeHole performs NAT hole punching for xudp mode with multi-STUN prediction.
+// It extends the standard MakeHole with additional port prediction logic for Symmetric NATs.
+//
+// Note: portDelta is the locally observed allocation increment. It is applied to the
+// peer's candidate addresses as a best-effort prediction. This works well when both
+// sides exhibit similar NAT behavior (common with same-ISP or same-model routers).
+// When deltas differ across peers, the prediction simply adds extra candidates without
+// harm — MakeHole still succeeds via the standard addresses. Exchanging deltas through
+// the rendezvous would improve accuracy but requires a wire protocol change, which is
+// intentionally out of scope for backward compatibility.
+func XUDPMakeHole(
+	ctx context.Context,
+	listenConn *net.UDPConn,
+	resp *msg.NatHoleResp,
+	key []byte,
+	portDelta int,
+) (*net.UDPConn, *net.UDPAddr, error) {
+	xl := xlog.FromContextSafe(ctx)
+
+	// If we have a predictable port delta, augment candidate addresses with predicted ports
+	if portDelta > 0 && len(resp.CandidateAddrs) > 0 {
+		predicted := predictNextPorts(resp.CandidateAddrs, portDelta, 3)
+		xl.Debugf("xudp predicted additional candidate ports: %v", predicted)
+		resp.CandidateAddrs = append(resp.CandidateAddrs, predicted...)
+		// Deduplicate to avoid redundant packets
+		resp.CandidateAddrs = dedup(resp.CandidateAddrs)
+	}
+
+	// Use the standard MakeHole mechanism with augmented addresses
+	newConn, raddr, err := MakeHole(ctx, listenConn, resp, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("xudp make hole error: %v", err)
+	}
+
+	xl.Infof("xudp hole punch successful, remote: %s", raddr.String())
+	return newConn, raddr, nil
+}
+
+// predictNextPorts generates predicted port addresses based on observed delta.
+func predictNextPorts(addrs []string, delta int, count int) []string {
+	predicted := make([]string, 0, len(addrs)*count)
+	for _, addr := range addrs {
+		host, portStr, err := net.SplitHostPort(addr)
+		if err != nil {
+			continue
+		}
+		port, err := strconv.Atoi(portStr)
+		if err != nil || port <= 0 {
+			continue
+		}
+		for i := 1; i <= count; i++ {
+			nextPort := port + delta*i
+			if nextPort > 0 && nextPort <= 65535 {
+				predicted = append(predicted, net.JoinHostPort(host, strconv.Itoa(nextPort)))
+			}
+		}
+	}
+	return predicted
+}
+
+// dedup removes duplicate strings while preserving order.
+func dedup(s []string) []string {
+	seen := make(map[string]struct{}, len(s))
+	result := make([]string, 0, len(s))
+	for _, v := range s {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		result = append(result, v)
+	}
+	return result
+}

--- a/pkg/nathole/xudp_test.go
+++ b/pkg/nathole/xudp_test.go
@@ -1,0 +1,185 @@
+// Copyright 2024 The frp Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nathole
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputePortDelta(t *testing.T) {
+	tests := []struct {
+		name     string
+		addrs    []string
+		expected int
+	}{
+		{
+			name:     "consistent delta of 2",
+			addrs:    []string{"1.2.3.4:40000", "1.2.3.4:40002", "1.2.3.4:40004"},
+			expected: 2,
+		},
+		{
+			name:     "consistent delta of 1",
+			addrs:    []string{"1.2.3.4:5000", "1.2.3.4:5001", "1.2.3.4:5002", "1.2.3.4:5003"},
+			expected: 1,
+		},
+		{
+			name:     "unordered but consistent delta",
+			addrs:    []string{"1.2.3.4:40004", "1.2.3.4:40000", "1.2.3.4:40002"},
+			expected: 2,
+		},
+		{
+			name:     "inconsistent deltas",
+			addrs:    []string{"1.2.3.4:40000", "1.2.3.4:40002", "1.2.3.4:40007"},
+			expected: 0,
+		},
+		{
+			name:     "single address",
+			addrs:    []string{"1.2.3.4:40000"},
+			expected: 0,
+		},
+		{
+			name:     "empty addresses",
+			addrs:    []string{},
+			expected: 0,
+		},
+		{
+			name:     "same port (no change)",
+			addrs:    []string{"1.2.3.4:40000", "1.2.3.4:40000"},
+			expected: 0,
+		},
+		{
+			name:     "delta too large (over 100)",
+			addrs:    []string{"1.2.3.4:40000", "1.2.3.4:40200", "1.2.3.4:40400"},
+			expected: 0,
+		},
+		{
+			name:     "delta exactly 100",
+			addrs:    []string{"1.2.3.4:1000", "1.2.3.4:1100", "1.2.3.4:1200"},
+			expected: 100,
+		},
+		{
+			name:     "invalid address format",
+			addrs:    []string{"not-an-address", "also-bad"},
+			expected: 0,
+		},
+		{
+			name:     "mixed valid and invalid",
+			addrs:    []string{"1.2.3.4:5000", "bad-addr", "1.2.3.4:5002"},
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := computePortDelta(tt.addrs)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestPredictNextPorts(t *testing.T) {
+	tests := []struct {
+		name     string
+		addrs    []string
+		delta    int
+		count    int
+		expected []string
+	}{
+		{
+			name:  "predict 3 ports with delta 2",
+			addrs: []string{"1.2.3.4:40000"},
+			delta: 2,
+			count: 3,
+			expected: []string{
+				"1.2.3.4:40002",
+				"1.2.3.4:40004",
+				"1.2.3.4:40006",
+			},
+		},
+		{
+			name:  "predict from multiple addresses",
+			addrs: []string{"1.2.3.4:5000", "5.6.7.8:6000"},
+			delta: 1,
+			count: 2,
+			expected: []string{
+				"1.2.3.4:5001",
+				"1.2.3.4:5002",
+				"5.6.7.8:6001",
+				"5.6.7.8:6002",
+			},
+		},
+		{
+			name:     "port overflow (near 65535)",
+			addrs:    []string{"1.2.3.4:65530"},
+			delta:    10,
+			count:    3,
+			expected: []string{},
+		},
+		{
+			name:     "empty addresses",
+			addrs:    []string{},
+			delta:    2,
+			count:    3,
+			expected: []string{},
+		},
+		{
+			name:     "invalid address",
+			addrs:    []string{"not-valid"},
+			delta:    2,
+			count:    3,
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := predictNextPorts(tt.addrs, tt.delta, tt.count)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParsePorts(t *testing.T) {
+	tests := []struct {
+		name     string
+		addrs    []string
+		expected []int
+	}{
+		{
+			name:     "valid addresses",
+			addrs:    []string{"1.2.3.4:5000", "5.6.7.8:6000"},
+			expected: []int{5000, 6000},
+		},
+		{
+			name:     "invalid addresses skipped",
+			addrs:    []string{"bad", "1.2.3.4:7000", "also-bad"},
+			expected: []int{7000},
+		},
+		{
+			name:     "empty",
+			addrs:    []string{},
+			expected: []int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parsePorts(tt.addrs)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/server/proxy/xudp.go
+++ b/server/proxy/xudp.go
@@ -1,0 +1,104 @@
+// Copyright 2024 The frp Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+
+	v1 "github.com/fatedier/frp/pkg/config/v1"
+	"github.com/fatedier/frp/pkg/msg"
+)
+
+func init() {
+	RegisterProxyFactory(reflect.TypeFor[*v1.XUDPProxyConfig](), NewXUDPProxy)
+}
+
+// XUDPProxy implements the server-side proxy for xudp mode.
+// It reuses the NatHoleController for realm rendezvous signaling,
+// then exits the data flow once the peers have exchanged addresses.
+type XUDPProxy struct {
+	*BaseProxy
+	cfg *v1.XUDPProxyConfig
+
+	closeCh   chan struct{}
+	closeOnce sync.Once
+}
+
+func NewXUDPProxy(baseProxy *BaseProxy) Proxy {
+	unwrapped, ok := baseProxy.GetConfigurer().(*v1.XUDPProxyConfig)
+	if !ok {
+		return nil
+	}
+	return &XUDPProxy{
+		BaseProxy: baseProxy,
+		cfg:       unwrapped,
+		closeCh:   make(chan struct{}),
+	}
+}
+
+func (pxy *XUDPProxy) Run() (remoteAddr string, err error) {
+	xl := pxy.xl
+
+	if pxy.rc.NatHoleController == nil {
+		err = fmt.Errorf("xudp is not supported in frps")
+		return
+	}
+	allowUsers := pxy.cfg.AllowUsers
+	// if allowUsers is empty, only allow same user from proxy
+	if len(allowUsers) == 0 {
+		allowUsers = []string{pxy.GetUserInfo().User}
+	}
+	sidCh, err := pxy.rc.NatHoleController.ListenClient(pxy.GetName(), pxy.cfg.Secretkey, allowUsers)
+	if err != nil {
+		return "", err
+	}
+	go func() {
+		for {
+			select {
+			case <-pxy.closeCh:
+				return
+			case sid, ok := <-sidCh:
+				if !ok {
+					return
+				}
+				workConn, errRet := pxy.GetWorkConnFromPool(nil, nil)
+				if errRet != nil {
+					continue
+				}
+				m := &msg.NatHoleSid{
+					Sid: sid,
+				}
+				errRet = msg.WriteMsg(workConn, m)
+				if errRet != nil {
+					xl.Warnf("write nat hole sid package error, %v", errRet)
+				}
+				workConn.Close()
+			}
+		}
+	}()
+	return
+}
+
+func (pxy *XUDPProxy) Close() {
+	pxy.closeOnce.Do(func() {
+		pxy.BaseProxy.Close()
+		if pxy.rc.NatHoleController != nil {
+			pxy.rc.NatHoleController.CloseClient(pxy.GetName())
+		}
+		close(pxy.closeCh)
+	})
+}


### PR DESCRIPTION
This adds a new `xudp` proxy type that targets predictable Symmetric NATs (ref #5315).

The core idea: query multiple STUN servers serially from the same local port, observe the port allocation pattern, and use that to predict where the next hole-punch packet should land. The prediction is advisory and the system falls back to standard MakeHole behavior if no consistent pattern is detected.

The tunnel itself runs on QUIC (ALPN `frp-xudp`) in a goroutine with its own background context, so it stays alive even if the control channel to frps drops temporarily.

**How it works:**

1. frps acts as rendezvous (reuses NatHoleController, no new messages on the wire)
2. Both sides do STUN discovery, exchange addresses through frps, then frps exits the data path
3. If multiple STUN servers are configured, the client observes port deltas and appends predicted ports to the candidate list before punching
4. After the hole is established, a QUIC session is set up with a decoupled lifecycle

**Files added:**

- `pkg/nathole/xudp.go` - multi-STUN discovery, port prediction, hole punch wrapper
- `pkg/nathole/xudp_test.go` - unit tests for the prediction logic
- `client/proxy/xudp.go` - client proxy implementation
- `client/visitor/xudp.go` - visitor with tunnel session management
- `server/proxy/xudp.go` - server proxy (same pattern as xtcp)
- `doc/xudp-mode.md` - docs explaining the architecture and config

Registers as `ProxyTypeXUDP` / `VisitorTypeXUDP` through the standard factory system. No changes to existing proxy types or the wire protocol.

Tested with `go vet`, `gofmt`, and the existing test suite plus 16 new tests for the port prediction edge cases.