### PR TITLE
fix(client): write proxy protocol header in tls2raw plugin

### DIFF
--- a/pkg/plugin/client/tls2raw.go
+++ b/pkg/plugin/client/tls2raw.go
@@ -72,6 +72,15 @@ func (p *TLS2RawPlugin) Handle(ctx context.Context, connInfo *ConnectionInfo) {
 		return
 	}
 
+	if connInfo.ProxyProtocolHeader != nil {
+		if _, err := connInfo.ProxyProtocolHeader.WriteTo(rawConn); err != nil {
+			xl.Warnf("tls2raw write proxy protocol header to local conn error: %v", err)
+			rawConn.Close()
+			tlsConn.Close()
+			return
+		}
+	}
+
 	libio.Join(tlsConn, rawConn)
 }
 


### PR DESCRIPTION
### WHY
When `transport.proxyProtocolVersion = "v2"` is configured with the `tls2raw` plugin, frpc already builds the PROXY protocol header in the common TCP work connection path, but `tls2raw` did not write that header to the local service.
As a result, the setting had no effect for `tls2raw`.