### PR TITLE
fix(client): reject duplicate proxy and visitor names

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -394,6 +394,10 @@ func LoadClientConfigResult(path string, strict bool) (*ClientConfigLoadResult, 
 		}
 	}
 
+	if err := validateNoDuplicateNames(result.Proxies, result.Visitors); err != nil {
+		return nil, err
+	}
+
 	return result, nil
 }
 
@@ -415,6 +419,31 @@ func LoadClientConfig(path string, strict bool) (
 	proxyCfgs = CompleteProxyConfigurers(proxyCfgs)
 	visitorCfgs = CompleteVisitorConfigurers(visitorCfgs)
 	return result.Common, proxyCfgs, visitorCfgs, result.IsLegacyFormat, nil
+}
+
+// validateNoDuplicateNames rejects proxies or visitors that share a name. They are
+// keyed by name in the config sources, so a duplicate would otherwise be silently
+// overwritten and never started, with no error or log.
+func validateNoDuplicateNames(proxies []v1.ProxyConfigurer, visitors []v1.VisitorConfigurer) error {
+	proxyNames := make(map[string]struct{}, len(proxies))
+	for _, p := range proxies {
+		name := p.GetBaseConfig().Name
+		if _, ok := proxyNames[name]; ok {
+			return fmt.Errorf("proxy name [%s] is duplicated", name)
+		}
+		proxyNames[name] = struct{}{}
+	}
+
+	visitorNames := make(map[string]struct{}, len(visitors))
+	for _, v := range visitors {
+		name := v.GetBaseConfig().Name
+		if _, ok := visitorNames[name]; ok {
+			return fmt.Errorf("visitor name [%s] is duplicated", name)
+		}
+		visitorNames[name] = struct{}{}
+	}
+
+	return nil
 }
 
 func CompleteProxyConfigurers(proxies []v1.ProxyConfigurer) []v1.ProxyConfigurer {

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -17,6 +17,8 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -460,6 +462,111 @@ func TestFilterClientConfigurers_FilterByStartAndEnabled(t *testing.T) {
 	require.Len(visitors, 0)
 	require.Len(proxies, 1)
 	require.Equal("keep", proxies[0].GetBaseConfig().Name)
+}
+
+func TestLoadClientConfigResult_DuplicateNames(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		errSubstr string
+	}{
+		{
+			name: "duplicate proxy names",
+			content: `
+serverAddr = "127.0.0.1"
+serverPort = 7000
+
+[[proxies]]
+name = "dup"
+type = "tcp"
+localPort = 22
+remotePort = 6000
+
+[[proxies]]
+name = "dup"
+type = "tcp"
+localPort = 3306
+remotePort = 6001
+`,
+			errSubstr: "proxy name [dup] is duplicated",
+		},
+		{
+			name: "duplicate visitor names",
+			content: `
+serverAddr = "127.0.0.1"
+serverPort = 7000
+
+[[visitors]]
+name = "dup"
+type = "stcp"
+serverName = "a"
+secretKey = "secret"
+bindPort = 9001
+
+[[visitors]]
+name = "dup"
+type = "stcp"
+serverName = "b"
+secretKey = "secret"
+bindPort = 9002
+`,
+			errSubstr: "visitor name [dup] is duplicated",
+		},
+		{
+			name: "unique names",
+			content: `
+serverAddr = "127.0.0.1"
+serverPort = 7000
+
+[[proxies]]
+name = "p1"
+type = "tcp"
+localPort = 22
+remotePort = 6000
+
+[[proxies]]
+name = "p2"
+type = "tcp"
+localPort = 3306
+remotePort = 6001
+`,
+		},
+		{
+			name: "same name across proxy and visitor",
+			content: `
+serverAddr = "127.0.0.1"
+serverPort = 7000
+
+[[proxies]]
+name = "same"
+type = "tcp"
+localPort = 22
+remotePort = 6000
+
+[[visitors]]
+name = "same"
+type = "stcp"
+serverName = "a"
+secretKey = "secret"
+bindPort = 9001
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			path := filepath.Join(t.TempDir(), "frpc.toml")
+			require.NoError(os.WriteFile(path, []byte(tc.content), 0o600))
+
+			_, err := LoadClientConfigResult(path, false)
+			if tc.errSubstr == "" {
+				require.NoError(err)
+			} else {
+				require.ErrorContains(err, tc.errSubstr)
+			}
+		})
+	}
 }
 
 // TestYAMLEdgeCases tests edge cases for YAML parsing, including non-map types


### PR DESCRIPTION
## Problem

When a frpc config declares two proxies (or two visitors) with the same `name`, only
one of them is ever started. Proxies and visitors are stored in name-keyed maps in the
config sources (`ConfigSource.ReplaceAll`, `Aggregator.Load`), so a duplicate name
overwrites the earlier entry — last one wins. The dropped entry is discarded
**silently: no error, and no log even at trace level**, so the proxy/visitor simply
never comes up and nothing explains why.

This is the root cause behind reports like #5361 (two `[[visitors]]`, only the last one
gets a local listening port). It is also easy to hit when splitting a config across
`includeConfigFiles` and reusing a name by accident.

For comparison, the dynamic config store already rejects duplicate names
(`ErrAlreadyExists`) and frps rejects duplicate proxy names at registration — only the
static client config silently allowed them.

## Fix

Detect duplicate proxy/visitor names when loading the client config in
`LoadClientConfigResult` — the single path shared by startup, `frpc verify`, and config
reload — and fail with a clear error instead of dropping entries silently:

```
proxy name [dup] is duplicated
visitor name [dup] is duplicated
```

Proxies and visitors are separate namespaces, so a proxy and a visitor may still share
a name. Inline `[[proxies]]`/`[[visitors]]` and `includeConfigFiles` are checked together.

## Testing

- Added `TestLoadClientConfigResult_DuplicateNames` covering duplicate proxies,
  duplicate visitors, unique names, and a proxy and visitor sharing a name.
- Before this change, `frpc verify` reports `syntax is ok` for a config with two
  same-named proxies/visitors and frpc starts with only one of them; with the fix, both
  `frpc verify` and `frpc` fail with the error above.
- `make test`, full `make e2e` (239 passed / 0 failed), and `golangci-lint run` pass.

Fixes #5361