### PR TITLE
deps: migrate to fatedier/yamux v0.2.0

### DIFF
--- a/client/connector.go
+++ b/client/connector.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	libnet "github.com/fatedier/golib/net"
-	fmux "github.com/hashicorp/yamux"
+	fmux "github.com/fatedier/yamux"
 	quic "github.com/quic-go/quic-go"
 	"github.com/samber/lo"
 

--- a/client/proxy/xtcp.go
+++ b/client/proxy/xtcp.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"time"
 
-	fmux "github.com/hashicorp/yamux"
+	fmux "github.com/fatedier/yamux"
 	"github.com/quic-go/quic-go"
 
 	v1 "github.com/fatedier/frp/pkg/config/v1"

--- a/client/visitor/xtcp.go
+++ b/client/visitor/xtcp.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	libio "github.com/fatedier/golib/io"
-	fmux "github.com/hashicorp/yamux"
+	fmux "github.com/fatedier/yamux"
 	quic "github.com/quic-go/quic-go"
 	"golang.org/x/time/rate"
 

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/fatedier/golib v0.8.2
+	github.com/fatedier/yamux v0.2.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.0
-	github.com/hashicorp/yamux v0.1.1
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.36.3
 	github.com/pelletier/go-toml/v2 v2.2.0
@@ -73,6 +73,3 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-// TODO(fatedier): Temporary use the modified version, update to the official version after merging into the official repository.
-replace github.com/hashicorp/yamux => github.com/fatedier/yamux v0.0.0-20250825093530-d0154be01cd6

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatedier/golib v0.8.2 h1:02n2Dg7KJ7rR7p7n4/6hBUjaLQf2J7EiHYZQsgGTvww=
 github.com/fatedier/golib v0.8.2/go.mod h1:ArUGvPg2cOw/py2RAuBt46nNZH2VQ5Z70p109MAZpJw=
-github.com/fatedier/yamux v0.0.0-20250825093530-d0154be01cd6 h1:u92UUy6FURPmNsMBUuongRWC0rBqN6gd01Dzu+D21NE=
-github.com/fatedier/yamux v0.0.0-20250825093530-d0154be01cd6/go.mod h1:c5/tk6G0dSpXGzJN7Wk1OEie8grdSJAmeawId9Zvd34=
+github.com/fatedier/yamux v0.2.0 h1:H+2A9iBVh7aJlEOc1Ws1FXWOaecBf2nRv9zpFMPUWg8=
+github.com/fatedier/yamux v0.2.0/go.mod h1:d4FtRDrC9sHvRpiDL6J5EnfjLhqzZZplHe5yToSn2Ac=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=

--- a/server/service.go
+++ b/server/service.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/fatedier/golib/crypto"
 	"github.com/fatedier/golib/net/mux"
-	fmux "github.com/hashicorp/yamux"
+	fmux "github.com/fatedier/yamux"
 	quic "github.com/quic-go/quic-go"
 	"github.com/samber/lo"
 


### PR DESCRIPTION
## Summary

- Replace the direct `github.com/hashicorp/yamux v0.1.1` dependency with `github.com/fatedier/yamux v0.2.0`.
- Update the four production imports used by the connector, XTCP proxy and visitor, and server service.
- Remove the temporary pseudo-version `replace` and its TODO, then refresh only the yamux checksums. The module graph now contains a single yamux identity at v0.2.0.

## Verification

- `gofmt -d`
- `go mod tidy -diff` and `go mod verify`
- `git diff --check` and dependency identity checks
- `make gotest`
- `make vet`
- `make build`
- XTCP focused E2E: 2 passed
- Full E2E: 254 passed, 2 existing STUN-dependent skips
- Compatibility E2E with frp v0.71.0: 6 passed
- frpc/frps cross-builds for Linux amd64, armv7, arm64, ppc64le, and Windows amd64
- Independent full-diff review: no actionable findings