### PR TITLE
fix(server): avoid extra work connection request when pool is empty

### DIFF
--- a/server/control.go
+++ b/server/control.go
@@ -610,6 +610,10 @@ func (ctl *Control) GetWorkConn() (workConn *proxy.WorkConn, err error) {
 			return
 		}
 		xl.Debugf("get work connection from pool")
+
+    // When we get a work connection from pool, replace it with a new one.
+    _ = ctl.msgDispatcher.Send(&msg.ReqWorkConn{})
+
 	default:
 		// no work connections available in the poll, send message to frpc to get more
 		if err := ctl.msgDispatcher.Send(&msg.ReqWorkConn{}); err != nil {
@@ -631,8 +635,6 @@ func (ctl *Control) GetWorkConn() (workConn *proxy.WorkConn, err error) {
 		}
 	}
 
-	// When we get a work connection from pool, replace it with a new one.
-	_ = ctl.msgDispatcher.Send(&msg.ReqWorkConn{})
 	return
 }
 

--- a/server/control.go
+++ b/server/control.go
@@ -611,8 +611,8 @@ func (ctl *Control) GetWorkConn() (workConn *proxy.WorkConn, err error) {
 		}
 		xl.Debugf("get work connection from pool")
 
-    // When we get a work connection from pool, replace it with a new one.
-    _ = ctl.msgDispatcher.Send(&msg.ReqWorkConn{})
+		// When we get a work connection from pool, replace it with a new one.
+		_ = ctl.msgDispatcher.Send(&msg.ReqWorkConn{})
 
 	default:
 		// no work connections available in the poll, send message to frpc to get more


### PR DESCRIPTION
### WHY

Fixes #5460.

Issue #5460 was initially reported as repeated:

`work connection pool is full, discarding`

errors while TCP multiplexing is enabled, even though proxy traffic continues to work normally.

After investigating `Control.GetWorkConn()`, it appears that an unnecessary `ReqWorkConn` can be sent when the work connection pool is empty.

There are two paths in `GetWorkConn()`:

1. **A work connection is available in the pool**

   frps takes the connection from the pool and should request one new connection from frpc to replace the consumed pooled connection.

2. **The pool is empty**

   frps sends `ReqWorkConn` and waits for the requested connection so it can immediately use it for the current user connection.

Currently, after either path completes, frps sends another unconditional `ReqWorkConn`.

This means that in the second case, where the pool was empty, frps effectively does:

```text
pool empty
  -> request work connection
  -> receive work connection
  -> use work connection
  -> request another work connection
```

The second request is not replacing a connection taken from the pool. The connection was requested specifically for the current user connection.

Under concurrent traffic, these additional requests can create surplus work connections. They can accumulate in `workConnCh` until the channel is full, resulting in:

```text
work connection pool is full, discarding
```

This PR moves the replacement `ReqWorkConn` into the branch where a work connection was actually taken from the pool.

After the change, the behavior becomes:

```text
Pool hit:
  take pooled connection
  -> request one replacement

Pool miss:
  request connection
  -> receive it
  -> use it directly
  -> no additional replacement request
```

This keeps the existing connection-pool behavior while avoiding an additional work connection request when the pool was already empty.

The intention is to address the cause of the errors reported in #5460 rather than suppressing or changing the log message.
