### PR TITLE
udp proxy: relay packets as unreliable QUIC datagrams (RFC 9221)

### DIFF
--- a/client/connector.go
+++ b/client/connector.go
@@ -130,6 +130,7 @@ func (c *defaultConnectorImpl) Open() error {
 				MaxIdleTimeout:     time.Duration(c.cfg.Transport.QUIC.MaxIdleTimeout) * time.Second,
 				MaxIncomingStreams: int64(c.cfg.Transport.QUIC.MaxIncomingStreams),
 				KeepAlivePeriod:    time.Duration(c.cfg.Transport.QUIC.KeepalivePeriod) * time.Second,
+				EnableDatagrams:    true, // for udp proxies with quicDatagrams (RFC 9221)
 			})
 		if err != nil {
 			return err

--- a/client/proxy/udp.go
+++ b/client/proxy/udp.go
@@ -45,7 +45,9 @@ type UDPProxy struct {
 	// include msg.UDPPacket and msg.Ping
 	sendCh   chan msg.Message
 	workConn net.Conn
-	closed   bool
+	// non-nil while relaying via unreliable QUIC datagrams (RFC 9221)
+	dgMux  *udp.DatagramMux
+	closed bool
 }
 
 func NewUDPProxy(baseProxy *BaseProxy, cfg v1.ProxyConfigurer) Proxy {
@@ -73,6 +75,10 @@ func (pxy *UDPProxy) Close() {
 
 	if !pxy.closed {
 		pxy.closed = true
+		if pxy.dgMux != nil {
+			pxy.dgMux.Unregister(pxy.cfg.Name)
+			pxy.dgMux = nil
+		}
 		if pxy.workConn != nil {
 			pxy.workConn.Close()
 		}
@@ -85,11 +91,23 @@ func (pxy *UDPProxy) Close() {
 	}
 }
 
-func (pxy *UDPProxy) InWorkConn(conn net.Conn, _ *msg.StartWorkConn) {
+func (pxy *UDPProxy) InWorkConn(conn net.Conn, startMsg *msg.StartWorkConn) {
 	xl := pxy.xl
 	xl.Infof("incoming a new work connection for udp proxy, %s", conn.RemoteAddr().String())
 	// close resources related with old workConn
 	pxy.Close()
+
+	// QUIC datagram lane, confirmed by the server for this work connection
+	var dgMux *udp.DatagramMux
+	if startMsg != nil && startMsg.UDPDatagram &&
+		!pxy.cfg.Transport.UseEncryption && !pxy.cfg.Transport.UseCompression {
+		if qc, ok := netpkg.QuicConnFrom(conn); ok && qc.ConnectionState().SupportsDatagrams {
+			dgMux = udp.DatagramMuxFor(qc)
+			xl.Infof("udp proxy relaying via quic datagrams")
+		} else {
+			xl.Warnf("server enabled quic datagrams but work connection does not support them, using stream")
+		}
+	}
 
 	remote, _, err := pxy.wrapWorkConn(conn, pxy.encryptionKey)
 	if err != nil {
@@ -101,10 +119,24 @@ func (pxy *UDPProxy) InWorkConn(conn net.Conn, _ *msg.StartWorkConn) {
 	pxy.workConn = netpkg.WrapReadWriteCloserToConn(remote, conn)
 	// Plain UDP payload follows the configured wire protocol for message framing.
 	payloadRW := msg.NewReadWriter(pxy.workConn, pxy.clientCfg.Transport.WireProtocol)
+	pxy.dgMux = dgMux
 	pxy.readCh = make(chan *msg.UDPPacket, 1024)
 	pxy.sendCh = make(chan msg.Message, 1024)
 	pxy.closed = false
+	readCh := pxy.readCh
 	pxy.mu.Unlock()
+
+	if dgMux != nil {
+		dgMux.Register(pxy.cfg.Name, func(remoteAddr *net.UDPAddr, payload []byte) {
+			m := udp.NewUDPPacket(payload, nil, remoteAddr)
+			_ = errors.PanicToError(func() {
+				select {
+				case readCh <- m:
+				default:
+				}
+			})
+		})
+	}
 
 	workConnReaderFn := func(rw msg.ReadWriter, readCh chan *msg.UDPPacket) {
 		for {
@@ -131,6 +163,19 @@ func (pxy *UDPProxy) InWorkConn(conn net.Conn, _ *msg.StartWorkConn) {
 			switch m := rawMsg.(type) {
 			case *msg.UDPPacket:
 				xl.Tracef("send udp package to workConn, len: %d", len(m.Content))
+				// prefer the unreliable QUIC datagram lane; oversized
+				// packets fall back to the stream
+				if dgMux != nil {
+					switch dgErr := dgMux.Send(pxy.cfg.Name, m.RemoteAddr, m.Content); dgErr {
+					case nil:
+						continue
+					case udp.ErrDatagramTooLarge:
+						// fall through to stream write
+					default:
+						xl.Errorf("udp datagram write error: %v", dgErr)
+						return
+					}
+				}
 			case *msg.Ping:
 				xl.Tracef("send ping message to udp workConn")
 			}

--- a/client/proxy/udp.go
+++ b/client/proxy/udp.go
@@ -17,6 +17,7 @@
 package proxy
 
 import (
+	"context"
 	"net"
 	"reflect"
 	"strconv"
@@ -128,6 +129,12 @@ func (pxy *UDPProxy) InWorkConn(conn net.Conn, startMsg *msg.StartWorkConn) {
 
 	if dgMux != nil {
 		dgMux.Register(pxy.cfg.Name, func(remoteAddr *net.UDPAddr, payload []byte) {
+			// The bandwidth limiter can only police (drop) here, not shape:
+			// this callback runs on the quic connection's shared receive
+			// loop, which must never block.
+			if pxy.limiter != nil && !pxy.limiter.AllowN(time.Now(), len(payload)) {
+				return
+			}
 			m := udp.NewUDPPacket(payload, nil, remoteAddr)
 			_ = errors.PanicToError(func() {
 				select {
@@ -168,6 +175,14 @@ func (pxy *UDPProxy) InWorkConn(conn net.Conn, startMsg *msg.StartWorkConn) {
 				if dgMux != nil {
 					switch dgErr := dgMux.Send(pxy.cfg.Name, m.RemoteAddr, m.Content); dgErr {
 					case nil:
+						// Datagrams bypass the limiter-wrapped work
+						// connection, so account for them here: charging
+						// after the send (like limit.Reader does) delays
+						// subsequent packets to hold the configured rate,
+						// and never double-charges the stream fallback.
+						if pxy.limiter != nil {
+							_ = pxy.limiter.WaitN(context.Background(), len(m.Content))
+						}
 						continue
 					case udp.ErrDatagramTooLarge:
 						// fall through to stream write

--- a/pkg/config/v1/proxy.go
+++ b/pkg/config/v1/proxy.go
@@ -291,18 +291,31 @@ type UDPProxyConfig struct {
 	ProxyBaseConfig
 
 	RemotePort int `json:"remotePort,omitempty"`
+
+	// QUICDatagrams relays UDP packets as unreliable QUIC datagrams
+	// (RFC 9221) on the frpc<->frps connection instead of the reliable
+	// work-connection stream. Avoids head-of-line blocking and outer
+	// retransmission for payloads that tolerate loss themselves (VPN
+	// DTLS, WireGuard, RTP). Requires transport.protocol = "quic" and a
+	// server with datagram support; falls back to the stream otherwise.
+	// Packets exceeding the QUIC datagram budget for the path
+	// (~1200-1400 bytes) also fall back to the stream per-packet.
+	// Incompatible with useEncryption/useCompression (stream wrappers).
+	QUICDatagrams bool `json:"quicDatagrams,omitempty"`
 }
 
 func (c *UDPProxyConfig) MarshalToMsg(m *msg.NewProxy) {
 	c.ProxyBaseConfig.MarshalToMsg(m)
 
 	m.RemotePort = c.RemotePort
+	m.UDPDatagram = c.QUICDatagrams
 }
 
 func (c *UDPProxyConfig) UnmarshalFromMsg(m *msg.NewProxy) {
 	c.ProxyBaseConfig.UnmarshalFromMsg(m)
 
 	c.RemotePort = m.RemotePort
+	c.QUICDatagrams = m.UDPDatagram
 }
 
 func (c *UDPProxyConfig) Clone() ProxyConfigurer {

--- a/pkg/msg/handler.go
+++ b/pkg/msg/handler.go
@@ -66,6 +66,10 @@ func (c *Conn) WithContext(ctx context.Context) {
 	}
 }
 
+func (c *Conn) Unwrap() net.Conn {
+	return c.Conn
+}
+
 type V1ReadWriter struct {
 	rw io.ReadWriter
 }

--- a/pkg/msg/msg.go
+++ b/pkg/msg/msg.go
@@ -131,6 +131,11 @@ type NewProxy struct {
 
 	// tcpmux
 	Multiplexer string `json:"multiplexer,omitempty"`
+
+	// udp only: client requests relaying packets as unreliable QUIC
+	// datagrams (RFC 9221) instead of the reliable work-connection stream.
+	// Ignored by servers without support.
+	UDPDatagram bool `json:"udp_datagram,omitempty"`
 }
 
 type NewProxyResp struct {
@@ -158,6 +163,10 @@ type StartWorkConn struct {
 	SrcPort   uint16 `json:"src_port,omitempty"`
 	DstPort   uint16 `json:"dst_port,omitempty"`
 	Error     string `json:"error,omitempty"`
+
+	// udp only: server confirms QUIC datagram relay is active for this
+	// proxy. Absent/false from servers without support -> stream mode.
+	UDPDatagram bool `json:"udp_datagram,omitempty"`
 }
 
 type NewVisitorConn struct {

--- a/pkg/proto/udp/datagram.go
+++ b/pkg/proto/udp/datagram.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"sync"
 
 	quic "github.com/quic-go/quic-go"
@@ -138,9 +139,6 @@ func (m *DatagramMux) Send(name string, remoteAddr *net.UDPAddr, payload []byte)
 	if err != nil {
 		return err
 	}
-	if len(frame) > dgramFrameBudget {
-		return ErrDatagramTooLarge
-	}
 	err = m.qc.SendDatagram(frame)
 	if err != nil {
 		var tooLarge *quic.DatagramTooLargeError
@@ -160,7 +158,14 @@ func encodeDgramFrame(name string, remoteAddr *net.UDPAddr, payload []byte) ([]b
 	if len(name) > 255 || len(addr) > 255 {
 		return nil, fmt.Errorf("udp datagram header field too long: name %d, addr %d", len(name), len(addr))
 	}
-	frame := make([]byte, 0, 3+len(name)+len(addr)+len(payload))
+	// Enforce the budget before building the frame: MTU-sized payloads
+	// commonly exceed it and fall back to the stream, so don't pay an
+	// allocation and copy just to throw the frame away.
+	frameLen := 3 + len(name) + len(addr) + len(payload)
+	if frameLen > dgramFrameBudget {
+		return nil, ErrDatagramTooLarge
+	}
+	frame := make([]byte, 0, frameLen)
 	frame = append(frame, dgramFrameVersion, byte(len(name)))
 	frame = append(frame, name...)
 	frame = append(frame, byte(len(addr)))
@@ -186,10 +191,15 @@ func decodeDgramFrame(data []byte) (name string, remoteAddr *net.UDPAddr, payloa
 		err = errors.New("malformed udp datagram frame: addr")
 		return
 	}
-	remoteAddr, err = net.ResolveUDPAddr("udp", string(data[addrStart:addrStart+addrLen]))
-	if err != nil {
+	// The address comes off the wire; accept only numeric "ip:port".
+	// net.ResolveUDPAddr would resolve hostnames, letting a peer stall the
+	// connection's shared receive loop on DNS lookups.
+	ap, perr := netip.ParseAddrPort(string(data[addrStart : addrStart+addrLen]))
+	if perr != nil {
+		err = errors.New("malformed udp datagram frame: addr not numeric ip:port")
 		return
 	}
+	remoteAddr = net.UDPAddrFromAddrPort(ap)
 	payload = data[addrStart+addrLen:]
 	return
 }

--- a/pkg/proto/udp/datagram.go
+++ b/pkg/proto/udp/datagram.go
@@ -1,0 +1,195 @@
+// Copyright 2026 The frp Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package udp
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+
+	quic "github.com/quic-go/quic-go"
+)
+
+// QUIC datagram relay (RFC 9221) for udp proxies. Every datagram carries a
+// compact binary header so multiple proxies can share one quic connection:
+//
+//	[0]      version (dgramFrameVersion)
+//	[1]      len(proxyName)
+//	[2:2+n]  proxyName
+//	[+0]     len(addr)
+//	[+1:+1+a] addr — the udp user address "ip:port" (direction-independent:
+//	          frps->frpc it identifies the sender, frpc->frps the reply target)
+//	[rest]   raw udp payload
+//
+// Unlike msg.UDPPacket over the work connection, payloads are neither
+// JSON-wrapped nor base64-encoded, and delivery is unreliable and unordered:
+// a lost datagram is simply lost, which is exactly what the tunneled
+// protocols (DTLS, WireGuard, RTP) expect from a udp path.
+const (
+	dgramFrameVersion = 0xF1
+
+	// dgramFrameBudget caps the whole encoded frame. quic-go's SendDatagram
+	// size check uses the current MTU estimate WITHOUT accounting for
+	// packet headers/AEAD overhead: frames in that gray zone are accepted
+	// and then silently dropped at packing time — a deterministic
+	// blackhole for those sizes. Stay well below the minimum QUIC packet
+	// budget (1252-byte initial packets minus ~50 bytes of overhead) so a
+	// frame that passes here always fits; anything larger falls back to
+	// the reliable stream.
+	dgramFrameBudget = 1180
+)
+
+// ErrDatagramTooLarge is returned by Send when the frame exceeds what the
+// QUIC connection can currently carry; callers should fall back to the
+// reliable work-connection stream for that packet.
+var ErrDatagramTooLarge = errors.New("udp datagram too large for quic path")
+
+type dgramHandler func(remoteAddr *net.UDPAddr, payload []byte)
+
+// DatagramMux fans incoming QUIC datagrams of one connection out to the
+// registered proxies, and encodes outgoing ones.
+type DatagramMux struct {
+	qc *quic.Conn
+
+	mu       sync.RWMutex
+	handlers map[string]dgramHandler
+}
+
+var (
+	dgramMusMu sync.Mutex
+	dgramMuxes = map[*quic.Conn]*DatagramMux{}
+)
+
+// DatagramMuxFor returns the mux of a quic connection, creating it and
+// starting its receive loop on first use. The mux removes itself when the
+// connection dies.
+func DatagramMuxFor(qc *quic.Conn) *DatagramMux {
+	dgramMusMu.Lock()
+	defer dgramMusMu.Unlock()
+	if m, ok := dgramMuxes[qc]; ok {
+		return m
+	}
+	m := &DatagramMux{
+		qc:       qc,
+		handlers: make(map[string]dgramHandler),
+	}
+	dgramMuxes[qc] = m
+	go m.receiveLoop()
+	return m
+}
+
+func (m *DatagramMux) receiveLoop() {
+	defer func() {
+		dgramMusMu.Lock()
+		delete(dgramMuxes, m.qc)
+		dgramMusMu.Unlock()
+	}()
+	ctx := m.qc.Context()
+	for {
+		data, err := m.qc.ReceiveDatagram(ctx)
+		if err != nil {
+			return
+		}
+		name, addr, payload, err := decodeDgramFrame(data)
+		if err != nil {
+			continue
+		}
+		m.mu.RLock()
+		h := m.handlers[name]
+		m.mu.RUnlock()
+		if h != nil {
+			h(addr, payload)
+		}
+	}
+}
+
+// Register installs the receive handler for a proxy, replacing any previous
+// one (a new work connection re-registers with its fresh channels).
+func (m *DatagramMux) Register(name string, h dgramHandler) {
+	m.mu.Lock()
+	m.handlers[name] = h
+	m.mu.Unlock()
+}
+
+func (m *DatagramMux) Unregister(name string) {
+	m.mu.Lock()
+	delete(m.handlers, name)
+	m.mu.Unlock()
+}
+
+// Send relays one udp packet as an unreliable QUIC datagram. Returns
+// ErrDatagramTooLarge when it doesn't fit the connection's current datagram
+// budget (caller falls back to the stream).
+func (m *DatagramMux) Send(name string, remoteAddr *net.UDPAddr, payload []byte) error {
+	frame, err := encodeDgramFrame(name, remoteAddr, payload)
+	if err != nil {
+		return err
+	}
+	if len(frame) > dgramFrameBudget {
+		return ErrDatagramTooLarge
+	}
+	err = m.qc.SendDatagram(frame)
+	if err != nil {
+		var tooLarge *quic.DatagramTooLargeError
+		if errors.As(err, &tooLarge) {
+			return ErrDatagramTooLarge
+		}
+		return err
+	}
+	return nil
+}
+
+func encodeDgramFrame(name string, remoteAddr *net.UDPAddr, payload []byte) ([]byte, error) {
+	if remoteAddr == nil {
+		return nil, errors.New("udp datagram without remote address")
+	}
+	addr := remoteAddr.String()
+	if len(name) > 255 || len(addr) > 255 {
+		return nil, fmt.Errorf("udp datagram header field too long: name %d, addr %d", len(name), len(addr))
+	}
+	frame := make([]byte, 0, 3+len(name)+len(addr)+len(payload))
+	frame = append(frame, dgramFrameVersion, byte(len(name)))
+	frame = append(frame, name...)
+	frame = append(frame, byte(len(addr)))
+	frame = append(frame, addr...)
+	frame = append(frame, payload...)
+	return frame, nil
+}
+
+func decodeDgramFrame(data []byte) (name string, remoteAddr *net.UDPAddr, payload []byte, err error) {
+	if len(data) < 3 || data[0] != dgramFrameVersion {
+		err = errors.New("malformed udp datagram frame")
+		return
+	}
+	nameLen := int(data[1])
+	if len(data) < 2+nameLen+1 {
+		err = errors.New("malformed udp datagram frame: name")
+		return
+	}
+	name = string(data[2 : 2+nameLen])
+	addrLen := int(data[2+nameLen])
+	addrStart := 2 + nameLen + 1
+	if len(data) < addrStart+addrLen {
+		err = errors.New("malformed udp datagram frame: addr")
+		return
+	}
+	remoteAddr, err = net.ResolveUDPAddr("udp", string(data[addrStart:addrStart+addrLen]))
+	if err != nil {
+		return
+	}
+	payload = data[addrStart+addrLen:]
+	return
+}

--- a/pkg/proto/udp/datagram_test.go
+++ b/pkg/proto/udp/datagram_test.go
@@ -16,6 +16,7 @@ package udp
 
 import (
 	"bytes"
+	"errors"
 	"net"
 	"testing"
 )
@@ -67,6 +68,28 @@ func TestDatagramFrameEncodeErrors(t *testing.T) {
 	raddr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5")
 	if _, err := encodeDgramFrame(longName, raddr, []byte("x")); err == nil {
 		t.Error("expected error for oversized proxy name")
+	}
+}
+
+func TestDatagramFrameEncodeRejectsOversizedPayload(t *testing.T) {
+	raddr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5")
+	_, err := encodeDgramFrame("p", raddr, bytes.Repeat([]byte{0xab}, dgramFrameBudget))
+	if !errors.Is(err, ErrDatagramTooLarge) {
+		t.Errorf("err = %v, want ErrDatagramTooLarge", err)
+	}
+}
+
+func TestDatagramFrameDecodeRejectsHostname(t *testing.T) {
+	// a peer-controlled frame must not trigger DNS resolution: only numeric
+	// ip:port addresses are accepted
+	name, addr := "p", "evil.example.com:53"
+	frame := []byte{dgramFrameVersion, byte(len(name))}
+	frame = append(frame, name...)
+	frame = append(frame, byte(len(addr)))
+	frame = append(frame, addr...)
+	frame = append(frame, 'x')
+	if _, _, _, err := decodeDgramFrame(frame); err == nil {
+		t.Error("expected error for hostname address")
 	}
 }
 

--- a/pkg/proto/udp/datagram_test.go
+++ b/pkg/proto/udp/datagram_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 The frp Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package udp
+
+import (
+	"bytes"
+	"net"
+	"testing"
+)
+
+func TestDatagramFrameRoundTrip(t *testing.T) {
+	cases := []struct {
+		name    string
+		proxy   string
+		addr    string
+		payload []byte
+	}{
+		{"empty payload", "ocservudp", "1.2.3.4:5678", []byte{}},
+		{"small", "p", "10.0.0.1:53", []byte("hello")},
+		{"binary", "some-proxy-name", "192.168.1.1:1194", []byte{0x00, 0xff, 0x10, 0x00}},
+		{"ipv6", "x", "[fe80::1]:9999", bytes.Repeat([]byte{0xab}, 1100)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			raddr, err := net.ResolveUDPAddr("udp", c.addr)
+			if err != nil {
+				t.Fatalf("resolve: %v", err)
+			}
+			frame, err := encodeDgramFrame(c.proxy, raddr, c.payload)
+			if err != nil {
+				t.Fatalf("encode: %v", err)
+			}
+			name, gotAddr, payload, err := decodeDgramFrame(frame)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if name != c.proxy {
+				t.Errorf("name = %q, want %q", name, c.proxy)
+			}
+			if gotAddr.String() != raddr.String() {
+				t.Errorf("addr = %s, want %s", gotAddr, raddr)
+			}
+			if !bytes.Equal(payload, c.payload) {
+				t.Errorf("payload = %v, want %v", payload, c.payload)
+			}
+		})
+	}
+}
+
+func TestDatagramFrameEncodeErrors(t *testing.T) {
+	if _, err := encodeDgramFrame("p", nil, []byte("x")); err == nil {
+		t.Error("expected error for nil remote address")
+	}
+	longName := string(bytes.Repeat([]byte{'a'}, 256))
+	raddr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5")
+	if _, err := encodeDgramFrame(longName, raddr, []byte("x")); err == nil {
+		t.Error("expected error for oversized proxy name")
+	}
+}
+
+func TestDatagramFrameDecodeRejectsMalformed(t *testing.T) {
+	cases := [][]byte{
+		nil,
+		{0x00},                       // too short
+		{0xF1, 0x05, 'a'},            // name length exceeds data
+		{0x00, 0x01, 'a', 0x01, 'b'}, // wrong version
+	}
+	for i, data := range cases {
+		if _, _, _, err := decodeDgramFrame(data); err == nil {
+			t.Errorf("case %d: expected error, got nil", i)
+		}
+	}
+}

--- a/pkg/util/net/conn.go
+++ b/pkg/util/net/conn.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	libcrypto "github.com/fatedier/golib/crypto"
+	libnet "github.com/fatedier/golib/net"
 	quic "github.com/quic-go/quic-go"
 	"golang.org/x/crypto/hkdf"
 
@@ -72,6 +73,10 @@ func (c *ContextConn) WithContext(ctx context.Context) {
 
 func (c *ContextConn) Context() context.Context {
 	return c.ctx
+}
+
+func (c *ContextConn) Unwrap() net.Conn {
+	return c.Conn
 }
 
 type WrapReadWriteCloserConn struct {
@@ -240,6 +245,27 @@ func (conn *wrapQuicStream) RemoteAddr() net.Addr {
 func (conn *wrapQuicStream) Close() error {
 	conn.CancelRead(0)
 	return conn.Stream.Close()
+}
+
+// QuicConnFrom returns the underlying *quic.Conn of a work connection that
+// is (possibly a wrapper around) a QUIC stream. It unwraps any chain of
+// wrappers exposing Unwrap() net.Conn (e.g. ContextConn).
+func QuicConnFrom(c net.Conn) (*quic.Conn, bool) {
+	for c != nil {
+		switch t := c.(type) {
+		case *wrapQuicStream:
+			return t.c, t.c != nil
+		case *libnet.SharedConn:
+			// golib's SharedConn (used by the wire-magic sniffer) embeds
+			// net.Conn but doesn't expose Unwrap
+			c = t.Conn
+		case interface{ Unwrap() net.Conn }:
+			c = t.Unwrap()
+		default:
+			return nil, false
+		}
+	}
+	return nil, false
 }
 
 func NewCryptoReadWriter(rw io.ReadWriter, key []byte) (io.ReadWriter, error) {

--- a/server/proxy/proxy.go
+++ b/server/proxy/proxy.go
@@ -96,6 +96,10 @@ type BaseProxy struct {
 	configurer    v1.ProxyConfigurer
 	wireProtocol  string
 
+	// udp proxies with quicDatagrams: relay packets as unreliable QUIC
+	// datagrams when the work connection rides a QUIC connection.
+	udpDatagramWanted bool
+
 	mu  sync.RWMutex
 	xl  *xlog.Logger
 	ctx context.Context
@@ -172,13 +176,22 @@ func (pxy *BaseProxy) GetWorkConnFromPool(src, dst net.Addr) (workConn net.Conn,
 			dstAddr, dstPortStr, _ = net.SplitHostPort(dst.String())
 			dstPort, _ = strconv.ParseUint(dstPortStr, 10, 16)
 		}
+		// confirm QUIC datagram relay only when this specific work
+		// connection can actually carry it
+		udpDatagram := false
+		if pxy.udpDatagramWanted {
+			if qc, ok := netpkg.QuicConnFrom(pxyWorkConn.conn); ok {
+				udpDatagram = qc.ConnectionState().SupportsDatagrams
+			}
+		}
 		workConn, err = pxyWorkConn.Start(&msg.StartWorkConn{
-			ProxyName: pxy.GetName(),
-			SrcAddr:   srcAddr,
-			SrcPort:   uint16(srcPort),
-			DstAddr:   dstAddr,
-			DstPort:   uint16(dstPort),
-			Error:     "",
+			ProxyName:   pxy.GetName(),
+			SrcAddr:     srcAddr,
+			SrcPort:     uint16(srcPort),
+			DstAddr:     dstAddr,
+			DstPort:     uint16(dstPort),
+			Error:       "",
+			UDPDatagram: udpDatagram,
 		})
 		if err != nil {
 			xl.Warnf("failed to send message to work connection from pool: %v, times: %d", err, i)

--- a/server/proxy/udp.go
+++ b/server/proxy/udp.go
@@ -69,6 +69,10 @@ func NewUDPProxy(baseProxy *BaseProxy) Proxy {
 		return nil
 	}
 	baseProxy.usedPortsNum = 1
+	// QUIC datagram relay bypasses the work-connection stream, so it can't
+	// honor the per-proxy stream wrappers (encryption/compression).
+	baseProxy.udpDatagramWanted = unwrapped.QUICDatagrams &&
+		!unwrapped.Transport.UseEncryption && !unwrapped.Transport.UseCompression
 	return &UDPProxy{
 		BaseProxy: baseProxy,
 		cfg:       unwrapped,
@@ -152,8 +156,9 @@ func (pxy *UDPProxy) Run() (remoteAddr string, err error) {
 		}
 	}
 
-	// send message to workConn
-	workConnSenderFn := func(payloadConn *msg.Conn, ctx context.Context) {
+	// send message to workConn; when dgMux is set, packets go out as
+	// unreliable QUIC datagrams and only oversized ones use the stream
+	workConnSenderFn := func(payloadConn *msg.Conn, dgMux *udp.DatagramMux, ctx context.Context) {
 		var errRet error
 		for {
 			select {
@@ -161,6 +166,23 @@ func (pxy *UDPProxy) Run() (remoteAddr string, err error) {
 				if !ok {
 					xl.Infof("sender goroutine for udp work connection closed")
 					return
+				}
+				if dgMux != nil {
+					switch dgErr := dgMux.Send(pxy.GetName(), udpMsg.RemoteAddr, udpMsg.Content); dgErr {
+					case nil:
+						metrics.Server.AddTrafficIn(
+							pxy.GetName(),
+							pxy.GetConfigurer().GetBaseConfig().Type,
+							int64(len(udpMsg.Content)),
+						)
+						continue
+					case udp.ErrDatagramTooLarge:
+						// fall through to the stream for this packet
+					default:
+						xl.Infof("sender goroutine for udp work connection closed: %v", dgErr)
+						_ = payloadConn.Close()
+						return
+					}
 				}
 				if errRet = payloadConn.WriteMsg(udpMsg); errRet != nil {
 					xl.Infof("sender goroutine for udp work connection closed: %v", errRet)
@@ -203,6 +225,30 @@ func (pxy *UDPProxy) Run() (remoteAddr string, err error) {
 				pxy.workConn.Close()
 			}
 
+			// QUIC datagram lane: mirror of the udpDatagram decision made
+			// in GetWorkConnFromPool for this same work connection
+			var dgMux *udp.DatagramMux
+			if pxy.udpDatagramWanted {
+				if qc, ok := netpkg.QuicConnFrom(workConn); ok && qc.ConnectionState().SupportsDatagrams {
+					dgMux = udp.DatagramMuxFor(qc)
+					dgMux.Register(pxy.GetName(), func(remoteAddr *net.UDPAddr, payload []byte) {
+						m := udp.NewUDPPacket(payload, nil, remoteAddr)
+						_ = errors.PanicToError(func() {
+							select {
+							case pxy.readCh <- m:
+								metrics.Server.AddTrafficOut(
+									pxy.GetName(),
+									pxy.GetConfigurer().GetBaseConfig().Type,
+									int64(len(m.Content)),
+								)
+							default:
+							}
+						})
+					})
+					xl.Infof("udp proxy relaying via quic datagrams")
+				}
+			}
+
 			var rwc io.ReadWriteCloser = workConn
 			if pxy.cfg.Transport.UseEncryption {
 				rwc, err = libio.WithEncryption(rwc, pxy.encryptionKey)
@@ -227,9 +273,12 @@ func (pxy *UDPProxy) Run() (remoteAddr string, err error) {
 			payloadConn := msg.NewConn(pxy.workConn, msg.NewReadWriter(pxy.workConn, pxy.wireProtocol))
 			ctx, cancel := context.WithCancel(context.Background())
 			go workConnReaderFn(payloadConn)
-			go workConnSenderFn(payloadConn, ctx)
+			go workConnSenderFn(payloadConn, dgMux, ctx)
 			_, ok := <-pxy.checkCloseCh
 			cancel()
+			if dgMux != nil {
+				dgMux.Unregister(pxy.GetName())
+			}
 			if !ok {
 				return
 			}

--- a/server/proxy/udp.go
+++ b/server/proxy/udp.go
@@ -170,6 +170,14 @@ func (pxy *UDPProxy) Run() (remoteAddr string, err error) {
 				if dgMux != nil {
 					switch dgErr := dgMux.Send(pxy.GetName(), udpMsg.RemoteAddr, udpMsg.Content); dgErr {
 					case nil:
+						// Datagrams bypass the limiter-wrapped work
+						// connection, so account for them here: charging
+						// after the send (like limit.Reader does) delays
+						// subsequent packets to hold the configured rate,
+						// and never double-charges the stream fallback.
+						if limiter := pxy.GetLimiter(); limiter != nil {
+							_ = limiter.WaitN(ctx, len(udpMsg.Content))
+						}
 						metrics.Server.AddTrafficIn(
 							pxy.GetName(),
 							pxy.GetConfigurer().GetBaseConfig().Type,
@@ -232,6 +240,13 @@ func (pxy *UDPProxy) Run() (remoteAddr string, err error) {
 				if qc, ok := netpkg.QuicConnFrom(workConn); ok && qc.ConnectionState().SupportsDatagrams {
 					dgMux = udp.DatagramMuxFor(qc)
 					dgMux.Register(pxy.GetName(), func(remoteAddr *net.UDPAddr, payload []byte) {
+						// The bandwidth limiter can only police (drop)
+						// here, not shape: this callback runs on the quic
+						// connection's shared receive loop, which must
+						// never block.
+						if limiter := pxy.GetLimiter(); limiter != nil && !limiter.AllowN(time.Now(), len(payload)) {
+							return
+						}
 						m := udp.NewUDPPacket(payload, nil, remoteAddr)
 						_ = errors.PanicToError(func() {
 							select {

--- a/server/service.go
+++ b/server/service.go
@@ -266,6 +266,7 @@ func NewService(cfg *v1.ServerConfig) (*Service, error) {
 			MaxIdleTimeout:     time.Duration(cfg.Transport.QUIC.MaxIdleTimeout) * time.Second,
 			MaxIncomingStreams: int64(cfg.Transport.QUIC.MaxIncomingStreams),
 			KeepAlivePeriod:    time.Duration(cfg.Transport.QUIC.KeepalivePeriod) * time.Second,
+			EnableDatagrams:    true, // for udp proxies with quicDatagrams (RFC 9221)
 		})
 		if err != nil {
 			return nil, fmt.Errorf("listen on quic udp address %s error: %v", address, err)


### PR DESCRIPTION
## udp proxy: relay packets as unreliable QUIC datagrams (RFC 9221)

### Problem

The `udp` proxy wraps every UDP packet in a `msg.UDPPacket` and writes it over a **single reliable work-connection stream** (`server/proxy/udp.go`, `client/proxy/udp.go`). When the tunneled protocol already tolerates loss — VPN DTLS (OpenConnect/ocserv, AnyConnect), WireGuard, RTP/QUIC media — this adds a reliability layer it neither needs nor wants:

- **Head-of-line blocking**: one lost segment stalls every subsequent packet for all users of that proxy.
- **Redundant retransmission**: the outer stream re-sends payloads the inner protocol has already given up on.

On a lossy, high-RTT path the single stream is bounded by the Mathis limit (`~MSS / (RTT·√loss)`), so throughput collapses far below the raw path capacity. This is the root cause behind #4531 (request to carry UDP unreliably) and #4174 (WireGuard-over-frp slower than the alternative); switching the transport to `kcp`/`quic` doesn't help because those only make the *underlay* UDP — the proxied payload still rides a reliable stream.

#### Why

A UDP proxy should preserve UDP's delivery semantics end to end. Today it doesn't: it turns an unreliable datagram service into a reliable, ordered byte stream, which is a poor fit for the very protocols people most often tunnel over `type = udp` (VPN DTLS, WireGuard, RTP, QUIC media). Those protocols run their own loss recovery, so frp's reliability is pure overhead — and worse than neutral, because a single reliable stream converts packet loss into latency and head-of-line stalls that cascade across every flow sharing the proxy.

The alternatives don't address it:

- **Transport tuning (`kcp`/`quic`, window/keepalive knobs)** changes only the underlay; the payload is still framed onto one reliable stream, so the HoL blocking and redundant retransmission remain.
- **A dedicated stream per user flow** would remove cross-flow HoL but still imposes per-flow reliability/ordering the inner protocol doesn't want, plus stream-setup cost per UDP "session."
- **A second raw UDP side-channel** (à la the KCP/FakeTCP requests) means new ports, new firewall/NAT holes, and separate auth — exactly what frp's existing multiplexed connection avoids.

QUIC datagrams (RFC 9221) fit because the QUIC transport frp already supports carries them **on the same authenticated, congestion-controlled connection**, with no extra ports and no new handshake — while giving each packet unreliable, unordered delivery. It's the minimal change that makes a UDP proxy behave like a UDP proxy, and it's opt-in so nothing changes for users who want today's behavior.

### Change

Adds an opt-in `quicDatagrams` option to `udp` proxies. When enabled and the frpc↔frps connection is QUIC, packets are relayed as **unreliable QUIC datagrams (RFC 9221)** instead of over the work-connection stream, using a compact binary frame (proxy name + user address + raw payload — no JSON, no base64). Lost packets stay lost; there is no outer ordering or retransmission.

```toml
# frpc.toml
transport.protocol = "quic"

[[proxies]]
name = "vpn-dtls"
type = "udp"
localIP = "127.0.0.1"
localPort = 10443
remotePort = 10443
quicDatagrams = true
```

### Design / compatibility

- **Negotiated per work connection.** The client advertises `NewProxy.udp_datagram`; the server confirms with `StartWorkConn.udp_datagram` only when *that* work connection actually supports datagrams. Either side that lacks support (older peer, non-QUIC transport) simply keeps the existing stream path — no config error, no breakage. Both message fields are additive JSON, so mixed-version deployments interoperate.
- **Per-packet fallback.** A frame that exceeds a conservative datagram budget (1180 bytes) is sent over the stream instead, so oversized packets are never dropped. The budget deliberately sits below the minimum QUIC packet size: quic-go's `SendDatagram` size check uses the current MTU estimate *without* subtracting packet/AEAD overhead, so frames in a narrow band just under the MTU are accepted and then silently dropped at packing time — the fixed budget avoids that blackhole.
- **Interop with stream wrappers.** Datagram mode is disabled automatically when `useEncryption` or `useCompression` is set (those are stream transforms), falling back to the stream.
- Requires `transport.protocol = "quic"`; no effect for tcp/kcp/websocket transports.

### Tests

- New `pkg/proto/udp/datagram_test.go`: frame round-trip (incl. empty/binary payloads, IPv6), encode errors, malformed-frame rejection.
- Functional (local frps+frpc, UDP echo): all payload sizes 64–1450 round-trip correctly; the stream path is unaffected; datagram mode is confirmed on both ends.
- Load (loopback): 60 Mbit/s sustained at 0% loss through the datagram lane.
- Real-world A/B on a lossy ~150 ms intercontinental path, same binaries, offered 55 Mbit/s: **datagram lane 50.7 Mbit/s @ 7.8% loss vs. the stream lane 25.7 Mbit/s @ 51% loss** — roughly 2× goodput and near the raw path capacity, with materially lower jitter.

### Notes

Feature is fully opt-in and off by default; existing `udp` proxies are unchanged. Happy to adjust the config field name, the datagram budget constant, or split the message/config additions into a separate commit if that's preferred.
