### PR TITLE
xtcp: add maxWorkConnections to limit concurrent work connection handlers

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -1,3 +1,7 @@
+## Features
+
+* Support `maxWorkConnections` for xtcp proxies to limit concurrently handled work connections. The default 0 means no limit.
+
 ## Fixes
 
 * Fixed control-session replacement leaks when frpc reconnects through a half-open TCP multiplexed connection.

--- a/Release.md
+++ b/Release.md
@@ -1,6 +1,7 @@
 ## Features
 
 * UDP packet payloads for ordinary UDP proxies and SUDP now use a dedicated binary codec when frpc and frps successfully negotiate the capability under wire protocol v2, using a more compact wire representation. Wire protocol v1 remains JSON; wire protocol v2 falls back to JSON `UDPPacket` when the peer does not support or did not negotiate the capability.
+* Support `maxWorkConnections` for xtcp proxies to limit concurrently handled work connections. The default 0 means no limit.
 
 ## Fixes
 

--- a/client/proxy/xtcp.go
+++ b/client/proxy/xtcp.go
@@ -17,6 +17,7 @@
 package proxy
 
 import (
+	"context"
 	"io"
 	"net"
 	"reflect"
@@ -41,6 +42,10 @@ type XTCPProxy struct {
 	*BaseProxy
 
 	cfg *v1.XTCPProxyConfig
+	// workConnSlots bounds the number of concurrently running work
+	// connection handlers when cfg.MaxWorkConnections is set. A nil
+	// channel means no limit.
+	workConnSlots chan struct{}
 }
 
 func NewXTCPProxy(baseProxy *BaseProxy, cfg v1.ProxyConfigurer) Proxy {
@@ -48,10 +53,14 @@ func NewXTCPProxy(baseProxy *BaseProxy, cfg v1.ProxyConfigurer) Proxy {
 	if !ok {
 		return nil
 	}
-	return &XTCPProxy{
+	pxy := &XTCPProxy{
 		BaseProxy: baseProxy,
 		cfg:       unwrapped,
 	}
+	if unwrapped.MaxWorkConnections > 0 {
+		pxy.workConnSlots = make(chan struct{}, unwrapped.MaxWorkConnections)
+	}
+	return pxy
 }
 
 func (pxy *XTCPProxy) InWorkConn(conn net.Conn, startWorkConnMsg *msg.StartWorkConn) {
@@ -173,7 +182,14 @@ func (pxy *XTCPProxy) listenByKCP(listenConn *net.UDPConn, raddr *net.UDPAddr, s
 			xl.Errorf("accept connection error: %v", err)
 			return
 		}
-		go pxy.HandleTCPWorkConnection(muxConn, startWorkConnMsg, []byte(pxy.cfg.Secretkey))
+		ok := runBoundedWorkConn(pxy.ctx, pxy.workConnSlots, func() {
+			pxy.HandleTCPWorkConnection(muxConn, startWorkConnMsg, []byte(pxy.cfg.Secretkey))
+		})
+		if !ok {
+			xl.Debugf("proxy context done while waiting for a work connection slot")
+			muxConn.Close()
+			return
+		}
 	}
 }
 
@@ -211,6 +227,37 @@ func (pxy *XTCPProxy) listenByQUIC(listenConn *net.UDPConn, _ *net.UDPAddr, star
 			_ = c.CloseWithError(0, "")
 			return
 		}
-		go pxy.HandleTCPWorkConnection(netpkg.QuicStreamToNetConn(stream, c), startWorkConnMsg, []byte(pxy.cfg.Secretkey))
+		conn := netpkg.QuicStreamToNetConn(stream, c)
+		ok := runBoundedWorkConn(pxy.ctx, pxy.workConnSlots, func() {
+			pxy.HandleTCPWorkConnection(conn, startWorkConnMsg, []byte(pxy.cfg.Secretkey))
+		})
+		if !ok {
+			xl.Debugf("proxy context done while waiting for a work connection slot")
+			conn.Close()
+			_ = c.CloseWithError(0, "")
+			return
+		}
 	}
+}
+
+// runBoundedWorkConn runs handler in a new goroutine. slots bounds the
+// number of concurrently running handlers; a nil slots means no limit.
+// When the limit is reached, it blocks until a running handler finishes,
+// applying backpressure to the accept loop. It returns false if ctx is
+// done before a slot becomes available.
+func runBoundedWorkConn(ctx context.Context, slots chan struct{}, handler func()) bool {
+	if slots == nil {
+		go handler()
+		return true
+	}
+	select {
+	case slots <- struct{}{}:
+	case <-ctx.Done():
+		return false
+	}
+	go func() {
+		defer func() { <-slots }()
+		handler()
+	}()
+	return true
 }

--- a/client/proxy/xtcp_test.go
+++ b/client/proxy/xtcp_test.go
@@ -17,7 +17,9 @@
 package proxy
 
 import (
+	"context"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -53,6 +55,79 @@ func TestReadNatHoleSidUsesSelectedWireProtocol(t *testing.T) {
 			require.Equal(t, "sid", out.Sid)
 			require.NoError(t, <-errCh)
 		})
