### PR TITLE
feat(client): allow seeding the initial RunID

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -64,6 +64,11 @@ func (e cancelErr) Error() string {
 type ServiceOptions struct {
 	Common *v1.ClientCommonConfig
 
+	// InitialRunID is sent in the first login request. When empty, frps
+	// assigns a RunID as usual. After a successful login, the RunID returned
+	// by frps is used for subsequent reconnects.
+	InitialRunID string
+
 	// ConfigSourceAggregator manages internal config and optional store sources.
 	// It is required for creating a Service.
 	ConfigSourceAggregator *source.Aggregator
@@ -194,6 +199,7 @@ func NewService(options ServiceOptions) (*Service, error) {
 
 	s := &Service{
 		ctx:              context.Background(),
+		runID:            options.InitialRunID,
 		auth:             authRuntime,
 		webServer:        webServer,
 		common:           options.Common,

--- a/client/service.go
+++ b/client/service.go
@@ -277,7 +277,13 @@ func (svr *Service) Run(ctx context.Context) error {
 }
 
 func (svr *Service) keepControllerWorking() {
-	<-svr.ctl.Done()
+	svr.ctlMu.RLock()
+	ctl := svr.ctl
+	svr.ctlMu.RUnlock()
+	if ctl == nil {
+		return
+	}
+	<-ctl.Done()
 
 	// There is a situation where the login is successful but due to certain reasons,
 	// the control immediately exits. It is necessary to limit the frequency of reconnection in this case.
@@ -287,8 +293,11 @@ func (svr *Service) keepControllerWorking() {
 		// loopLoginUntilSuccess is another layer of loop that will continuously attempt to
 		// login to the server until successful.
 		svr.loopLoginUntilSuccess(20*time.Second, false)
-		if svr.ctl != nil {
-			<-svr.ctl.Done()
+		svr.ctlMu.RLock()
+		ctl = svr.ctl
+		svr.ctlMu.RUnlock()
+		if ctl != nil {
+			<-ctl.Done()
 			return false, errors.New("control is closed and try another loop")
 		}
 		// If the control is nil, it means that the login failed and the service is also closed.

--- a/client/service_test.go
+++ b/client/service_test.go
@@ -8,7 +8,9 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/samber/lo"
 
@@ -45,13 +47,25 @@ func getFreeTCPPort(t *testing.T) int {
 	return ln.Addr().(*net.TCPAddr).Port
 }
 
-func TestRunSendsInitialRunIDOnFirstLogin(t *testing.T) {
-	clientConn, serverConn := net.Pipe()
+func TestRunSendsInitialRunIDOnFirstLoginAndReconnect(t *testing.T) {
+	firstClientConn, firstServerConn := net.Pipe()
+	secondClientConn, secondServerConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = firstClientConn.Close()
+		_ = firstServerConn.Close()
+		_ = secondClientConn.Close()
+		_ = secondServerConn.Close()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	serverErrCh := make(chan error, 1)
 	go func() {
-		defer serverConn.Close()
-		rw := msg.NewV1ReadWriter(serverConn)
+		defer firstServerConn.Close()
+		defer secondServerConn.Close()
+
+		rw := msg.NewV1ReadWriter(firstServerConn)
 		var loginMsg msg.Login
 		if err := rw.ReadMsgInto(&loginMsg); err != nil {
 			serverErrCh <- err
@@ -61,29 +75,76 @@ func TestRunSendsInitialRunIDOnFirstLogin(t *testing.T) {
 			serverErrCh <- fmt.Errorf("first login RunID = %q, want %q", loginMsg.RunID, "initial-run-id")
 			return
 		}
-		serverErrCh <- rw.WriteMsg(&msg.LoginResp{Error: "stop after first login"})
+		if err := rw.WriteMsg(&msg.LoginResp{RunID: "initial-run-id"}); err != nil {
+			serverErrCh <- err
+			return
+		}
+		if err := firstServerConn.Close(); err != nil {
+			serverErrCh <- err
+			return
+		}
+
+		rw = msg.NewV1ReadWriter(secondServerConn)
+		loginMsg = msg.Login{}
+		if err := rw.ReadMsgInto(&loginMsg); err != nil {
+			serverErrCh <- err
+			return
+		}
+		if loginMsg.RunID != "initial-run-id" {
+			serverErrCh <- fmt.Errorf("reconnect login RunID = %q, want %q", loginMsg.RunID, "initial-run-id")
+			return
+		}
+		cancel()
+		serverErrCh <- nil
 	}()
 
+	var connectorCount atomic.Int32
 	svr, err := NewService(ServiceOptions{
-		Common: &v1.ClientCommonConfig{
-			LoginFailExit: lo.ToPtr(true),
-		},
+		Common:                 &v1.ClientCommonConfig{},
 		ConfigSourceAggregator: source.NewAggregator(source.NewConfigSource()),
 		InitialRunID:           "initial-run-id",
 		ConnectorCreator: func(context.Context, *v1.ClientCommonConfig) Connector {
-			return &testConnector{conn: &trackingConn{Conn: clientConn}}
+			switch connectorCount.Add(1) {
+			case 1:
+				return &testConnector{conn: &trackingConn{Conn: firstClientConn}}
+			case 2:
+				return &testConnector{conn: &trackingConn{Conn: secondClientConn}}
+			default:
+				return &failingConnector{err: context.Canceled}
+			}
 		},
 	})
 	if err != nil {
 		t.Fatalf("new service: %v", err)
 	}
 
-	err = svr.Run(context.Background())
-	if err := <-serverErrCh; err != nil {
-		t.Fatalf("mock server: %v", err)
+	runErrCh := make(chan error, 1)
+	go func() {
+		runErrCh <- svr.Run(ctx)
+	}()
+
+	select {
+	case err := <-serverErrCh:
+		cancel()
+		if err != nil {
+			t.Fatalf("mock server: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("timed out waiting for reconnect login")
 	}
-	if err == nil || !strings.Contains(err.Error(), "stop after first login") {
-		t.Fatalf("run error = %v, want first-login stop error", err)
+
+	select {
+	case err := <-runErrCh:
+		if err != nil {
+			t.Fatalf("run service: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for service shutdown")
+	}
+
+	if got := connectorCount.Load(); got != 2 {
+		t.Fatalf("connector attempts = %d, want 2", got)
 	}
 }
 

--- a/client/service_test.go
+++ b/client/service_test.go
@@ -47,10 +47,10 @@ func getFreeTCPPort(t *testing.T) int {
 
 func TestRunSendsInitialRunIDOnFirstLogin(t *testing.T) {
 	clientConn, serverConn := net.Pipe()
-	defer serverConn.Close()
 
 	serverErrCh := make(chan error, 1)
 	go func() {
+		defer serverConn.Close()
 		rw := msg.NewV1ReadWriter(serverConn)
 		var loginMsg msg.Login
 		if err := rw.ReadMsgInto(&loginMsg); err != nil {
@@ -79,11 +79,11 @@ func TestRunSendsInitialRunIDOnFirstLogin(t *testing.T) {
 	}
 
 	err = svr.Run(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "stop after first login") {
-		t.Fatalf("run error = %v, want first-login stop error", err)
-	}
 	if err := <-serverErrCh; err != nil {
 		t.Fatalf("mock server: %v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "stop after first login") {
+		t.Fatalf("run error = %v, want first-login stop error", err)
 	}
 }
 

--- a/client/service_test.go
+++ b/client/service_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"path/filepath"
 	"strconv"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/fatedier/frp/pkg/config/source"
 	v1 "github.com/fatedier/frp/pkg/config/v1"
+	"github.com/fatedier/frp/pkg/msg"
 )
 
 type failingConnector struct {
@@ -41,6 +43,48 @@ func getFreeTCPPort(t *testing.T) int {
 	defer ln.Close()
 
 	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func TestRunSendsInitialRunIDOnFirstLogin(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer serverConn.Close()
+
+	serverErrCh := make(chan error, 1)
+	go func() {
+		rw := msg.NewV1ReadWriter(serverConn)
+		var loginMsg msg.Login
+		if err := rw.ReadMsgInto(&loginMsg); err != nil {
+			serverErrCh <- err
+			return
+		}
+		if loginMsg.RunID != "initial-run-id" {
+			serverErrCh <- fmt.Errorf("first login RunID = %q, want %q", loginMsg.RunID, "initial-run-id")
+			return
+		}
+		serverErrCh <- rw.WriteMsg(&msg.LoginResp{Error: "stop after first login"})
+	}()
+
+	svr, err := NewService(ServiceOptions{
+		Common: &v1.ClientCommonConfig{
+			LoginFailExit: lo.ToPtr(true),
+		},
+		ConfigSourceAggregator: source.NewAggregator(source.NewConfigSource()),
+		InitialRunID:           "initial-run-id",
+		ConnectorCreator: func(context.Context, *v1.ClientCommonConfig) Connector {
+			return &testConnector{conn: &trackingConn{Conn: clientConn}}
+		},
+	})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+
+	err = svr.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "stop after first login") {
+		t.Fatalf("run error = %v, want first-login stop error", err)
+	}
+	if err := <-serverErrCh; err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
 }
 
 func TestRunStopsStartedComponentsOnInitialLoginFailure(t *testing.T) {


### PR DESCRIPTION
### WHY

Applications embedding the frp client can establish a session correlation identifier before the first frps Login—for example, to bind a preceding authenticated bootstrap step to the resulting control session. Today `Service.runID` is private and always starts empty, so embedders cannot carry that identity through the supported client API.

Add `ServiceOptions.InitialRunID` and use it for the first Login. Leaving it empty preserves the existing server-assigned behavior. After login, the RunID returned by frps remains authoritative and is reused for reconnects exactly as before.

The public `NewService`/`Run` integration test verifies the seeded value is present byte-for-byte in both the first Login and the reconnect Login. Exercising that reconnect path under the race detector exposed an existing unsynchronized read of `Service.ctl` during concurrent shutdown; the focused mutex fix uses the already-existing `ctlMu` and is kept in its own commit.

Local validation on the current head passed with:

- `make fmt`
- `make vet`
- `make test`
- `go test -race ./client/...`
- `go test -race ./client -run TestRunSendsInitialRunIDOnFirstLoginAndReconnect -count=100`
- `golangci-lint run ./client/...`
