### PR TITLE
ci: pin golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,4 +28,4 @@ jobs:
       uses: golangci/golangci-lint-action@v9
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v2.11
+        version: v2.12.2


### PR DESCRIPTION
## Summary

- Pin golangci-lint to the exact `v2.12.2` release instead of the floating `v2.11` patch selection.
- Keep the action, Go, Node, and lint configuration unchanged.

## Validation

- `golangci-lint config verify`
- `golangci-lint run` (`0 issues`)
- `make web-ci`
- `make gotest`