### PR TITLE
ci: attach provenance and SBOM attestations to the published images

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -67,6 +67,8 @@ jobs:
           file: ./dockerfiles/Dockerfile-for-frpc
           platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
           push: true
+          provenance: mode=max
+          sbom: true
           tags: |
             ${{ env.TAG_FRPC }}
             ${{ env.TAG_FRPC_GPR }}
@@ -78,6 +80,8 @@ jobs:
           file: ./dockerfiles/Dockerfile-for-frps
           platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
           push: true
+          provenance: mode=max
+          sbom: true
           tags: |
             ${{ env.TAG_FRPS }}
             ${{ env.TAG_FRPS_GPR }}


### PR DESCRIPTION
Hi, and thanks for frp.

`.github/workflows/build-and-push-image.yml` pushes four images on every release — `fatedier/frpc` and `fatedier/frps` to Docker Hub, and the same two to `ghcr.io` — but the manifests carry no provenance or SBOM attestation. Someone pulling `fatedier/frps:latest` has no way to check that the image was built by this workflow, from this repository, at that tag.

frp is usually deployed as an edge service with a public listener, and the image is very often pulled straight into a `docker run` or compose file. That combination is why this seemed worth raising rather than left alone.

The change is two lines on each of the two build steps:

```yaml
      - name: Build and push frpc
        uses: docker/build-push-action@v7
        with:
          ...
          push: true
          provenance: mode=max
          sbom: true
```

I used BuildKit's own attestation support rather than a separate signing action, for a specific reason: you push the same build to two registries in one step, and BuildKit attaches the attestation to the image manifest itself, so both Docker Hub and GHCR get it without any extra plumbing. It also means **no permissions change** — the workflow keeps `contents: read` exactly as it is, and nothing needs `id-token`.

After a release, consumers can check with:

```
docker buildx imagetools inspect ghcr.io/fatedier/frps:<tag> --format '{{ json .Provenance }}'
```

Two honest caveats:

- `mode=max` records the full build, including the Dockerfile and build arguments. That is normally what you want for a public image, but if any of your build args were ever sensitive it is worth a look before merging — `provenance: true` gives a smaller record if you would prefer.
- Attestations add an extra manifest to the index. Docker Hub and GHCR both handle this, but a very old registry mirror in front of them might not. Worth knowing if you have one in the path.

I have not claimed a SLSA level here — the attestation is what BuildKit produces, and how the overall build should be characterised is your call.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow and its push targets myself.
