### PR TITLE
feat(build): add size-optimized (slim) build targets to Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,18 @@ NOWEB_TAG = $(shell [ ! -d web/frps/dist ] || [ ! -d web/frpc/dist ] && echo ',n
 FRP_COMPAT_BASELINE_COUNT ?= 8
 FRP_COMPAT_FLOOR_VERSION ?= 0.61.0
 
-.PHONY: web frps-web frpc-web frps frpc e2e-compatibility-smoke e2e-compatibility e2e-compatibility-floor
+# Size-optimized build flags (noweb + stripped + no buildid)
+SLIM_LDFLAGS := -s -w -buildid=
+SLIM_TAGS_FRPC := frpc,noweb
+SLIM_TAGS_FRPS := frps,noweb
+OUT_BIN_FRPC ?= bin/frpc_slim
+OUT_BIN_FRPS ?= bin/frps_slim
+
+# UPX_COMPRESS=1 (default) compresses the slim binaries with UPX if installed.
+# Set UPX_COMPRESS=0 to skip compression.
+UPX_COMPRESS ?= 1
+
+.PHONY: web frps-web frpc-web frps frpc e2e-compatibility-smoke e2e-compatibility e2e-compatibility-floor frpc-mt7621 frps-mt7621 frpc-slim frps-slim
 
 all: env fmt web build
 
@@ -39,6 +50,42 @@ frps:
 
 frpc:
 	env CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -tags "frpc$(NOWEB_TAG)" -o bin/frpc ./cmd/frpc
+
+# Slim builds (stripped, without web admin, optionally UPX-compressed)
+frpc-slim:
+	env CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags "$(SLIM_LDFLAGS)" \
+		-tags "$(SLIM_TAGS_FRPC)" -o $(OUT_BIN_FRPC) ./cmd/frpc
+	@if [ "$(UPX_COMPRESS)" = "1" ]; then \
+		if command -v upx >/dev/null 2>&1; then \
+			echo "Compressing $(OUT_BIN_FRPC) with UPX..."; \
+			upx --ultra-brute --lzma $(OUT_BIN_FRPC); \
+		else \
+			echo "WARN: upx not found in PATH, skipping compression."; \
+		fi; \
+	fi
+	@ls -lh $(OUT_BIN_FRPC)
+
+frps-slim:
+	env CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags "$(SLIM_LDFLAGS)" \
+		-tags "$(SLIM_TAGS_FRPS)" -o $(OUT_BIN_FRPS) ./cmd/frps
+	@if [ "$(UPX_COMPRESS)" = "1" ]; then \
+		if command -v upx >/dev/null 2>&1; then \
+			echo "Compressing $(OUT_BIN_FRPS) with UPX..."; \
+			upx --ultra-brute --lzma $(OUT_BIN_FRPS); \
+		else \
+			echo "WARN: upx not found in PATH, skipping compression."; \
+		fi; \
+	fi
+	@ls -lh $(OUT_BIN_FRPS)
+
+# MT7621 router build (MIPS little-endian, softfloat) — minimal size.
+# OpenWrt on MT7621 uses softfloat ABI, so this is the safe default.
+# Set UPX_COMPRESS=0 to skip UPX compression.
+frpc-mt7621:
+	env GOOS=linux GOARCH=mipsle GOMIPS=softfloat $(MAKE) frpc-slim OUT_BIN_FRPC=bin/frpc_mt7621
+
+frps-mt7621:
+	env GOOS=linux GOARCH=mipsle GOMIPS=softfloat $(MAKE) frps-slim OUT_BIN_FRPS=bin/frps_mt7621
 
 test: gotest
 


### PR DESCRIPTION
### 1. Background

FRP is commonly used on embedded and router devices such as MT7621 systems running OpenWrt. However, the official MIPS release binaries (`linux_mipsle` and `linux_mips` soft-float builds) include the Web UI dashboard, debug information, and are distributed uncompressed.

As a result, both `frpc` and `frps` are approximately 16 MB in size, which can be problematic for devices with limited flash storage. For example, some MT7621 routers provide only 8 MB of flash.

### 2. Changes in this PR

This PR adds optional size-optimized build targets to the main Makefile:

* `frpc-slim` and `frps-slim`

  * build binaries without the Web UI (`noweb` tag)
  * strip symbols and remove the build ID
  * optionally compress the resulting binary with UPX if it is available

* `frpc-mt7621` and `frps-mt7621`

  * convenience targets for MT7621/OpenWrt devices
  * use `GOOS=linux`, `GOARCH=mipsle`, and `GOMIPS=softfloat`

With these optimizations, the `frpc` binary size decreases from roughly 16 MB to approximately 5–6 MB without UPX, and to around 2 MB with UPX compression.

### 3. Maintainer Feedback

The new targets are optional and do not affect existing build workflows.

There are several possible directions:

1. Keep these targets as optional Makefile targets.
2. Use the slim configuration for official MIPS/MIPSLE release builds.
3. Produce separate `_slim` release artifacts in the GitHub release pipeline.

Feedback on the preferred approach is welcome.

### How to test

```sh
make frpc-slim
make frpc-mt7621
```
