### PR TITLE
web/frpc: fix visitor plugin validation for SUDP

### DIFF
--- a/web/frpc/src/views/VisitorEdit.vue
+++ b/web/frpc/src/views/VisitorEdit.vue
@@ -110,7 +110,11 @@ const formRules: FormRules = {
   pluginDestinationIP: [
     {
       validator: (_rule, value, callback) => {
-        if (form.value.pluginType === 'virtual_net' && !value?.trim()) {
+        if (
+          form.value.pluginType === 'virtual_net' &&
+          (form.value.type === 'stcp' || form.value.type === 'xtcp') &&
+          !value?.trim()
+        ) {
           callback(new Error('Destination IP is required for virtual_net'))
           return
         }


### PR DESCRIPTION
## Summary

- gate `pluginDestinationIP` validation to STCP/XTCP visitors
- allow SUDP forms to save when stale visitor plugin fields are hidden
- preserve plugin draft values when switching visitor types while relying on existing converter gates to keep them out of SUDP payloads

## Verification

- `npm run lint --workspace frpc`
- `npm run type-check --workspace frpc`
- `npm run build --workspace frpc`
- `git diff --check`

Follow-up to #5414.