### PR TITLE
fix(util): skip empty segments in ParseRangeNumbers

### DIFF
--- a/pkg/util/util/util.go
+++ b/pkg/util/util/util.go
@@ -70,6 +70,11 @@ func ParseRangeNumbers(rangeStr string) (numbers []int64, err error) {
 	// e.g. 1000-2000,2001,2002,3000-4000
 	numRanges := strings.SplitSeq(rangeStr, ",")
 	for numRangeStr := range numRanges {
+		numRangeStr = strings.TrimSpace(numRangeStr)
+		// Tolerate trailing/duplicate commas: "1,2," or "1,,2".
+		if numRangeStr == "" {
+			continue
+		}
 		// 1000-2000 or 2001
 		numArray := strings.Split(numRangeStr, "-")
 		// length: only 1 or 2 is correct
@@ -77,7 +82,7 @@ func ParseRangeNumbers(rangeStr string) (numbers []int64, err error) {
 		switch rangeType {
 		case 1:
 			// single number
-			singleNum, errRet := strconv.ParseInt(strings.TrimSpace(numArray[0]), 10, 64)
+			singleNum, errRet := strconv.ParseInt(numArray[0], 10, 64)
 			if errRet != nil {
 				err = fmt.Errorf("range number is invalid, %v", errRet)
 				return

--- a/pkg/util/util/util_test.go
+++ b/pkg/util/util/util_test.go
@@ -40,6 +40,19 @@ func TestParseRangeNumbers(t *testing.T) {
 
 	_, err = ParseRangeNumbers("3-a")
 	require.Error(err)
+
+	// Empty segments from trailing/duplicate commas are ignored.
+	numbers, err = ParseRangeNumbers("1,2,")
+	require.NoError(err)
+	require.Equal([]int64{1, 2}, numbers)
+
+	numbers, err = ParseRangeNumbers("1,,3")
+	require.NoError(err)
+	require.Equal([]int64{1, 3}, numbers)
+
+	numbers, err = ParseRangeNumbers(",")
+	require.NoError(err)
+	require.Empty(numbers)
 }
 
 func TestClonePtr(t *testing.T) {


### PR DESCRIPTION
Trailing or duplicate commas (e.g. "1,2," or "1,,3") previously failed with strconv.ParseInt on an empty token. Skip blank segments so common config typos still parse cleanly.

### WHY

<!-- author to complete -->
