### PR TITLE
fix(config): clarify http/https errors when vhost ports are unset

### DIFF
--- a/pkg/config/v1/validation/proxy.go
+++ b/pkg/config/v1/validation/proxy.go
@@ -212,7 +212,9 @@ func validateTCPMuxProxyConfigForServer(c *v1.TCPMuxProxyConfig, s *v1.ServerCon
 
 func validateHTTPProxyConfigForServer(c *v1.HTTPProxyConfig, s *v1.ServerConfig) error {
 	if s.VhostHTTPPort == 0 {
-		return fmt.Errorf("type [http] not supported when vhost http port is not set")
+		// Keep the historical phrase so existing docs/search hits still match, and
+		// tell operators which server field must be configured (common #5097 footgun).
+		return fmt.Errorf("type [http] not supported when vhost http port is not set; set vhostHTTPPort in frps configuration")
 	}
 
 	return validateDomainConfigForServer(&c.DomainConfig, s)
@@ -220,7 +222,7 @@ func validateHTTPProxyConfigForServer(c *v1.HTTPProxyConfig, s *v1.ServerConfig)
 
 func validateHTTPSProxyConfigForServer(c *v1.HTTPSProxyConfig, s *v1.ServerConfig) error {
 	if s.VhostHTTPSPort == 0 {
-		return fmt.Errorf("type [https] not supported when vhost https port is not set")
+		return fmt.Errorf("type [https] not supported when vhost https port is not set; set vhostHTTPSPort in frps configuration")
 	}
 
 	return validateDomainConfigForServer(&c.DomainConfig, s)

--- a/pkg/config/v1/validation/proxy_test.go
+++ b/pkg/config/v1/validation/proxy_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 The frp Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/fatedier/frp/pkg/config/v1"
+)
+
+func TestValidateHTTPProxyRequiresVhostHTTPPort(t *testing.T) {
+	require := require.New(t)
+
+	cfg := &v1.HTTPProxyConfig{}
+	err := ValidateProxyConfigurerForServer(cfg, &v1.ServerConfig{})
+	require.Error(err)
+	require.Contains(err.Error(), "type [http] not supported when vhost http port is not set")
+	require.Contains(err.Error(), "vhostHTTPPort")
+
+	err = ValidateProxyConfigurerForServer(cfg, &v1.ServerConfig{VhostHTTPPort: 80})
+	// Domain validation may still fail, but not because the vhost port is missing.
+	if err != nil {
+		require.False(strings.Contains(err.Error(), "vhost http port is not set"))
+	}
+}
+
+func TestValidateHTTPSProxyRequiresVhostHTTPSPort(t *testing.T) {
+	require := require.New(t)
+
+	cfg := &v1.HTTPSProxyConfig{}
+	err := ValidateProxyConfigurerForServer(cfg, &v1.ServerConfig{})
+	require.Error(err)
+	require.Contains(err.Error(), "type [https] not supported when vhost https port is not set")
+	require.Contains(err.Error(), "vhostHTTPSPort")
+}


### PR DESCRIPTION
## Summary

Fixes a common operator footgun (see #5097): starting an `http`/`https` proxy while frps has not enabled vhost ports yields a cryptic error with no hint of which config key to set.

Keep the historical phrase so existing docs/search still match, and append the concrete field name:

- `...; set vhostHTTPPort in frps configuration`
- `...; set vhostHTTPSPort in frps configuration`

## Test plan

- [x] `go test ./pkg/config/v1/validation/ -run TestValidateHTTP`
- Unit tests assert both the historical phrase and the config key hint