### PR TITLE
fix(auth): use constant-time compare for vhost and tcpmux credentials

### DIFF
--- a/pkg/util/tcpmux/httpconnect.go
+++ b/pkg/util/tcpmux/httpconnect.go
@@ -25,6 +25,7 @@ import (
 	libnet "github.com/fatedier/golib/net"
 
 	httppkg "github.com/fatedier/frp/pkg/util/http"
+	"github.com/fatedier/frp/pkg/util/util"
 	"github.com/fatedier/frp/pkg/util/vhost"
 )
 
@@ -84,7 +85,9 @@ func (muxer *HTTPConnectTCPMuxer) sendConnectResponse(c net.Conn, _ map[string]s
 func (muxer *HTTPConnectTCPMuxer) auth(c net.Conn, username, password string, reqInfo map[string]string) (bool, error) {
 	reqUsername := reqInfo["HTTPUser"]
 	reqPassword := reqInfo["HTTPPwd"]
-	if username == reqUsername && password == reqPassword {
+	// Match admin HTTP auth: compare credentials in constant time.
+	if util.ConstantTimeEqString(username, reqUsername) &&
+		util.ConstantTimeEqString(password, reqPassword) {
 		return true, nil
 	}
 

--- a/pkg/util/vhost/http.go
+++ b/pkg/util/vhost/http.go
@@ -33,6 +33,7 @@ import (
 
 	httppkg "github.com/fatedier/frp/pkg/util/http"
 	"github.com/fatedier/frp/pkg/util/log"
+	"github.com/fatedier/frp/pkg/util/util"
 )
 
 var ErrNoRouteFound = errors.New("no route found")
@@ -200,11 +201,15 @@ func checkRouteAuthByRequest(req *http.Request, rc *RouteConfig) bool {
 			return false
 		}
 		user, passwd, ok := httppkg.ParseBasicAuth(proxyAuth)
-		return ok && user == rc.Username && passwd == rc.Password
+		return ok &&
+			util.ConstantTimeEqString(user, rc.Username) &&
+			util.ConstantTimeEqString(passwd, rc.Password)
 	}
 
 	user, passwd, ok := req.BasicAuth()
-	return ok && user == rc.Username && passwd == rc.Password
+	return ok &&
+		util.ConstantTimeEqString(user, rc.Username) &&
+		util.ConstantTimeEqString(passwd, rc.Password)
 }
 
 func (rp *HTTPReverseProxy) connectHandler(rw http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
## Summary

Admin dashboard basic auth already compares credentials with `util.ConstantTimeEqString` (`pkg/util/net/http.go`). Two other password-check paths still used plain `==`:

1. **HTTP/HTTPS vhost route auth** (`checkRouteAuthByRequest`) — `Authorization` / `Proxy-Authorization`
2. **TCPMux HTTP CONNECT auth** (`HTTPConnectTCPMuxer.auth`)

This change aligns both with the admin middleware so route passwords are not compared with non-constant-time string equality.

## Test plan

- [x] `go test ./pkg/util/vhost/ ./pkg/util/tcpmux/ ./pkg/util/net/ ./pkg/util/util/`
- Existing vhost auth unit tests cover correct/wrong credentials for both Basic and Proxy-Authorization