### PR TITLE
fix(util): bracket bare IPv6 in CanonicalAddr for default ports

### DIFF
--- a/pkg/util/util/util.go
+++ b/pkg/util/util/util.go
@@ -55,13 +55,19 @@ func GetAuthKey(token string, timestamp int64) (key string) {
 	return hex.EncodeToString(data)
 }
 
+// CanonicalAddr formats host:port for display/routing.
+// Default HTTP(S) ports 80/443 are omitted, but bare IPv6 literals are still
+// bracketed so the result is a valid host (e.g. "[::1]" not "::1").
 func CanonicalAddr(host string, port int) (addr string) {
-	if port == 80 || port == 443 {
-		addr = host
-	} else {
-		addr = net.JoinHostPort(host, strconv.Itoa(port))
+	if port != 80 && port != 443 {
+		return net.JoinHostPort(host, strconv.Itoa(port))
 	}
-	return
+	if host != "" && host[0] != '[' {
+		if ip := net.ParseIP(host); ip != nil && ip.To4() == nil {
+			return "[" + host + "]"
+		}
+	}
+	return host
 }
 
 func ParseRangeNumbers(rangeStr string) (numbers []int64, err error) {

--- a/pkg/util/util/util_test.go
+++ b/pkg/util/util/util_test.go
@@ -42,6 +42,24 @@ func TestParseRangeNumbers(t *testing.T) {
 	require.Error(err)
 }
 
+func TestCanonicalAddr(t *testing.T) {
+	require := require.New(t)
+
+	require.Equal("example.com", CanonicalAddr("example.com", 80))
+	require.Equal("example.com", CanonicalAddr("example.com", 443))
+	require.Equal("example.com:8080", CanonicalAddr("example.com", 8080))
+
+	// Bare IPv6 must stay bracketed even when the default port is omitted.
+	require.Equal("[::1]", CanonicalAddr("::1", 80))
+	require.Equal("[2001:db8::1]", CanonicalAddr("2001:db8::1", 443))
+	require.Equal("[::1]:8080", CanonicalAddr("::1", 8080))
+
+	// Already-bracketed IPv6 and IPv4 stay unchanged for default ports.
+	require.Equal("[::1]", CanonicalAddr("[::1]", 80))
+	require.Equal("127.0.0.1", CanonicalAddr("127.0.0.1", 80))
+	require.Equal("127.0.0.1:8443", CanonicalAddr("127.0.0.1", 8443))
+}
+
 func TestClonePtr(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
## Summary

`CanonicalAddr` omits ports 80/443, but for bare IPv6 hosts it returned the literal without brackets:

| input | before | after |
|-------|--------|-------|
| `("::1", 80)` | `::1` | `[::1]` |
| `("::1", 8080)` | `[::1]:8080` (already correct via `JoinHostPort`) | unchanged |
| `("example.com", 80)` | `example.com` | unchanged |

Used when reporting HTTP/HTTPS/TCPMux proxy addresses (`server/proxy/{http,https,tcpmux}.go`).

## Test plan

- [x] `go test ./pkg/util/util/`
- Added `TestCanonicalAddr` covering hostname, IPv4, bare IPv6, and already-bracketed IPv6