### PR TITLE
docs: add release note for PR #5378

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -7,3 +7,4 @@
 
 * WebSocket and WSS tunnel payloads are now sent as binary frames, avoiding disconnects through RFC-compliant intermediaries that validate text frames as UTF-8.
 * The `tls2raw` client plugin now writes the proxy protocol header to the local raw connection when proxy protocol is enabled.
+* frpc now rejects duplicate proxy and visitor names in config files instead of silently overwriting earlier entries.


### PR DESCRIPTION
## Summary
- Add a Fixes release note for PR #5378.
- Note that frpc now rejects duplicate proxy and visitor names instead of silently overwriting earlier config entries.

## Validation
- git diff --check