### PR TITLE
fix(util): make ConstantTimeEqString safe for unequal lengths

### DIFF
--- a/pkg/util/util/util.go
+++ b/pkg/util/util/util.go
@@ -131,7 +131,15 @@ func RandomSleep(duration time.Duration, minRatio, maxRatio float64) time.Durati
 	return d
 }
 
+// ConstantTimeEqString reports whether a and b are equal without leaking the
+// equality result via early-exit byte compares. Length mismatches still return
+// false without panicking (subtle.ConstantTimeCompare requires equal length).
 func ConstantTimeEqString(a, b string) bool {
+	if len(a) != len(b) {
+		// Still touch both sides so a pure length check is not the only work.
+		_ = subtle.ConstantTimeByteEq(byte(len(a)), byte(len(b)))
+		return false
+	}
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 

--- a/pkg/util/util/util_test.go
+++ b/pkg/util/util/util_test.go
@@ -54,3 +54,12 @@ func TestClonePtr(t *testing.T) {
 	require.Equal(v, *cloned)
 	require.NotSame(&v, cloned)
 }
+
+func TestConstantTimeEqString(t *testing.T) {
+	require := require.New(t)
+	require.True(ConstantTimeEqString("abc", "abc"))
+	require.False(ConstantTimeEqString("abc", "abd"))
+	require.False(ConstantTimeEqString("abc", "ab"))
+	require.False(ConstantTimeEqString("abc", "abcd"))
+	require.True(ConstantTimeEqString("", ""))
+}


### PR DESCRIPTION
Avoid relying on subtle.ConstantTimeCompare with unequal inputs; return false after a length mismatch without panicking.

### WHY

<!-- author to complete -->
