### PR TITLE
fix: support large UDP packets over wire protocol v1

### DIFF
--- a/pkg/msg/ctl.go
+++ b/pkg/msg/ctl.go
@@ -22,13 +22,25 @@ import (
 
 type Message = jsonMsg.Message
 
-var msgCtl *jsonMsg.MsgCtl
+var (
+	msgCtl    *jsonMsg.MsgCtl
+	udpMsgCtl *jsonMsg.MsgCtl
+)
 
 func init() {
-	msgCtl = jsonMsg.NewMsgCtl()
-	for typeByte, msg := range msgTypeMap {
-		msgCtl.RegisterMsg(typeByte, msg)
+	msgCtl = newMsgCtl(0)
+	udpMsgCtl = newMsgCtl(maxV1UDPPacketMessageSize)
+}
+
+func newMsgCtl(maxMessageLength int64) *jsonMsg.MsgCtl {
+	ctl := jsonMsg.NewMsgCtl()
+	if maxMessageLength > 0 {
+		ctl.SetMaxMsgLength(maxMessageLength)
 	}
+	for typeByte, msg := range msgTypeMap {
+		ctl.RegisterMsg(typeByte, msg)
+	}
+	return ctl
 }
 
 func ReadMsg(c io.Reader) (msg Message, err error) {

--- a/pkg/msg/handler.go
+++ b/pkg/msg/handler.go
@@ -20,6 +20,8 @@ import (
 	"net"
 	"reflect"
 
+	jsonMsg "github.com/fatedier/golib/msg/json"
+
 	"github.com/fatedier/frp/pkg/proto/wire"
 )
 
@@ -67,11 +69,16 @@ func (c *Conn) WithContext(ctx context.Context) {
 }
 
 type V1ReadWriter struct {
-	rw io.ReadWriter
+	rw     io.ReadWriter
+	msgCtl *jsonMsg.MsgCtl
 }
 
 func NewV1ReadWriter(rw io.ReadWriter) ReadWriter {
-	return &V1ReadWriter{rw: rw}
+	return newV1ReadWriter(rw, msgCtl)
+}
+
+func newV1ReadWriter(rw io.ReadWriter, ctl *jsonMsg.MsgCtl) ReadWriter {
+	return &V1ReadWriter{rw: rw, msgCtl: ctl}
 }
 
 // NewReadWriter wraps rw with the message codec for the selected wire protocol.
@@ -88,15 +95,15 @@ func NewReadWriter(rw io.ReadWriter, wireProtocol string) ReadWriter {
 }
 
 func (rw *V1ReadWriter) ReadMsg() (Message, error) {
-	return ReadMsg(rw.rw)
+	return rw.msgCtl.ReadMsg(rw.rw)
 }
 
 func (rw *V1ReadWriter) ReadMsgInto(m Message) error {
-	return ReadMsgInto(rw.rw, m)
+	return rw.msgCtl.ReadMsgInto(rw.rw, m)
 }
 
 func (rw *V1ReadWriter) WriteMsg(m Message) error {
-	return WriteMsg(rw.rw, m)
+	return rw.msgCtl.WriteMsg(rw.rw, m)
 }
 
 func AsyncHandler(f func(Message)) func(Message) {

--- a/pkg/msg/udp_binary.go
+++ b/pkg/msg/udp_binary.go
@@ -26,6 +26,10 @@ import (
 
 const MaxUDPPayloadSize = 65507
 
+// V1 JSON encoding expands binary payloads with base64. Keep the larger bound
+// local to UDP work connections instead of relaxing the control-plane limit.
+const maxV1UDPPacketMessageSize = 128 * 1024
+
 const (
 	udpPacketFlagLocalAddr  byte = 1 << 0
 	udpPacketFlagRemoteAddr byte = 1 << 1
@@ -322,7 +326,7 @@ func NewUDPPacketReadWriter(rw io.ReadWriter, wireProtocol, udpPacketCodec strin
 		if udpPacketCodec != "" {
 			return nil, fmt.Errorf("UDP packet codec %q requires wire protocol v2", udpPacketCodec)
 		}
-		return NewV1ReadWriter(rw), nil
+		return newV1ReadWriter(rw, udpMsgCtl), nil
 	case wire.ProtocolV2:
 		switch udpPacketCodec {
 		case "":

--- a/pkg/msg/udp_binary_test.go
+++ b/pkg/msg/udp_binary_test.go
@@ -201,6 +201,47 @@ func TestNewUDPPacketReadWriterDefaultProtocolUsesV1(t *testing.T) {
 	require.Equal(t, TypeUDPPacket, stream.Bytes()[0])
 }
 
+func TestNewUDPPacketReadWriterV1SupportsLargePayload(t *testing.T) {
+	for _, tc := range []struct {
+		size     int
+		readInto bool
+	}{
+		{size: 10 * 1024},
+		{size: MaxUDPPayloadSize, readInto: true},
+	} {
+		t.Run(strconv.Itoa(tc.size), func(t *testing.T) {
+			in := &UDPPacket{
+				Content:    bytes.Repeat([]byte{0xa5}, tc.size),
+				RemoteAddr: &net.UDPAddr{IP: net.ParseIP("203.0.113.9"), Port: 54321},
+			}
+			var stream bytes.Buffer
+			writer, err := NewUDPPacketReadWriter(&stream, wire.ProtocolV1, "")
+			require.NoError(t, err)
+			require.NoError(t, writer.WriteMsg(in))
+
+			reader, err := NewUDPPacketReadWriter(&stream, wire.ProtocolV1, "")
+			require.NoError(t, err)
+			var out *UDPPacket
+			if tc.readInto {
+				out = &UDPPacket{}
+				require.NoError(t, reader.ReadMsgInto(out))
+			} else {
+				message, err := reader.ReadMsg()
+				require.NoError(t, err)
+				out = message.(*UDPPacket)
+			}
+			require.Equal(t, in.Content, out.Content)
+			require.Equal(t, in.RemoteAddr.String(), out.RemoteAddr.String())
+		})
+	}
+
+	var controlStream bytes.Buffer
+	controlRW := NewV1ReadWriter(&controlStream)
+	require.NoError(t, controlRW.WriteMsg(&UDPPacket{Content: bytes.Repeat([]byte{0xa5}, 10*1024)}))
+	_, err := controlRW.ReadMsg()
+	require.ErrorContains(t, err, "message length exceed the limit")
+}
+
 func TestNewUDPPacketReadWriterRejectsInvalidSelection(t *testing.T) {
 	for _, tc := range []struct {
 		name           string


### PR DESCRIPTION
### WHY

The default v1 wire protocol base64-encodes UDP payloads in JSON. A configured 10,240-byte datagram therefore exceeds the generic 10,240-byte message limit and closes the UDP work connection. This change gives only v1 UDP work connections enough bounded headroom for the maximum UDP datagram while leaving the control-plane limit unchanged.

## Summary

- Fixes: With the default v1 wire protocol, a 10,240-byte UDP datagram configured through udpPacketSize closes the work connection with 'message length exceed the limit'.
- Root cause: V1 encodes the byte payload as base64 JSON, but UDP work connections shared the generic 10,240-byte V1 reader limit, so the encoded message was rejected before forwarding.

## Regression evidence

- Before: `go test ./pkg/msg -run '^TestNewUDPPacketReadWriterV1SupportsLargePayload$' -count=1 -v` exited `1`

- After: `go test ./pkg/msg -run '^TestNewUDPPacketReadWriterV1SupportsLargePayload$' -count=1 -v` exited `0`

## Verification

- `go test ./pkg/msg -count=1`
- `make test`
- `go test -race ./pkg/msg -run 'TestNewUDPPacketReadWriter(DefaultProtocolUsesV1|V1SupportsLargePayload)' -count=1`
- `make vet`
- `make build`
- `make web-ci`
- `golangci-lint run -v (v2.11.0)`

Local `make e2e` was also attempted, but this managed host kills `frpc` with exit 137 before a scenario can start, so E2E is not claimed as passing.

## Scope

- 4 files changed, +73 / -9 lines

## Authorship

This fix was developed with AI assistance and was validated with the regression and project checks listed above.
