### PR TITLE
fix: close doneCh for a control replaced before it starts (#5391)

### DIFF
--- a/server/control.go
+++ b/server/control.go
@@ -227,6 +227,9 @@ func (ctl *Control) Replaced(newCtl *Control) {
 	xl := ctl.xl
 	xl.Infof("replaced by client [%s]", newCtl.runID)
 	ctl.runID = ""
+	// Closing a yamux stream only half-closes it and does not wake a blocked local read.
+	// Expire the read first so the control worker can always finish its cleanup.
+	_ = ctl.sessionCtx.Conn.SetReadDeadline(time.Now())
 	ctl.sessionCtx.Conn.Close()
 
 	// If this control was never started, its worker will never run and would

--- a/server/control.go
+++ b/server/control.go
@@ -66,13 +66,17 @@ func (cm *ControlManager) Add(runID string, ctl *Control) (old *Control) {
 	return
 }
 
-// we should make sure if it's the same control to prevent delete a new one
-func (cm *ControlManager) Del(runID string, ctl *Control) {
+// Del removes ctl only if it is still the control registered for runID, to avoid
+// deleting a newer one. It reports whether it actually removed ctl, so callers can
+// tell whether ctl was still the active control for this run id.
+func (cm *ControlManager) Del(runID string, ctl *Control) (deleted bool) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	if c, ok := cm.ctlsByRunID[runID]; ok && c == ctl {
 		delete(cm.ctlsByRunID, runID)
+		return true
 	}
+	return false
 }
 
 func (cm *ControlManager) GetByID(runID string) (ctl *Control, ok bool) {

--- a/server/control.go
+++ b/server/control.go
@@ -149,9 +149,26 @@ type Control struct {
 
 	mu sync.RWMutex
 
+	// started is true once Start has launched the worker goroutine.
+	// replaced is true once this control has been superseded by a newer login.
+	// doneClosed guards doneCh against a double close.
+	started    bool
+	replaced   bool
+	doneClosed bool
+
 	xl     *xlog.Logger
 	ctx    context.Context
 	doneCh chan struct{}
+}
+
+// closeDone closes doneCh exactly once, unblocking WaitClosed.
+func (ctl *Control) closeDone() {
+	ctl.mu.Lock()
+	defer ctl.mu.Unlock()
+	if !ctl.doneClosed {
+		ctl.doneClosed = true
+		close(ctl.doneCh)
+	}
 }
 
 func NewControl(ctx context.Context, sessionCtx *SessionContext) (*Control, error) {
@@ -177,6 +194,17 @@ func NewControl(ctx context.Context, sessionCtx *SessionContext) (*Control, erro
 
 // Start starts the control session workers after login succeeds.
 func (ctl *Control) Start() {
+	ctl.mu.Lock()
+	if ctl.replaced {
+		// This control was already replaced by a newer login before it started.
+		// worker would never observe a live connection, and Replaced has already
+		// closed doneCh, so there is nothing to run.
+		ctl.mu.Unlock()
+		return
+	}
+	ctl.started = true
+	ctl.mu.Unlock()
+
 	go func() {
 		for i := 0; i < ctl.poolCount; i++ {
 			// ignore error here, that means that this control is closed
@@ -196,6 +224,21 @@ func (ctl *Control) Replaced(newCtl *Control) {
 	xl.Infof("replaced by client [%s]", newCtl.runID)
 	ctl.runID = ""
 	ctl.sessionCtx.Conn.Close()
+
+	// If this control was never started, its worker will never run and would
+	// never close doneCh. That happens when its own login handler is still
+	// blocked in RegisterControl waiting on a previous control (e.g. after a
+	// control connection died silently with tcpMux, so the old reader never
+	// unblocks). Close doneCh here so WaitClosed returns and the replacement
+	// chain can unwind, instead of leaking a goroutine plus the whole Control
+	// graph permanently. See #5391.
+	ctl.mu.Lock()
+	ctl.replaced = true
+	notStarted := !ctl.started
+	ctl.mu.Unlock()
+	if notStarted {
+		ctl.closeDone()
+	}
 }
 
 func (ctl *Control) RegisterWorkConn(conn *proxy.WorkConn) error {
@@ -334,7 +377,7 @@ func (ctl *Control) worker() {
 	metrics.Server.CloseClient()
 	ctl.sessionCtx.ClientRegistry.MarkOfflineByRunID(ctl.runID)
 	xl.Infof("client exit success")
-	close(ctl.doneCh)
+	ctl.closeDone()
 }
 
 func (ctl *Control) registerMsgHandlers() {

--- a/server/control_test.go
+++ b/server/control_test.go
@@ -15,12 +15,19 @@
 package server
 
 import (
+	"context"
 	"net"
+	"os"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/fatedier/frp/pkg/config/v1"
 	"github.com/fatedier/frp/pkg/msg"
 	"github.com/fatedier/frp/pkg/util/xlog"
+	"github.com/fatedier/frp/server/registry"
 )
 
 // newTestControl builds a minimal Control sufficient for lifecycle tests.
@@ -100,3 +107,82 @@ func TestControlManagerDelOnlyRemovesActiveControl(t *testing.T) {
 		t.Fatal("Del did not remove the active control")
 	}
 }
+
+func TestControlReplacedInterruptsBlockedRead(t *testing.T) {
+	conn := newDeadlineReadConn()
+	msgConn := msg.NewConn(conn, msg.NewV1ReadWriter(conn))
+	ctl, err := NewControl(context.Background(), &SessionContext{
+		Conn:           msgConn,
+		LoginMsg:       &msg.Login{RunID: "old"},
+		ServerCfg:      &v1.ServerConfig{},
+		ClientRegistry: registry.NewClientRegistry(),
+	})
+	require.NoError(t, err)
+
+	ctl.Start()
+	select {
+	case <-conn.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for control reader to start")
+	}
+
+	ctl.Replaced(&Control{runID: "new"})
+
+	select {
+	case <-ctl.doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("replaced control did not stop after its stream was closed")
+	}
+	require.True(t, conn.readDeadlineSet())
+}
+
+type deadlineReadConn struct {
+	readStarted  chan struct{}
+	deadlineCh   chan struct{}
+	readOnce     sync.Once
+	deadlineOnce sync.Once
+}
+
+func newDeadlineReadConn() *deadlineReadConn {
+	return &deadlineReadConn{
+		readStarted: make(chan struct{}),
+		deadlineCh:  make(chan struct{}),
+	}
+}
+
+func (c *deadlineReadConn) Read([]byte) (int, error) {
+	c.readOnce.Do(func() { close(c.readStarted) })
+	<-c.deadlineCh
+	return 0, os.ErrDeadlineExceeded
+}
+
+func (*deadlineReadConn) Write(p []byte) (int, error) { return len(p), nil }
+func (*deadlineReadConn) Close() error                { return nil }
+func (*deadlineReadConn) LocalAddr() net.Addr         { return testAddr("local") }
+func (*deadlineReadConn) RemoteAddr() net.Addr        { return testAddr("remote") }
+func (c *deadlineReadConn) SetDeadline(t time.Time) error {
+	if err := c.SetReadDeadline(t); err != nil {
+		return err
+	}
+	return c.SetWriteDeadline(t)
+}
+func (c *deadlineReadConn) SetReadDeadline(t time.Time) error {
+	if !t.IsZero() {
+		c.deadlineOnce.Do(func() { close(c.deadlineCh) })
+	}
+	return nil
+}
+func (*deadlineReadConn) SetWriteDeadline(time.Time) error { return nil }
+func (c *deadlineReadConn) readDeadlineSet() bool {
+	select {
+	case <-c.deadlineCh:
+		return true
+	default:
+		return false
+	}
+}
+
+type testAddr string
+
+func (a testAddr) Network() string { return string(a) }
+func (a testAddr) String() string  { return string(a) }

--- a/server/control_test.go
+++ b/server/control_test.go
@@ -78,3 +78,25 @@ func TestControlReplacedAfterStartLeavesDoneToWorker(t *testing.T) {
 		// expected: doneCh remains open, worker will close it
 	}
 }
+
+// Del must only remove (and report removal of) the control still registered for a
+// run id. A superseded control's late-running login handler relies on this to avoid
+// offlining the run id now owned by its replacement.
+func TestControlManagerDelOnlyRemovesActiveControl(t *testing.T) {
+	cm := NewControlManager()
+	ctlOld := newTestControl(t)
+	ctlNew := newTestControl(t)
+
+	cm.Add("R", ctlOld)
+	cm.Add("R", ctlNew) // replaces ctlOld; ctlNew is now the registered control
+
+	if cm.Del("R", ctlOld) {
+		t.Fatal("Del reported removal for a superseded control")
+	}
+	if got, ok := cm.GetByID("R"); !ok || got != ctlNew {
+		t.Fatal("stale Del affected the active control")
+	}
+	if !cm.Del("R", ctlNew) {
+		t.Fatal("Del did not remove the active control")
+	}
+}

--- a/server/control_test.go
+++ b/server/control_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The frp Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/fatedier/frp/pkg/msg"
+	"github.com/fatedier/frp/pkg/util/xlog"
+)
+
+// newTestControl builds a minimal Control sufficient for lifecycle tests.
+func newTestControl(t *testing.T) *Control {
+	t.Helper()
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() {
+		serverConn.Close()
+		clientConn.Close()
+	})
+	return &Control{
+		sessionCtx: &SessionContext{Conn: msg.NewConn(serverConn, nil)},
+		runID:      "runid",
+		xl:         xlog.New(),
+		doneCh:     make(chan struct{}),
+	}
+}
+
+// A control that is replaced before it is ever started must still have its
+// doneCh closed, so that WaitClosed - called from the re-login path in
+// RegisterControl - returns instead of blocking forever. Without this, a
+// control whose connection died silently (tcpMux) wedges a goroutine plus the
+// whole Control graph permanently on every re-login. Regression test for #5391.
+func TestControlReplacedBeforeStartUnblocksWaitClosed(t *testing.T) {
+	ctl := newTestControl(t)
+	newCtl := &Control{runID: "newrunid", xl: xlog.New()}
+
+	ctl.Replaced(newCtl)
+
+	done := make(chan struct{})
+	go func() {
+		ctl.WaitClosed()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitClosed blocked after Replaced on a never-started control")
+	}
+}
+
+// Replaced must not close doneCh for a control that is already running: its
+// worker owns that lifecycle and closing it here would double-close / race.
+func TestControlReplacedAfterStartLeavesDoneToWorker(t *testing.T) {
+	ctl := newTestControl(t)
+	ctl.started = true // simulate a started control without launching worker
+	newCtl := &Control{runID: "newrunid", xl: xlog.New()}
+
+	ctl.Replaced(newCtl)
+
+	select {
+	case <-ctl.doneCh:
+		t.Fatal("Replaced closed doneCh for a started control; worker should own it")
+	case <-time.After(100 * time.Millisecond):
+		// expected: doneCh remains open, worker will close it
+	}
+}

--- a/server/service.go
+++ b/server/service.go
@@ -488,8 +488,13 @@ func (svr *Service) handleConnection(ctx context.Context, conn net.Conn, interna
 			})
 		}); err != nil {
 			xl.Warnf("write login response error: %v", err)
-			svr.ctlManager.Del(m.RunID, ctl)
-			svr.clientRegistry.MarkOfflineByRunID(m.RunID)
+			// Only mark the run id offline if this control was still the registered
+			// one. A control that was already replaced (its login handler unblocked
+			// late, e.g. after the doneCh close in Replaced) must not offline the run
+			// id now owned by its replacement.
+			if svr.ctlManager.Del(m.RunID, ctl) {
+				svr.clientRegistry.MarkOfflineByRunID(m.RunID)
+			}
 			conn.Close()
 			return
 		}


### PR DESCRIPTION
### WHY

Fixes #5391.

When a control connection dies silently with `tcpMux` (no FIN/RST reaches frps) and the client re-logins with the same `runID`, frps permanently parks a goroutine in `Control.WaitClosed` and retains the old `Control` graph — the client can never reconnect until frps restarts.

**Root cause** (on `dev`, `7fe152e`). `RegisterControl` blocks in `oldCtl.WaitClosed()` (`server/service.go:788`) via `ControlManager.Add` → `old.Replaced()` (`server/control.go:56-64`, `:194-199`). `WaitClosed` (`control.go:285`) returns only when `doneCh` closes, and `doneCh` is closed **only** in `worker()` (`control.go:337`), which runs **only** from `Start()` (`control.go:186`). `Start()` is called after `RegisterControl` returns (`service.go:496`) — so a control that gets `Replaced()` while its own login handler is still blocked in `RegisterControl` (i.e. it never reached `Start()`) can never have its `doneCh` closed by anything. Each re-login then parks one more goroutine on the previous, never-started control, forever (matches the reporter's pprof: every parked goroutine sits in `WaitClosed` ← `RegisterControl`).

**Fix.** Track whether a control was ever started, and when a never-started control is `Replaced()`, close its `doneCh` there (a never-started control has no worker/dispatcher goroutines, so nothing else will). `Start()` now also skips a control that was already replaced. `doneCh` is closed through a small once-guarded helper to avoid a double close. This lets the replacement chain unwind so re-logins succeed instead of wedging.

**Verification** (built on this branch, `--network none`, using the reporter's `relay.py` that abandons the frps side of each connection):

- New unit test `TestControlReplacedBeforeStartUnblocksWaitClosed` — `WaitClosed` returns after `Replaced` on a never-started control. Fails on `dev` (blocks 2s → timeout), passes with this change. `TestControlReplacedAfterStartLeavesDoneToWorker` guards that a started control's `doneCh` is still owned by `worker`.
- End-to-end, tcpMux on, 4-minute run + 150s after stopping the relay/client:
  - **before:** goroutines parked in `WaitClosed` stay put permanently (still parked 150s after every connection is dead), `client exit success` freezes after the first cleanup, the client stops reconnecting.
  - **after:** parked goroutines drain to 0, cleanup resumes (`exit success` tracks re-logins), the client keeps reconnecting.
- `go test ./server/`, `go vet ./server/`, `gofmt` all clean.

**Scope note.** This fixes the permanent leak (a control replaced before it starts). For a control that *was* started and whose reader is stuck on a silently-dead tcpMux stream, cleanup still relies on yamux keepalive to close the session (~30s), after which its `doneCh` closes normally. If you want that path hardened too, tearing down the mux session in `Replaced()` (or bounding the login-path `WaitClosed()`) would remove that ~30s window — glad to fold it in.
