### PR TITLE
fix(util): do not panic in GenerateResponseErrorString on nil error

### DIFF
--- a/pkg/util/util/util.go
+++ b/pkg/util/util/util.go
@@ -111,7 +111,7 @@ func ParseRangeNumbers(rangeStr string) (numbers []int64, err error) {
 }
 
 func GenerateResponseErrorString(summary string, err error, detailed bool) string {
-	if detailed {
+	if detailed && err != nil {
 		return err.Error()
 	}
 	return summary

--- a/pkg/util/util/util_test.go
+++ b/pkg/util/util/util_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -53,4 +54,14 @@ func TestClonePtr(t *testing.T) {
 	require.NotNil(cloned)
 	require.Equal(v, *cloned)
 	require.NotSame(&v, cloned)
+}
+
+func TestGenerateResponseErrorString(t *testing.T) {
+	require := require.New(t)
+
+	require.Equal("summary", GenerateResponseErrorString("summary", nil, false))
+	// detailed + nil error must not panic and should fall back to summary
+	require.Equal("summary", GenerateResponseErrorString("summary", nil, true))
+	require.Equal("boom", GenerateResponseErrorString("summary", fmt.Errorf("boom"), true))
+	require.Equal("summary", GenerateResponseErrorString("summary", fmt.Errorf("boom"), false))
 }


### PR DESCRIPTION
When detailed=true and err is nil, calling err.Error() panics. Fall back to the summary string instead so response helpers stay safe.

### WHY

<!-- author to complete -->
