### PR TITLE
fix(client): honor no_proxy when connecting to the server

### DIFF
--- a/client/connector.go
+++ b/client/connector.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"crypto/tls"
 	"net"
+	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -27,6 +29,7 @@ import (
 	fmux "github.com/hashicorp/yamux"
 	quic "github.com/quic-go/quic-go"
 	"github.com/samber/lo"
+	"golang.org/x/net/http/httpproxy"
 
 	v1 "github.com/fatedier/frp/pkg/config/v1"
 	"github.com/fatedier/frp/pkg/msg"
@@ -205,7 +208,12 @@ func (c *defaultConnectorImpl) realConnect() (net.Conn, error) {
 		}
 	}
 
-	proxyType, addr, auth, err := libnet.ParseProxyURL(c.cfg.Transport.ProxyURL)
+	serverAddr := net.JoinHostPort(c.cfg.ServerAddr, strconv.Itoa(c.cfg.ServerPort))
+	noProxy := os.Getenv("NO_PROXY")
+	if noProxy == "" {
+		noProxy = os.Getenv("no_proxy")
+	}
+	proxyType, addr, auth, err := libnet.ParseProxyURL(proxyURLForServer(c.cfg.Transport.ProxyURL, serverAddr, noProxy))
 	if err != nil {
 		xl.Errorf("fail to parse proxy url")
 		return nil, err
@@ -244,10 +252,37 @@ func (c *defaultConnectorImpl) realConnect() (net.Conn, error) {
 	)
 	conn, err := libnet.DialContext(
 		c.ctx,
-		net.JoinHostPort(c.cfg.ServerAddr, strconv.Itoa(c.cfg.ServerPort)),
+		serverAddr,
 		dialOptions...,
 	)
 	return conn, err
+}
+
+// proxyURLForServer decides which proxy (if any) frpc should use to reach the
+// server. rawProxyURL is the configured proxy (which may itself default to the
+// http_proxy environment variable). It returns "" when the server should be
+// reached directly because serverAddr is excluded by the no_proxy rules, which
+// also implicitly exempt localhost and loopback addresses. This mirrors how
+// other tools that honor http_proxy behave; previously frpc honored http_proxy
+// but ignored no_proxy.
+func proxyURLForServer(rawProxyURL, serverAddr, noProxy string) string {
+	if rawProxyURL == "" {
+		return ""
+	}
+	// Only the no_proxy matching (including the built-in localhost/loopback
+	// exemptions) is evaluated here; the placeholder proxy values just let
+	// ProxyFunc report whether serverAddr is excluded. The proxy actually used
+	// for dialing is rawProxyURL.
+	cfg := httpproxy.Config{
+		HTTPProxy:  "http://proxy.invalid",
+		HTTPSProxy: "http://proxy.invalid",
+		NoProxy:    noProxy,
+	}
+	used, err := cfg.ProxyFunc()(&url.URL{Scheme: "http", Host: serverAddr})
+	if err == nil && used == nil {
+		return ""
+	}
+	return rawProxyURL
 }
 
 func (c *defaultConnectorImpl) Close() error {

--- a/client/connector_test.go
+++ b/client/connector_test.go
@@ -1,0 +1,48 @@
+// Copyright 2024 The frp Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import "testing"
+
+func TestProxyURLForServer(t *testing.T) {
+	const proxy = "http://proxy.example.com:8080"
+
+	tests := []struct {
+		name     string
+		proxyURL string
+		server   string
+		noProxy  string
+		want     string
+	}{
+		{name: "no proxy configured", proxyURL: "", server: "1.2.3.4:7000", noProxy: "example.com", want: ""},
+		{name: "proxied by default", proxyURL: proxy, server: "1.2.3.4:7000", noProxy: "", want: proxy},
+		{name: "loopback always bypassed", proxyURL: proxy, server: "127.0.0.1:7000", noProxy: "", want: ""},
+		{name: "localhost always bypassed", proxyURL: proxy, server: "localhost:7000", noProxy: "", want: ""},
+		{name: "ip in no_proxy", proxyURL: proxy, server: "10.0.0.5:7000", noProxy: "10.0.0.5", want: ""},
+		{name: "ip not in no_proxy", proxyURL: proxy, server: "10.0.0.5:7000", noProxy: "10.0.0.6", want: proxy},
+		{name: "cidr in no_proxy", proxyURL: proxy, server: "10.0.0.5:7000", noProxy: "10.0.0.0/24", want: ""},
+		{name: "domain in no_proxy", proxyURL: proxy, server: "frps.example.com:7000", noProxy: "example.com", want: ""},
+		{name: "domain not in no_proxy", proxyURL: proxy, server: "frps.example.com:7000", noProxy: "other.com", want: proxy},
+		{name: "wildcard no_proxy", proxyURL: proxy, server: "frps.example.com:7000", noProxy: "*", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := proxyURLForServer(tt.proxyURL, tt.server, tt.noProxy); got != tt.want {
+				t.Fatalf("proxyURLForServer(%q, %q, %q) = %q, want %q",
+					tt.proxyURL, tt.server, tt.noProxy, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

frpc reads the `http_proxy` environment variable to decide whether to dial frps through a proxy (`pkg/config/v1/client.go`: `ProxyURL = EmptyOr(ProxyURL, os.Getenv("http_proxy"))`), but it never consulted `no_proxy`. So a server that should be reached directly — `localhost`/loopback, or a host explicitly listed in `no_proxy` — was still routed through the proxy, which usually fails.

This evaluates the `no_proxy` rules against the server address before applying the proxy. When the address is excluded, frpc connects directly.

- Uses `golang.org/x/net/http/httpproxy` (already an existing dependency) for the matching, so domains, suffixes, CIDRs and the `*` wildcard all behave like every other tool that honors `http_proxy`/`no_proxy`.
- `httpproxy` also implicitly exempts `localhost` and loopback addresses, so connecting to a loopback frps no longer goes through the proxy even when `no_proxy` doesn't list it.

## Why

Closes #4964. It is also surprising in general: honoring `http_proxy` while ignoring `no_proxy` breaks the de-facto convention shared by curl, the Go standard library, etc.

## Behavior change

Only affects setups where `http_proxy`/`transport.proxyURL` is set. For an excluded destination the connection is now direct instead of proxied. Setups without a proxy configured are unaffected.

## Test

- Added a unit test (`client/connector_test.go`) covering: no proxy configured, default proxying, localhost/loopback exemption, and `no_proxy` matching by IP, CIDR, domain and `*`.
- Manually verified end-to-end: with `http_proxy=http://proxy:8080` and `no_proxy=127.0.0.1` set, a stock frpc connecting to a loopback frps fails (the control connection is sent to the proxy), while the patched frpc connects and tunnels successfully.

```
$ go test ./client/ -run TestProxyURLForServer
ok      github.com/fatedier/frp/client
```

`golangci-lint` is clean.