### PR TITLE
ci: remove unsupported s390x image target

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           context: .
           file: ./dockerfiles/Dockerfile-for-frpc
-          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
           push: true
           tags: |
             ${{ env.TAG_FRPC }}
@@ -76,7 +76,7 @@ jobs:
         with:
           context: .
           file: ./dockerfiles/Dockerfile-for-frps
-          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
           push: true
           tags: |
             ${{ env.TAG_FRPS }}


### PR DESCRIPTION
## Summary

- remove `linux/s390x` from the frpc and frps Docker build matrices
- retain `linux/amd64`, `linux/arm/v7`, `linux/arm64`, and `linux/ppc64le`
- leave Dockerfiles, source build support, release packages, and other architectures unchanged

The default `node:22` image no longer publishes an s390x manifest, so the release-triggered multi-platform build cannot resolve its web-builder stage for that target. This change intentionally removes only the Docker delivery target.

## Validation

- YAML parse and `git diff --check`
- exact platform-list assertions for both image steps
- manifest coverage checks for `node:22`, `golang:1.25`, and `alpine:3`
- full non-pushing four-platform Buildx OCI builds for frpc and frps
- fresh Codex review of uncommitted changes: no findings