### PR TITLE
docs(config/legacy): fix truncated struct comments in LocalSvrConf

### DIFF
--- a/pkg/config/legacy/proxy.go
+++ b/pkg/config/legacy/proxy.go
@@ -93,16 +93,16 @@ func NewProxyConfFromIni(prefix, name string, section *ini.Section) (ProxyConf, 
 	return conf, nil
 }
 
-// LocalSvrConf configures what location the client will to, or what
+// LocalSvrConf configures what location the client will forward to, or what
 // plugin will be used.
 type LocalSvrConf struct {
-	// LocalIP specifies the IP address or host name to to.
+	// LocalIP specifies the IP address or host name of the backend.
 	LocalIP string `ini:"local_ip" json:"local_ip"`
-	// LocalPort specifies the port to to.
+	// LocalPort specifies the port of the backend.
 	LocalPort int `ini:"local_port" json:"local_port"`
 
-	// Plugin specifies what plugin should be used for ng. If this value
-	// is set, the LocalIp and LocalPort values will be ignored. By default,
+	// Plugin specifies what plugin should be used for handling connections. If this value
+	// is set, the LocalIP and LocalPort values will be ignored. By default,
 	// this value is "".
 	Plugin string `ini:"plugin" json:"plugin"`
 	// PluginParams specify parameters to be passed to the plugin, if one is


### PR DESCRIPTION
### WHY

The legacy `LocalSvrConf` struct doc comments were corrupted by an over-broad word replacement, producing fragments that no longer read as English:

- `LocalSvrConf configures what location the client will to` → missing verb (`will to`)
- `LocalIP specifies the IP address or host name to to` → duplicated `to`
- `LocalPort specifies the port to to` → duplicated `to`
- `Plugin specifies what plugin should be used for ng` → truncated (`for ng`)

These are the only occurrences of such corruption in `pkg/config/legacy`; the rest of the file is intact, so this looks like a localized bad find/replace rather than a systemic issue.

### WHAT

Restore the intended wording, matching the equivalent v1 comments in `pkg/config/v1/proxy.go` (`ProxyBackend`):

- `will forward to`
- `of the backend` (for both `LocalIP` and `LocalPort`)
- `for handling connections`

Also fix the field reference `LocalIp` → `LocalIP` to match the actual Go field name, so godoc renders the reference correctly.

Pure doc/comment change; no code or behavior touched.