### PR TITLE
remove retired Go Report Card badge from Chinese README

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://circleci.com/gh/fatedier/frp.svg?style=shield)](https://circleci.com/gh/fatedier/frp)
 [![GitHub release](https://img.shields.io/github/tag/fatedier/frp.svg?label=release)](https://github.com/fatedier/frp/releases)
-[![Go Report Card](https://goreportcard.com/badge/github.com/fatedier/frp)](https://goreportcard.com/report/github.com/fatedier/frp)
 [![GitHub Releases Stats](https://img.shields.io/github/downloads/fatedier/frp/total.svg?logo=github)](https://somsubhra.github.io/github-release-stats/?username=fatedier&repository=frp)
 
 [README](README.md) | [中文文档](README_zh.md)


### PR DESCRIPTION
### WHY

Go Report Card has been retired, so its badge no longer provides a repository grade. The primary README already removed the badge in #5409; this removes the remaining reference from `README_zh.md`.

Documentation-only change; validated with `git diff --check`.