### PR TITLE
feat(client): add transport.websocketPath option for custom websocket handshake path

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -1,5 +1,6 @@
 ## Features
 
+* frpc now supports `transport.websocketPath` to customize the HTTP path used for the websocket/wss handshake (default `/~!frp`), making it easier to place frps behind a reverse proxy that routes a specific path.
 * Added dashboard API v2 pagination endpoints for users, clients, and proxies.
 * The frps dashboard Clients and Proxies pages now use API v2 pagination and server-side search, including proxy type filtering and searchable proxy spec fields such as remote ports, custom domains, and subdomains.
 

--- a/client/connector.go
+++ b/client/connector.go
@@ -215,7 +215,7 @@ func (c *defaultConnectorImpl) realConnect() (net.Conn, error) {
 	switch protocol {
 	case "websocket":
 		protocol = "tcp"
-		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{Hook: netpkg.DialHookWebsocket(protocol, "")}))
+		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{Hook: netpkg.DialHookWebsocket(protocol, "", c.cfg.Transport.WebsocketPath)}))
 		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{
 			Hook: netpkg.DialHookCustomTLSHeadByte(tlsConfig != nil, lo.FromPtr(c.cfg.Transport.TLS.DisableCustomTLSFirstByte)),
 		}))
@@ -224,7 +224,7 @@ func (c *defaultConnectorImpl) realConnect() (net.Conn, error) {
 		protocol = "tcp"
 		dialOptions = append(dialOptions, libnet.WithTLSConfigAndPriority(100, tlsConfig))
 		// Make sure that if it is wss, the websocket hook is executed after the tls hook.
-		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{Hook: netpkg.DialHookWebsocket(protocol, tlsConfig.ServerName), Priority: 110}))
+		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{Hook: netpkg.DialHookWebsocket(protocol, tlsConfig.ServerName, c.cfg.Transport.WebsocketPath), Priority: 110}))
 	default:
 		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{
 			Hook: netpkg.DialHookCustomTLSHeadByte(tlsConfig != nil, lo.FromPtr(c.cfg.Transport.TLS.DisableCustomTLSFirstByte)),

--- a/conf/frpc_full_example.toml
+++ b/conf/frpc_full_example.toml
@@ -103,6 +103,12 @@ transport.poolCount = 5
 # supports tcp, kcp, quic, websocket and wss now, default is tcp
 transport.protocol = "tcp"
 
+# HTTP path used for the websocket handshake, only works when protocol is websocket or wss.
+# Must start with "/", default is "/~!frp". Useful when frps is behind a reverse proxy
+# (e.g. nginx) that routes a specific path to frps; the reverse proxy is responsible for
+# forwarding this path to frps' default "/~!frp" path.
+# transport.websocketPath = "/frp"
+
 # FRP wire protocol used inside the selected transport.
 # supports v1 and v2, default is v1. v2 requires frps support and must be enabled explicitly.
 # transport.wireProtocol = "v1"

--- a/conf/legacy/frpc_legacy_full.ini
+++ b/conf/legacy/frpc_legacy_full.ini
@@ -98,6 +98,12 @@ login_fail_exit = true
 # supports tcp, kcp, quic, websocket and wss now, default is tcp
 protocol = tcp
 
+# http path used for the websocket handshake, only works when protocol is websocket or wss.
+# must start with "/", default is "/~!frp". useful when frps is behind a reverse proxy
+# (e.g. nginx) that routes a specific path to frps; the reverse proxy is responsible for
+# forwarding this path to frps' default "/~!frp" path.
+# websocket_path = /frp
+
 # set client binding ip when connect server, default is empty.
 # only when protocol = tcp or websocket, the value will be used.
 connect_server_local_ip = 0.0.0.0

--- a/pkg/config/legacy/client.go
+++ b/pkg/config/legacy/client.go
@@ -122,6 +122,11 @@ type ClientCommonConf struct {
 	// Valid values are "tcp", "kcp", "quic", "websocket" and "wss". By default, this value
 	// is "tcp".
 	Protocol string `ini:"protocol" json:"protocol"`
+	// WebsocketPath specifies the HTTP path used for the websocket handshake when
+	// protocol is "websocket" or "wss". It must start with "/". Useful when frps is
+	// placed behind a reverse proxy that routes a specific path to frps. If this value
+	// is "", the default path "/~!frp" is used.
+	WebsocketPath string `ini:"websocket_path" json:"websocket_path"`
 	// QUIC protocol options
 	QUICKeepalivePeriod    int `ini:"quic_keepalive_period" json:"quic_keepalive_period"`
 	QUICMaxIdleTimeout     int `ini:"quic_max_idle_timeout" json:"quic_max_idle_timeout"`
@@ -382,6 +387,10 @@ func (cfg *ClientCommonConf) Validate() error {
 
 	if !slices.Contains([]string{"tcp", "kcp", "quic", "websocket", "wss"}, cfg.Protocol) {
 		return fmt.Errorf("invalid protocol")
+	}
+
+	if cfg.WebsocketPath != "" && !strings.HasPrefix(cfg.WebsocketPath, "/") {
+		return fmt.Errorf("invalid websocket_path, it must start with \"/\"")
 	}
 
 	for _, f := range cfg.IncludeConfigFiles {

--- a/pkg/config/legacy/conversion.go
+++ b/pkg/config/legacy/conversion.go
@@ -52,6 +52,7 @@ func Convert_ClientCommonConf_To_v1(conf *ClientCommonConf) *v1.ClientCommonConf
 	out.Transport.TCPMux = lo.ToPtr(conf.TCPMux)
 	out.Transport.TCPMuxKeepaliveInterval = conf.TCPMuxKeepaliveInterval
 	out.Transport.Protocol = conf.Protocol
+	out.Transport.WebsocketPath = conf.WebsocketPath
 	out.Transport.HeartbeatInterval = conf.HeartbeatInterval
 	out.Transport.HeartbeatTimeout = conf.HeartbeatTimeout
 	out.Transport.QUIC.KeepalivePeriod = conf.QUICKeepalivePeriod

--- a/pkg/config/v1/client.go
+++ b/pkg/config/v1/client.go
@@ -104,6 +104,12 @@ type ClientTransportConfig struct {
 	// Valid values are "tcp", "kcp", "quic", "websocket" and "wss". By default, this value
 	// is "tcp".
 	Protocol string `json:"protocol,omitempty"`
+	// WebsocketPath specifies the HTTP path used for the websocket handshake when
+	// Protocol is "websocket" or "wss". It must start with "/". This is useful when
+	// frps is placed behind a reverse proxy (e.g. nginx) that routes a specific path
+	// to frps. If this value is "", the default path "/~!frp" is used. The reverse
+	// proxy is responsible for forwarding this path to frps' default "/~!frp" path.
+	WebsocketPath string `json:"websocketPath,omitempty"`
 	// WireProtocol specifies the frpc/frps internal wire protocol version.
 	// Valid values are "v1" and "v2". By default, this value is "v1".
 	WireProtocol string `json:"wireProtocol,omitempty"`

--- a/pkg/config/v1/validation/client.go
+++ b/pkg/config/v1/validation/client.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/samber/lo"
 
@@ -133,6 +134,9 @@ func validateTransportConfig(c *v1.ClientTransportConfig) (Warning, error) {
 	}
 	if !slices.Contains(SupportedWireProtocols, c.WireProtocol) {
 		errs = AppendError(errs, fmt.Errorf("invalid transport.wireProtocol, optional values are %v", SupportedWireProtocols))
+	}
+	if c.WebsocketPath != "" && !strings.HasPrefix(c.WebsocketPath, "/") {
+		errs = AppendError(errs, fmt.Errorf("invalid transport.websocketPath, it must start with \"/\""))
 	}
 	return warnings, errs
 }

--- a/pkg/util/net/dial.go
+++ b/pkg/util/net/dial.go
@@ -21,7 +21,7 @@ func DialHookCustomTLSHeadByte(enableTLS bool, disableCustomTLSHeadByte bool) li
 	}
 }
 
-func DialHookWebsocket(protocol string, host string) libnet.AfterHookFunc {
+func DialHookWebsocket(protocol string, host string, path string) libnet.AfterHookFunc {
 	return func(ctx context.Context, c net.Conn, addr string) (context.Context, net.Conn, error) {
 		if protocol != "wss" {
 			protocol = "ws"
@@ -29,7 +29,10 @@ func DialHookWebsocket(protocol string, host string) libnet.AfterHookFunc {
 		if host == "" {
 			host = addr
 		}
-		addr = protocol + "://" + host + FrpWebsocketPath
+		if path == "" {
+			path = FrpWebsocketPath
+		}
+		addr = protocol + "://" + host + path
 		uri, err := url.Parse(addr)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
### WHY

Closes #5388

When `transport.protocol` is `websocket` or `wss`, frpc always performs the websocket handshake on a hard-coded path `/~!frp` (`pkg/util/net/websocket.go`), with no way to configure it. This makes it hard to place frps behind a reverse proxy (e.g. nginx) that routes traffic by path — for example sharing port 443 with other services, or running multiple frps instances behind a single entrypoint.

This PR adds a client-side `transport.websocketPath` option:

- Defaults to `/~!frp` when empty — **fully backward compatible**, existing configs are unaffected.
- When set (must start with `/`), the client uses it for the websocket/wss handshake.
- The **server needs no changes**: the reverse proxy is responsible for forwarding the custom path back to frps' default `/~!frp`.

Example:

```toml
transport.protocol = "wss"
transport.websocketPath = "/frp"
```

nginx then matches `location /frp`, rewrites it to `/~!frp`, and proxies to frps.

### Changes

- Add `WebsocketPath` to the v1 `ClientTransportConfig` and the legacy client config (with legacy→v1 conversion).
- Thread the path through `DialHookWebsocket`, defaulting to `/~!frp` when empty (consistent with the existing empty-parameter defaulting in that function).
- Validate that the path starts with `/` (both v1 and legacy validation).
- Update `frpc_full_example.toml`, the legacy ini example, and `Release.md`.

The change is client-side only; `go build` / `go vet` and `pkg/config/...` tests pass.
