### PR TITLE
fix(runtime): synchronize shutdown state

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -263,15 +263,15 @@ func (svr *Service) Run(ctx context.Context) error {
 		return fmt.Errorf("login to the server failed: %v. With loginFailExit enabled, no additional retries will be attempted", cancelCause.Err)
 	}
 
-	go svr.keepControllerWorking()
+	go svr.keepControllerWorking(svr.currentControl())
 
 	<-svr.ctx.Done()
 	svr.stop()
 	return nil
 }
 
-func (svr *Service) keepControllerWorking() {
-	<-svr.ctl.Done()
+func (svr *Service) keepControllerWorking(ctl *Control) {
+	<-ctl.Done()
 
 	// There is a situation where the login is successful but due to certain reasons,
 	// the control immediately exits. It is necessary to limit the frequency of reconnection in this case.
@@ -281,8 +281,9 @@ func (svr *Service) keepControllerWorking() {
 		// loopLoginUntilSuccess is another layer of loop that will continuously attempt to
 		// login to the server until successful.
 		svr.loopLoginUntilSuccess(20*time.Second, false)
-		if svr.ctl != nil {
-			<-svr.ctl.Done()
+		ctl := svr.currentControl()
+		if ctl != nil {
+			<-ctl.Done()
 			return false, errors.New("control is closed and try another loop")
 		}
 		// If the control is nil, it means that the login failed and the service is also closed.
@@ -373,7 +374,7 @@ func (svr *Service) UpdateAllConfigurer(proxyCfgs []v1.ProxyConfigurer, visitorC
 	svr.ctlMu.RUnlock()
 
 	if ctl != nil {
-		return svr.ctl.UpdateAllConfigurer(proxyCfgs, visitorCfgs)
+		return ctl.UpdateAllConfigurer(proxyCfgs, visitorCfgs)
 	}
 	return nil
 }
@@ -412,8 +413,16 @@ func (svr *Service) Close() {
 }
 
 func (svr *Service) GracefulClose(d time.Duration) {
+	svr.ctlMu.Lock()
 	svr.gracefulShutdownDuration = d
+	svr.ctlMu.Unlock()
 	svr.cancel(nil)
+}
+
+func (svr *Service) currentControl() *Control {
+	svr.ctlMu.RLock()
+	defer svr.ctlMu.RUnlock()
+	return svr.ctl
 }
 
 func (svr *Service) stop() {

--- a/server/control.go
+++ b/server/control.go
@@ -200,6 +200,8 @@ func (ctl *Control) Replaced(newCtl *Control) {
 
 func (ctl *Control) RegisterWorkConn(conn *proxy.WorkConn) error {
 	xl := ctl.xl
+	ctl.mu.RLock()
+	defer ctl.mu.RUnlock()
 	defer func() {
 		if err := recover(); err != nil {
 			xl.Errorf("panic error: %v", err)


### PR DESCRIPTION
### WHY

The runtime race detector reports two shutdown races in the v0.70.0 lifecycle:

- `client.Service.stop` writes `svr.ctl = nil` while `keepControllerWorking` and `UpdateAllConfigurer` read the same pointer.
- `server.Control.RegisterWorkConn` can send on `workConnCh` while shutdown closes that channel.

This patch protects client control-pointer and graceful-shutdown state with the existing mutex, captures stable control pointers for lifecycle goroutines, and serializes work-connection registration with channel closure.

The patch is intentionally limited to lifecycle synchronization. It does not change the frp wire protocol, login/reconnect behavior, proxy configuration, route semantics, or public APIs.

### TESTING

- `go test -race ./client ./server` on current `dev`
- `git diff --check`

### COMPATIBILITY

The change is source-compatible and preserves existing shutdown and reconnect behavior while removing concurrent read/write and send/close hazards.