### PR TITLE
refactor: clean up frps v2 frontend models

### DIFF
--- a/web/frps/src/api/proxy.ts
+++ b/web/frps/src/api/proxy.ts
@@ -49,7 +49,7 @@ export const toLegacyProxyStats = (proxy: ProxyV2Info): ProxyStatsInfo => ({
   curConns: proxy.status.curConns,
   lastStartTime: proxy.status.lastStartTime,
   lastCloseTime: proxy.status.lastCloseTime,
-  status: proxy.status.state || proxy.status.phase || '',
+  status: proxy.status.phase,
 })
 
 export const getProxy = (type: string, name: string) => {

--- a/web/frps/src/types/client.ts
+++ b/web/frps/src/types/client.ts
@@ -7,7 +7,6 @@ export interface ClientInfoData {
   wireProtocol?: string
   hostname: string
   clientIP?: string
-  metas?: Record<string, string>
   firstConnectedAt: number
   lastConnectedAt: number
   disconnectedAt?: number

--- a/web/frps/src/types/proxy.ts
+++ b/web/frps/src/types/proxy.ts
@@ -36,8 +36,7 @@ export interface ProxyV2Info {
 }
 
 export interface ProxyV2Status {
-  state?: string
-  phase?: string
+  phase: 'online' | 'offline'
   todayTrafficIn: number
   todayTrafficOut: number
   curConns: number

--- a/web/frps/src/utils/client.ts
+++ b/web/frps/src/utils/client.ts
@@ -10,7 +10,6 @@ export class Client {
   wireProtocol: string
   hostname: string
   ip: string
-  metas: Map<string, string>
   firstConnectedAt: Date
   lastConnectedAt: Date
   disconnectedAt?: Date
@@ -26,12 +25,6 @@ export class Client {
     this.wireProtocol = data.wireProtocol || ''
     this.hostname = data.hostname
     this.ip = data.clientIP || ''
-    this.metas = new Map<string, string>()
-    if (data.metas) {
-      for (const [key, value] of Object.entries(data.metas)) {
-        this.metas.set(key, value)
-      }
-    }
     this.firstConnectedAt = new Date(data.firstConnectedAt * 1000)
     this.lastConnectedAt = new Date(data.lastConnectedAt * 1000)
     if (data.disconnectedAt && data.disconnectedAt > 0) {
@@ -52,10 +45,6 @@ export class Client {
     return this.runID
   }
 
-  get shortRunId(): string {
-    return this.runID.substring(0, 8)
-  }
-
   get wireProtocolLabel(): string {
     if (!this.wireProtocol) return ''
     return `Protocol ${this.wireProtocol}`
@@ -72,29 +61,5 @@ export class Client {
   get disconnectedAgo(): string {
     if (!this.disconnectedAt) return ''
     return formatDistanceToNow(this.disconnectedAt)
-  }
-
-  get statusColor(): string {
-    return this.online ? 'success' : 'danger'
-  }
-
-  get metasArray(): Array<{ key: string; value: string }> {
-    const arr: Array<{ key: string; value: string }> = []
-    this.metas.forEach((value, key) => {
-      arr.push({ key, value })
-    })
-    return arr
-  }
-
-  matchesFilter(searchText: string): boolean {
-    const search = searchText.toLowerCase()
-    return (
-      this.key.toLowerCase().includes(search) ||
-      this.user.toLowerCase().includes(search) ||
-      this.clientID.toLowerCase().includes(search) ||
-      this.runID.toLowerCase().includes(search) ||
-      this.wireProtocol.toLowerCase().includes(search) ||
-      this.hostname.toLowerCase().includes(search)
-    )
   }
 }


### PR DESCRIPTION
## Summary
- F1 narrows the frps proxy v2 frontend status model to the required `phase` field and maps legacy proxy stats from `phase`.
- F2 removes unsupported/dead client frontend model fields and helpers (`metas`, `metasArray`, filter/status/run-id helpers).
- F3 proxy UI model conversion refactor is intentionally not included.
- Legacy compatibility `/api/...` routes/controllers and frontend legacy helpers are untouched.

## Tests
- `cd web/frps && npm run type-check`
- `git diff --check`
- Residual searches in `web/frps/src` confirmed no `state || phase`, `proxy.status.state`, `metasArray`, `matchesFilter`, `shortRunId`, or `statusColor`.