### PR TITLE
test(e2e): support INI-format baseline in compatibility suite

### DIFF
--- a/test/e2e/compatibility/compatibility_test.go
+++ b/test/e2e/compatibility/compatibility_test.go
@@ -23,14 +23,15 @@ import (
 )
 
 type compatTestContext struct {
-	CurrentFRPSPath   string
-	CurrentFRPCPath   string
-	BaselineFRPSPath  string
-	BaselineFRPCPath  string
-	BaselineVersion   string
-	LogLevel          string
-	Debug             bool
-	RunCurrentCurrent bool
+	CurrentFRPSPath      string
+	CurrentFRPCPath      string
+	BaselineFRPSPath     string
+	BaselineFRPCPath     string
+	BaselineVersion      string
+	BaselineConfigFormat string
+	LogLevel             string
+	Debug                bool
+	RunCurrentCurrent    bool
 }
 
 var compatCtx compatTestContext
@@ -41,6 +42,7 @@ func registerFlags(flags *flag.FlagSet) {
 	flags.StringVar(&compatCtx.BaselineFRPSPath, "baseline-frps-path", "", "The baseline frps binary to use.")
 	flags.StringVar(&compatCtx.BaselineFRPCPath, "baseline-frpc-path", "", "The baseline frpc binary to use.")
 	flags.StringVar(&compatCtx.BaselineVersion, "baseline-version", "custom", "The baseline version label for reporting.")
+	flags.StringVar(&compatCtx.BaselineConfigFormat, "baseline-config-format", "toml", "Baseline binary config format: toml (modern) or ini (legacy).")
 	flags.StringVar(&compatCtx.LogLevel, "log-level", "debug", "Log level.")
 	flags.BoolVar(&compatCtx.Debug, "debug", false, "Enable debug mode to print detailed info.")
 	flags.BoolVar(&compatCtx.RunCurrentCurrent, "run-current-current", true, "Run current frps/current frpc sanity checks.")
@@ -133,7 +135,7 @@ webServer.port = %d
 `, webPort)
 
 		portName := port.GenName("CompatBaselineFRPC")
-		clientConf := tcpClientConfig("tcp", portName, "")
+		clientConf := baselineClientConfig("tcp", portName, "")
 
 		f.RunProcessesWithBinaries(
 			compatCtx.CurrentFRPSPath,
@@ -206,6 +208,33 @@ type = "tcp"
 localPort = {{ .%s }}
 remotePort = {{ .%s }}
 `, consts.PortServerName, extra, proxyName, framework.TCPEchoServerPort, remotePortName)
+}
+
+// tcpClientConfigLegacy renders an INI ([common]) config for baseline frpc binaries
+// that predate the modern TOML/YAML config format (frp <= 0.5x, e.g. 0.38).
+func tcpClientConfigLegacy(proxyName string, remotePortName string, extra string) string {
+	return fmt.Sprintf(`
+[common]
+server_addr = 127.0.0.1
+server_port = {{ .%s }}
+login_fail_exit = true
+log_level = trace
+%s
+
+[%s]
+type = tcp
+local_ip = 127.0.0.1
+local_port = {{ .%s }}
+remote_port = {{ .%s }}
+`, consts.PortServerName, extra, proxyName, framework.TCPEchoServerPort, remotePortName)
+}
+
+// baselineClientConfig picks the config dialect that the baseline frpc binary understands.
+func baselineClientConfig(proxyName string, remotePortName string, extra string) string {
+	if compatCtx.BaselineConfigFormat == "ini" {
+		return tcpClientConfigLegacy(proxyName, remotePortName, extra)
+	}
+	return tcpClientConfig(proxyName, remotePortName, extra)
 }
 
 func expectProcessExit(p *process.Process, timeout time.Duration) {


### PR DESCRIPTION
## What

The compatibility e2e suite always renders the baseline frpc config in the modern TOML format. As a result it cannot exercise frp releases that predate the TOML/YAML config format (frp <= 0.5x), which only understand the legacy INI `[common]` format. Such binaries fail to start with:

```
invalid configuration file, not found [common] section
```

This PR adds:

- a `-baseline-config-format` flag (`toml` | `ini`, default `toml`);
- an INI client-config renderer `tcpClientConfigLegacy`;
- a small `baselineClientConfig` dispatcher that picks the dialect the baseline frpc understands.

With `-baseline-config-format=ini`, the existing **"current frps accepts baseline frpc using v1"** spec can verify that a legacy frpc (e.g. 0.38.0) still logs in, registers a proxy, and tunnels traffic through a current frps.

## Why

It is useful to be able to point the compatibility harness at very old frpc binaries (via `BASELINE_FRPS_PATH`/`BASELINE_FRPC_PATH`) to confirm the wire-protocol v1 control path stays backward compatible, beyond the versions covered by the default baseline matrix.

## Compatibility

Default behaviour is unchanged (`toml`), so existing `make e2e-compatibility*` invocations are unaffected.

## Verified

Built current `frps`/`frpc` from source and ran the focused spec against an official `0.38.0` frpc baseline binary:

```
ginkgo --focus="current frps accepts baseline frpc using v1" ./test/e2e/compatibility -- \
  -current-frps-path=bin/frps -current-frpc-path=bin/frpc \
  -baseline-frps-path=<0.38>/frps -baseline-frpc-path=<0.38>/frpc \
  -baseline-version=0.38.0 -baseline-config-format=ini -run-current-current=false

SUCCESS! -- 1 Passed | 0 Failed
```

`gofmt`, `gofumpt`, `go vet` and `golangci-lint` are clean.

## Scope / follow-up

This PR only wires the INI dialect for the **baseline frpc** direction. The two "baseline frps" specs (old binary acting as the server) still render a TOML server config; extending them to legacy INI server config can be a follow-up if testing old frps binaries is also desired.