### PR TITLE
fix(limit): avoid hang when rate.Limiter burst is zero

### DIFF
--- a/pkg/util/limit/limit_test.go
+++ b/pkg/util/limit/limit_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The frp Authors
+package limit
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+func TestReaderZeroBurstDoesNotSpin(t *testing.T) {
+	require := require.New(t)
+	src := bytes.NewReader([]byte("hello"))
+	// Limiter with zero burst is invalid for WaitN-based limiting; we must not hang.
+	lim := rate.NewLimiter(rate.Inf, 0)
+	r := NewReader(src, lim)
+	buf := make([]byte, 8)
+	n, err := r.Read(buf)
+	require.NoError(err)
+	require.Equal(5, n)
+	require.Equal("hello", string(buf[:n]))
+}
+
+func TestWriterZeroBurstWritesThrough(t *testing.T) {
+	require := require.New(t)
+	var dst bytes.Buffer
+	lim := rate.NewLimiter(rate.Inf, 0)
+	w := NewWriter(&dst, lim)
+	n, err := w.Write([]byte("world"))
+	require.NoError(err)
+	require.Equal(5, n)
+	require.Equal("world", dst.String())
+}
+
+func TestReaderWriterRoundTrip(t *testing.T) {
+	require := require.New(t)
+	lim := rate.NewLimiter(rate.Limit(1e6), 4)
+	var buf bytes.Buffer
+	w := NewWriter(&buf, lim)
+	_, err := io.WriteString(w, "abcdefgh")
+	require.NoError(err)
+	r := NewReader(bytes.NewReader(buf.Bytes()), lim)
+	out, err := io.ReadAll(r)
+	require.NoError(err)
+	require.Equal("abcdefgh", string(out))
+}

--- a/pkg/util/limit/reader.go
+++ b/pkg/util/limit/reader.go
@@ -34,15 +34,18 @@ func NewReader(r io.Reader, limiter *rate.Limiter) *Reader {
 }
 
 func (r *Reader) Read(p []byte) (n int, err error) {
+	// Burst() of 0 would slice p to empty and spin; treat as unlimited for this read.
 	b := r.limiter.Burst()
-	if b < len(p) {
+	if b > 0 && b < len(p) {
 		p = p[:b]
 	}
 	n, err = r.r.Read(p)
 	if err != nil {
 		return
 	}
-
+	if n == 0 || b <= 0 {
+		return
+	}
 	err = r.limiter.WaitN(context.Background(), n)
 	if err != nil {
 		return

--- a/pkg/util/limit/writer.go
+++ b/pkg/util/limit/writer.go
@@ -34,8 +34,12 @@ func NewWriter(w io.Writer, limiter *rate.Limiter) *Writer {
 }
 
 func (w *Writer) Write(p []byte) (n int, err error) {
-	var nn int
 	b := w.limiter.Burst()
+	// Burst() of 0 would lock the write loop on empty chunks; write through unlimited.
+	if b <= 0 {
+		return w.w.Write(p)
+	}
+	var nn int
 	for {
 		end := len(p)
 		if end == 0 {


### PR DESCRIPTION
Reader used to slice the buffer to Burst() without guarding burst<=0, which yields an empty slice and can spin. Writer similarly chunked by zero burst. Pass through unlimited when burst is not positive.

### WHY

<!-- author to complete -->
