### PR TITLE
docs: add MoonProxy (GUI desktop client for frpc) to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1348,6 +1348,7 @@ Features typically go through three stages:
 
 * [gofrp/plugin](https://github.com/gofrp/plugin) - A repository for frp plugins that contains a variety of plugins implemented based on the frp extension mechanism, meeting the customization needs of different scenarios.
 * [gofrp/tiny-frpc](https://github.com/gofrp/tiny-frpc) - A lightweight version of the frp client (around 3.5MB at minimum) implemented using the ssh protocol, supporting some of the most commonly used features, suitable for devices with limited resources.
+* [MoonProxy](https://github.com/MoonProxyHQ/moonproxy-desktop) - A cross-platform GUI desktop client for frpc (Tauri v2 + Vue 3 + Rust), exposing local services through a graphical interface — no command line required. MIT licensed, macOS & Windows.
 
 ## Contributing
 


### PR DESCRIPTION
Adds **MoonProxy** to the **Related Projects** section of the README.

## About

[MoonProxy](https://github.com/MoonProxyHQ/moonproxy-desktop) (月神代理) is a cross-platform **GUI desktop client for frpc**, built with **Tauri v2 + Vue 3 + Rust + TypeScript**. It exposes local TCP/UDP/HTTP/HTTPS services through a graphical interface — no command line, no config files. MIT licensed, for **macOS (Apple Silicon + Intel) and Windows**.

## Why it belongs here

- **Directly related**: it is a desktop GUI client for frpc, exactly the kind of ecosystem project this section is for (alongside gofrp/plugin and gofrp/tiny-frpc).
- **Active & maintained**: regular commits, English README, MIT licensed.
- **Bundles frpc via the Tauri sidecar mechanism** — users do not need to install frp separately.
- **Independence**: MoonProxy is **independent of fatedier/frp** and only acts as a GUI client. It does not modify frpc behavior — just generates config, manages the subprocess lifecycle, and visualizes connection state.

## Links

- Repo: https://github.com/MoonProxyHQ/moonproxy-desktop
- Site: https://moonproxy.app
- License: MIT
- Latest release: https://github.com/MoonProxyHQ/moonproxy-desktop/releases/latest

Happy to make any adjustments if you'd prefer a different wording or position. Thanks for frp — it powers our project.