### PR TITLE
feat: log source IP for visitor connections

### DIFF
--- a/client/visitor/stcp.go
+++ b/client/visitor/stcp.go
@@ -64,7 +64,7 @@ func (sv *STCPVisitor) handleConn(userConn net.Conn) {
 		userConn.Close()
 	}()
 
-	xl.Debugf("get a new stcp user connection")
+	xl.Infof("get a new stcp user connection from [%s]", userConn.RemoteAddr().String())
 	visitorConn, err := sv.dialRawVisitorConn(sv.cfg.GetBaseConfig())
 	if err != nil {
 		xl.Warnf("dialRawVisitorConn error: %v", err)

--- a/client/visitor/sudp.go
+++ b/client/visitor/sudp.go
@@ -90,6 +90,10 @@ func (sv *SUDPVisitor) dispatcher() {
 			return
 		}
 
+		if firstPacket.RemoteAddr != nil {
+			xl.Infof("get a new sudp user connection from [%s]", firstPacket.RemoteAddr.String())
+		}
+
 		visitorConn, recycleFn, err = sv.getNewVisitorConn()
 		if err != nil {
 			xl.Warnf("newVisitorConn to frps error: %v, try to reconnect", err)

--- a/client/visitor/xtcp.go
+++ b/client/visitor/xtcp.go
@@ -153,7 +153,7 @@ func (sv *XTCPVisitor) handleConn(userConn net.Conn) {
 		}
 	}()
 
-	xl.Debugf("get a new xtcp user connection")
+	xl.Infof("get a new xtcp user connection from [%s]", userConn.RemoteAddr().String())
 
 	// Open a tunnel connection to the server. If there is already a successful hole-punching connection,
 	// it will be reused. Otherwise, it will block and wait for a successful hole-punching connection until timeout.

--- a/server/service.go
+++ b/server/service.go
@@ -522,13 +522,14 @@ func (svr *Service) handleConnection(ctx context.Context, conn net.Conn, interna
 		}
 	case *msg.NewVisitorConn:
 		if err = svr.RegisterVisitorConn(conn, m, acceptedConn.wireProtocol); err != nil {
-			xl.Warnf("register visitor conn error: %v", err)
+			xl.Warnf("register visitor conn from [%s] for proxy [%s] error: %v", conn.RemoteAddr().String(), m.ProxyName, err)
 			_ = acceptedConn.conn.WriteMsg(&msg.NewVisitorConnResp{
 				ProxyName: m.ProxyName,
 				Error:     util.GenerateResponseErrorString("register visitor conn error", err, lo.FromPtr(svr.cfg.DetailedErrorsToClient)),
 			})
 			conn.Close()
 		} else {
+			xl.Infof("get a new visitor connection from [%s] for proxy [%s]", conn.RemoteAddr().String(), m.ProxyName)
 			_ = acceptedConn.conn.WriteMsg(&msg.NewVisitorConnResp{
 				ProxyName: m.ProxyName,
 				Error:     "",

--- a/server/service.go
+++ b/server/service.go
@@ -529,7 +529,7 @@ func (svr *Service) handleConnection(ctx context.Context, conn net.Conn, interna
 			})
 			conn.Close()
 		} else {
-			xl.Infof("get a new visitor connection from [%s] for proxy [%s]", conn.RemoteAddr().String(), m.ProxyName)
+			xl.Infof("get a new visitor user connection from [%s] for proxy [%s]", conn.RemoteAddr().String(), m.ProxyName)
 			_ = acceptedConn.conn.WriteMsg(&msg.NewVisitorConnResp{
 				ProxyName: m.ProxyName,
 				Error:     "",


### PR DESCRIPTION
Close #5486

Log the source IP of visitor connections at Info level so users can integrate with tools like fail2ban for brute-force protection:

1. `server/service.go` (`NewVisitorConn` case): log visitor connection arrival with source IP and proxy name at Info level; include source IP in the existing Warn-level error log
2. `client/visitor/stcp.go`: upgrade connection log from Debug to Info, include `userConn.RemoteAddr()`
3. `client/visitor/xtcp.go`: same as STCP
4. `client/visitor/sudp.go`: log `firstPacket.RemoteAddr` at Info level when a new UDP session starts

Log format follows the existing pattern `get a user connection [%s]` in `server/proxy/proxy.go`, and all messages contain `get a new ... user connection from [<ip>]` so a single fail2ban filter matches both frps and frpc lines, e.g.:

``
get a new stcp user connection from [1.2.3.4:5678]
get a new visitor user connection from [1.2.3.4:5678] for proxy [ssh]
``

Verified with `go build ./...`, `go vet`, and `go test ./server/... ./client/...` (all passing).