### PR TITLE
fix: fail fast on cross-compile errors

### DIFF
--- a/Makefile.cross-compiles
+++ b/Makefile.cross-compiles
@@ -9,7 +9,7 @@ all: build
 build: app
 
 app:
-	@$(foreach n, $(os-archs), \
+	@set -e; $(foreach n, $(os-archs), \
 		os=$(shell echo "$(n)" | cut -d : -f 1); \
 		arch=$(shell echo "$(n)" | cut -d : -f 2); \
 		extra=$(shell echo "$(n)" | cut -d : -f 3); \


### PR DESCRIPTION
## Summary

- Fix the cross-compile recipe so a failing `go build` is not masked by the later `echo` command.
- Add `set -e` at the start of the existing shell block so the first failing frpc or frps build propagates immediately.
- The observed Android linker error `github.com/wlynxg/anet: invalid reference to net.zoneCache` is unchanged; this PR does not modify dependencies.

## Verification

- The expanded recipe parses with `/bin/sh`.
- An invalid first target exits with status 2, does not start the next build, and does not print a false `Build ... done`.
- Fresh Codex review reported no findings.