### PR TITLE
update quic-go dependency to v0.60.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.0
 	github.com/pires/go-proxyproto v0.7.0
 	github.com/prometheus/client_golang v1.19.1
-	github.com/quic-go/quic-go v0.55.0
+	github.com/quic-go/quic-go v0.60.0
 	github.com/rodaine/table v1.2.0
 	github.com/samber/lo v1.47.0
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
@@ -64,7 +64,6 @@ require (
 	github.com/tjfoc/gmsm v1.4.1 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
-	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,10 @@ github.com/prometheus/common v0.48.0 h1:QO8U2CdOzSn1BBsmXJXduaaW+dY/5QLjfB8svtSz
 github.com/prometheus/common v0.48.0/go.mod h1:0/KsvlIEfPQCQ5I2iNSAWKPZziNCvRs5EC6ILDTlAPc=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/quic-go/quic-go v0.55.0 h1:zccPQIqYCXDt5NmcEabyYvOnomjs8Tlwl7tISjJh9Mk=
-github.com/quic-go/quic-go v0.55.0/go.mod h1:DR51ilwU1uE164KuWXhinFcKWGlEjzys2l8zUl5Ss1U=
+github.com/quic-go/go-ossfuzz-seeds v0.1.0 h1:APacT+iIaNF6fd8AGEiN3bT/Jtkd2jz4v4TzM7MFjy0=
+github.com/quic-go/go-ossfuzz-seeds v0.1.0/go.mod h1:3IOHRbJIc+L6YKMwfDtJAM9Vj9k0YY4muhuyUYk5tbk=
+github.com/quic-go/quic-go v0.60.0 h1:xcQioE8OM66UQLeUMHltK1CCcOu3JbVB4JAQdDQSB+0=
+github.com/quic-go/quic-go v0.60.0/go.mod h1:wpKpjmPpftl30sL6pFh7REVpjbcCVy4zt2vDyK1TuJk=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rodaine/table v1.2.0 h1:38HEnwK4mKSHQJIkavVj+bst1TEY7j9zhLMWu4QJrMA=
@@ -155,8 +157,6 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
-golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
## Summary

- Upgrade `github.com/quic-go/quic-go` from v0.55.0 to v0.60.0.
- Tidy the expected dependency changes, including `qpack` v0.6.0 and `go-ossfuzz-seeds`; remove the root module's redundant explicit `x/mod` requirement while MVS still selects `x/mod` through `x/text` and `x/tools`.
- The upgrade removes the targeted `GO-2025-4233` (fixed in quic-go v0.57.0) and `GO-2026-5676` (fixed in v0.59.1) findings.
- FRP does not import `quic-go/http3` or `qpack` and uses the private ALPN `frp`, so the affected HTTP/3 paths are not in the current call graph.

## Validation

- `go mod tidy`, `go mod verify`, `go list -m all`, `go mod graph`, and `go list -tags noweb -deps ./...` passed.
- `govulncheck -scan=package -show=verbose ./...` and the targeted symbol scan completed; the two targeted quic-go IDs are absent. The commands still exit 3 for unrelated findings documented below.
- Targeted package tests, race tests, `make test`, `make vet`, and `make build` passed.
- After base refresh to `origin/dev` `898bcf73d55b254fdcd71cdcf5cac6d81a5c97d8` (PR #5415), both dashboard `vue-tsc --noEmit` plus Vite production builds passed; embedded-web `make build` and `make test` passed; npm audit reported 0 vulnerabilities and no web/package-lock diff was produced.
- Focused QUIC E2E passed: 13/13 specs, 0 failed, 232 skipped.
- The deterministic XTCP QUIC probe passed `MakeHole -> quic.Listen/quic.Dial -> stream open/accept/read/write/close` on loopback.
- Linux amd64, Windows amd64, and Darwin arm64 frpc/frps cross-builds passed.
- The final fresh interactive Codex review found no actionable correctness regression.

## Boundaries

- The XTCP probe is deterministic loopback synthetic coverage. It does not cover STUN discovery, public NAT mappings, NAT type classification, port rewriting, or cross-network UDP; real public STUN/NAT validation remains an independent risk.
- govulncheck still reports `GO-2026-5932` as a module-level, unreachable `golang.org/x/crypto/openpgp` advisory with Fixed in N/A, plus Go 1.25.4 standard-library findings. FRP's noweb package graph contains no `openpgp` package or subpackage.
- A default `go test ./...` from a clean checkout can be blocked by missing web embed directories and E2E binaries; the required web builds, embedded `make build`, embedded `make test`, and focused E2E were run explicitly.

This is a single-commit dependency-only PR. The research report remains intentionally untracked and is not part of the PR.
