### PR TITLE
bump version to 0.70.0

### DIFF
--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -14,7 +14,7 @@
 
 package version
 
-var version = "0.69.1"
+var version = "0.70.0"
 
 func Full() string {
 	return version


### PR DESCRIPTION
## Summary

- Bump frp version to 0.70.0.

## Testing

- `make e2e-compatibility`
- `make e2e-compatibility-floor`
- Completed non-Android release artifact audit.