### PR TITLE
web: fix Vite config tsconfig includes

### DIFF
--- a/web/frpc/tsconfig.node.json
+++ b/web/frpc/tsconfig.node.json
@@ -6,5 +6,5 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.mts"]
 }

--- a/web/frpc/vite.config.mts
+++ b/web/frpc/vite.config.mts
@@ -28,15 +28,10 @@ export default defineConfig({
       '@shared': fileURLToPath(new URL('../shared', import.meta.url)),
     },
     dedupe: ['vue', 'element-plus', '@element-plus/icons-vue'],
-    modules: [
-      fileURLToPath(new URL('../node_modules', import.meta.url)),
-      'node_modules',
-    ],
   },
   css: {
     preprocessorOptions: {
       scss: {
-        api: 'modern',
         additionalData: `@use "@shared/css/_index.scss" as *;`,
       },
     },

--- a/web/frps/tsconfig.node.json
+++ b/web/frps/tsconfig.node.json
@@ -6,5 +6,5 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.mts"]
 }

--- a/web/frps/vite.config.mts
+++ b/web/frps/vite.config.mts
@@ -28,15 +28,10 @@ export default defineConfig({
       '@shared': fileURLToPath(new URL('../shared', import.meta.url)),
     },
     dedupe: ['vue', 'element-plus', '@element-plus/icons-vue'],
-    modules: [
-      fileURLToPath(new URL('../node_modules', import.meta.url)),
-      'node_modules',
-    ],
   },
   css: {
     preprocessorOptions: {
       scss: {
-        api: 'modern',
         additionalData: `@use "@shared/css/_index.scss" as *;`,
       },
     },


### PR DESCRIPTION
## Summary
- Point both dashboard node tsconfig files at the existing `vite.config.mts`.
- Remove Vite 7-incompatible `resolve.modules` and `css.preprocessorOptions.scss.api` options from both dashboard configs.

## Tests
- `npm ci`
- Direct `tsc --noEmit` for both node configs
- Workspace `vue-tsc --noEmit` for both dashboards
- Read-only `eslint .` for both dashboards
- Production `npm run build` for both dashboards