### PR TITLE
docs: add release note for #5456

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -1,3 +1,7 @@
+## Features
+
+* Ordinary UDP proxy payloads now use a dedicated binary codec when frpc and frps successfully negotiate the capability under wire protocol v2, reducing frame size and encoding/decoding overhead. Wire protocol v1 and SUDP remain unchanged; wire protocol v2 falls back to JSON `UDPPacket` when the peer does not support or did not negotiate the capability.
+
 ## Fixes
 
 * HTTP vhost servers no longer support HTTP/1.1 `Upgrade: h2c` requests. Cleartext HTTP/2 prior-knowledge remains supported.

--- a/Release.md
+++ b/Release.md
@@ -1,9 +1,3 @@
 ## Features
 
 * Ordinary UDP proxy payloads now use a dedicated binary codec when frpc and frps successfully negotiate the capability under wire protocol v2, reducing frame size and encoding/decoding overhead. Wire protocol v1 and SUDP remain unchanged; wire protocol v2 falls back to JSON `UDPPacket` when the peer does not support or did not negotiate the capability.
-
-## Fixes
-
-* HTTP vhost servers no longer support HTTP/1.1 `Upgrade: h2c` requests. Cleartext HTTP/2 prior-knowledge remains supported.
-* Fixed control-session replacement leaks when frpc reconnects through a half-open TCP multiplexed connection.
-* Fixed an SSH tunnel gateway panic when handling malformed exec requests.


### PR DESCRIPTION
## Summary

- Add a user-facing release note for #5456 under `Features`.
- Document the negotiated wire protocol v2 binary codec for ordinary UDP proxy payloads and its frame-size and encoding/decoding overhead benefits.
- Keep only this new-version feature note; remove the previous version's `Fixes` entries.

## Compatibility

- Wire protocol v1 and SUDP remain unchanged.
- Wire protocol v2 falls back to JSON `UDPPacket` when the peer does not support or did not negotiate the binary capability.

## Testing

- `git diff --check`
- CircleCI `go-version-latest`
- `golangci-lint/lint`
- Kilo Code Review