### PR TITLE
test: handle wire v2 compatibility baselines

### DIFF
--- a/test/e2e/compatibility/compatibility_test.go
+++ b/test/e2e/compatibility/compatibility_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -158,7 +160,7 @@ webServer.port = %d
 		framework.NewRequestExpect(f).PortName(portName).Ensure()
 	})
 
-	ginkgo.It("baseline frps rejects current frpc forced to v2", func() {
+	ginkgo.It("baseline frps handles current frpc forced to v2 according to baseline support", func() {
 		portName := port.GenName("CompatBaselineFRPSForcedV2")
 		clientConf := tcpClientConfig("tcp", portName, `
 transport.wireProtocol = "v2"
@@ -170,6 +172,21 @@ transport.wireProtocol = "v2"
 			consts.DefaultServerConfig,
 			[]string{clientConf},
 		)
+
+		// frp v0.69.0 added control connection wireProtocol v2 support, so
+		// baseline frps v0.69.0 and newer should accept a current frpc forced
+		// to v2. Older known baselines still must reject the unsupported protocol.
+		// For custom baselines, the version is unknown and the binary may be either
+		// side of the support boundary, so this versioned expectation is skipped.
+		supportsV2, knownVersion := baselineSupportsControlWireProtocolV2(compatCtx.BaselineVersion)
+		if !knownVersion {
+			ginkgo.Skip(fmt.Sprintf("baseline version %q is not semver; skip versioned forced-v2 expectation", compatCtx.BaselineVersion))
+		}
+		if supportsV2 {
+			framework.NewRequestExpect(f).PortName(portName).Ensure()
+			return
+		}
+
 		expectProcessExit(clientProcesses[0], 5*time.Second)
 		framework.NewRequestExpect(f).PortName(portName).ExpectError(true).Ensure()
 	})
@@ -197,6 +214,39 @@ func expectProcessExit(p *process.Process, timeout time.Duration) {
 	case <-time.After(timeout):
 		framework.Failf("process did not exit within %s; output:\n%s", timeout, p.Output())
 	}
+}
+
+func baselineSupportsControlWireProtocolV2(version string) (supports bool, known bool) {
+	version = strings.TrimPrefix(version, "v")
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return false, false
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false, false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return false, false
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return false, false
+	}
+
+	return compareSemanticVersion(major, minor, patch, 0, 69, 0) >= 0, true
+}
+
+func compareSemanticVersion(major, minor, patch int, baseMajor, baseMinor, basePatch int) int {
+	if major != baseMajor {
+		return major - baseMajor
+	}
+	if minor != baseMinor {
+		return minor - baseMinor
+	}
+	return patch - basePatch
 }
 
 type wireClientInfo struct {


### PR DESCRIPTION
## Summary

- update the compatibility e2e forced-v2 expectation to account for baseline version support
- expect semver baselines `>= 0.69.0` to accept current frpc forced to `transport.wireProtocol = "v2"`
- keep semver baselines `< 0.69.0` expecting rejection
- skip the versioned forced-v2 assertion for custom/non-semver baseline labels because their support boundary is unknown

## Context

frp `v0.69.0` already supports control connection `wireProtocol = "v2"`, so the old compatibility expectation that every baseline frps must reject a current frpc forced to v2 became stale. This caused release compatibility validation for v0.69.1 to fail on the `v0.69.0` baseline even though that behavior is expected.

## Validation

Pre-commit / submission checks:

- `git diff --check`
- `go test -c ./test/e2e/compatibility -o /tmp/frp-compatibility.test`
- `golangci-lint run --build-tags noweb`

Full compatibility validation already run after the test fix:

- `make e2e-compatibility`
  - passed with baselines: `0.69.0 0.68.1 0.68.0 0.67.0 0.66.0 0.65.0 0.64.0 0.63.0`
- `make e2e-compatibility-floor`
  - passed with baseline: `0.61.0`
- custom baseline validation:
  - `BASELINE_FRPS_PATH=$(pwd)/bin/frps BASELINE_FRPC_PATH=$(pwd)/bin/frpc ./hack/run-e2e-compatibility.sh`
- dotted non-semver baseline validation:
  - `FRP_COMPAT_BASELINE_VERSION=0.69.0-dev BASELINE_FRPS_PATH=$(pwd)/bin/frps BASELINE_FRPC_PATH=$(pwd)/bin/frpc ./hack/run-e2e-compatibility.sh`

Codex review:

- fresh interactive `/review` final pass: no correctness issues found
