### PR TITLE
Release v0.69.1

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -1,11 +1,9 @@
 ## Features
 
-* When `transport.wireProtocol = "v2"` is enabled, ordinary UDP proxy work connection payloads now use wire protocol v2 message framing. This keeps UDP message payloads aligned with the negotiated frpc/frps wire protocol.
-* SUDP proxy payloads now also follow the connection wire protocol. SUDP v2 endpoints use wire protocol v2 message framing, while v1/default endpoints continue to use the legacy message codec. When the SUDP proxy frpc and visitor frpc use mixed v1/v2 wire protocols, frps bridges UDPPacket messages between the two codecs.
+* `transport.wireProtocol = "v2"` now also applies to UDP-based proxy payloads, including ordinary UDP and SUDP, so their payload framing is consistent with the selected wire protocol.
+* Improved SUDP compatibility during mixed `transport.wireProtocol` deployments, allowing frps to bridge payloads between v1/default and v2 SUDP clients.
+* XTCP work connection `NatHoleSid` messages now follow the selected `transport.wireProtocol`.
 
 ## Compatibility Notes
 
-* The default/empty `transport.wireProtocol` and `transport.wireProtocol = "v1"` continue to use the legacy message codec for ordinary UDP and SUDP proxy payloads.
-* Raw stream proxy paths such as TCP, HTTP, and STCP remain unframed and are not affected by the UDP/SUDP payload framing change.
-* Direct NAT hole UDP sid probing packets are not changed by this release.
-* `transport.wireProtocol = "v2"` requires peers to use versions that support the same wire v2 payload semantics. Mixing a newer peer that sends v2-framed UDP or SUDP payloads with an older v2-capable peer that still expects the legacy payload codec can break that proxy traffic. During rolling upgrades, upgrade both SUDP proxy and visitor frpc instances before enabling `transport.wireProtocol = "v2"` for SUDP, or keep those clients on `transport.wireProtocol = "v1"` until both sides are upgraded.
+* When enabling `transport.wireProtocol = "v2"` for SUDP, upgrade both the proxy and visitor frpc instances first, or keep them on `v1` until both sides are upgraded.

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -14,7 +14,7 @@
 
 package version
 
-var version = "0.69.0"
+var version = "0.69.1"
 
 func Full() string {
 	return version


### PR DESCRIPTION
## Summary
- Bump frp version to `0.69.1`.
- Simplify `Release.md` for the v0.69.1 release notes.
- Document the UDP-based proxy payload framing updates for ordinary UDP and SUDP when `transport.wireProtocol = "v2"` is selected.
- Document the SUDP mixed `transport.wireProtocol` bridge.
- Document that XTCP work connection `NatHoleSid` messages now follow the selected `transport.wireProtocol`.

## Compatibility Notes
- Keep the compatibility note focused on SUDP rolling upgrades: upgrade both proxy and visitor frpc instances before enabling `transport.wireProtocol = "v2"`, or keep them on `v1` until both sides are upgraded.
- This PR does not add release-note wording for direct peer-to-peer NAT-hole UDP sid packets.

## Tests
- `git diff --check HEAD~1 HEAD`
- `go test ./pkg/util/version`
- `golangci-lint run`