+	}
+}
+
+func TestRunBoundedWorkConnAppliesBackpressure(t *testing.T) {
+	slots := make(chan struct{}, 2)
+	started := make(chan struct{}, 3)
+	dispatched := make(chan bool, 3)
+	release := make(chan struct{})
+
+	go func() {
+		for range 3 {
+			dispatched <- runBoundedWorkConn(context.Background(), slots, func() {
+				started <- struct{}{}
+				<-release
+			})
+		}
+	}()
+
+	// The first two handlers start immediately.
+	for range 2 {
+		requireRecv(t, started, "handler did not start")
+		require.True(t, <-dispatched)
+	}
+	// The third dispatch waits until a running handler finishes.
+	select {
+	case <-started:
+		t.Fatal("third handler started beyond the limit")
+	case <-time.After(50 * time.Millisecond):
+	}
+	release <- struct{}{}
+	requireRecv(t, started, "handler did not start after a slot was freed")
+	require.True(t, <-dispatched)
+	close(release)
+}
+
+func TestRunBoundedWorkConnUnlimitedByDefault(t *testing.T) {
+	const total = 5
+	var wg sync.WaitGroup
+	wg.Add(total)
+	block := make(chan struct{})
+	for range total {
+		require.True(t, runBoundedWorkConn(context.Background(), nil, func() {
+			wg.Done()
+			<-block
+		}))
+	}
+	// All handlers run concurrently without any dispatch blocking.
+	wg.Wait()
+	close(block)
+}
+
+func TestRunBoundedWorkConnReturnsFalseWhenContextDone(t *testing.T) {
+	slots := make(chan struct{}, 1)
+	release := make(chan struct{})
+	require.True(t, runBoundedWorkConn(context.Background(), slots, func() {
+		<-release
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.False(t, runBoundedWorkConn(ctx, slots, func() {
+		<-release
+	}))
+	close(release)
+}
+
+func requireRecv(t *testing.T, ch <-chan struct{}, msg string) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal(msg)
 	}
 }
 

--- a/conf/frpc_full_example.toml
+++ b/conf/frpc_full_example.toml
@@ -403,6 +403,10 @@ localPort = 22
 # If not empty, only visitors from specified users can connect.
 # Otherwise, visitors from same user can connect. '*' means allow all users.
 allowUsers = ["user1", "user2"]
+# Maximum number of work connections that are handled concurrently for this proxy.
+# When the limit is reached, newly accepted connections wait until a running one finishes.
+# Default: 0, which means no limit.
+maxWorkConnections = 0
 
 # NAT traversal configuration (optional)
 [proxies.natTraversal]

--- a/pkg/config/v1/proxy.go
+++ b/pkg/config/v1/proxy.go
@@ -477,6 +477,12 @@ type XTCPProxyConfig struct {
 	Secretkey  string   `json:"secretKey,omitempty"`
 	AllowUsers []string `json:"allowUsers,omitempty"`
 
+	// MaxWorkConnections specifies the maximum number of work connections
+	// that are handled concurrently for this proxy. When the limit is
+	// reached, newly accepted connections wait until a running handler
+	// finishes. By default, this value is 0, which means no limit.
+	MaxWorkConnections int `json:"maxWorkConnections,omitempty"`
+
 	// NatTraversal configuration for NAT traversal
 	NatTraversal *NatTraversalConfig `json:"natTraversal,omitempty"`
 }

--- a/pkg/config/v1/validation/proxy.go
+++ b/pkg/config/v1/validation/proxy.go
@@ -158,6 +158,9 @@ func validateSTCPProxyConfigForClient(c *v1.STCPProxyConfig) error {
 }
 
 func validateXTCPProxyConfigForClient(c *v1.XTCPProxyConfig) error {
+	if c.MaxWorkConnections < 0 {
+		return errors.New("maxWorkConnections should not be negative")
+	}
 	return nil
 }
 


### PR DESCRIPTION
### WHY

XTCP work connection accept loops start one handler goroutine per accepted connection with no cap. For KCP, `listenByKCP` in `client/proxy/xtcp.go` spawns a goroutine for every accepted yamux stream, so a peer that completed the hole punch and knows the secret key can drive a single frpc instance to an unbounded number of concurrent handler goroutines. The QUIC loop has the same shape. There is no per proxy setting to bound this today. This is an operational resilience gap, not a security issue, matching the framing in #5397.

This adds an optional `maxWorkConnections` setting to xtcp proxies. When set, both accept loops acquire a slot before starting a handler. When the limit is reached, newly accepted connections wait until a running handler finishes, so the accept loop applies backpressure and pending streams queue in the mux session, up to the mux's own backlog, instead of each getting a goroutine. The default 0 keeps the current unlimited behavior.

Design notes:

- The setting is client side only, following the `natTraversal` precedent from #4951: v1 config field plus `conf/frpc_full_example.toml`, no legacy ini mirror, not marshaled into `msg.NewProxy`.
- The QUIC loop is included so the option behaves the same regardless of which protocol the hole punch negotiates. `transport.quic.maxIncomingStreams` already bounds QUIC streams at the transport layer, but it is a client wide setting with a default of 100000, not a per proxy limit.
- Behavior at the limit is backpressure rather than rejecting connections. This is the simpler of the two options suggested in the issue and avoids inventing a rejection policy. If rejecting is preferred I can change it.

Fixes #5397
