### PR TITLE
feat: add web login page for frps/frpc dashboard

### DIFF
--- a/client/api_router.go
+++ b/client/api_router.go
@@ -29,7 +29,19 @@ func (svr *Service) registerRouteHandlers(helper *httppkg.RouterRegisterHelper) 
 	// Healthz endpoint without auth
 	helper.Router.HandleFunc("/healthz", healthz)
 
-	// API routes and static files with auth
+	// Public view routes: the SPA shell contains no sensitive data, all data
+	// APIs registered on the subrouter below stay behind the auth middleware.
+	// They must be registered before the subrouter because the mux router
+	// matches routes in registration order.
+	helper.Router.Handle("/favicon.ico", http.FileServer(helper.AssetsFS)).Methods(http.MethodGet)
+	helper.Router.PathPrefix("/static/").Handler(
+		netpkg.MakeHTTPGzipHandler(http.StripPrefix("/static/", http.FileServer(helper.AssetsFS))),
+	).Methods(http.MethodGet)
+	helper.Router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/static/", http.StatusMovedPermanently)
+	})
+
+	// API routes with auth
 	subRouter := helper.Router.NewRoute().Subrouter()
 	subRouter.Use(helper.AuthMiddleware)
 	subRouter.Use(httppkg.NewRequestLogger)
@@ -53,14 +65,6 @@ func (svr *Service) registerRouteHandlers(helper *httppkg.RouterRegisterHelper) 
 		subRouter.HandleFunc("/api/store/visitors/{name}", httppkg.MakeHTTPHandlerFunc(apiController.UpdateStoreVisitor)).Methods(http.MethodPut)
 		subRouter.HandleFunc("/api/store/visitors/{name}", httppkg.MakeHTTPHandlerFunc(apiController.DeleteStoreVisitor)).Methods(http.MethodDelete)
 	}
-
-	subRouter.Handle("/favicon.ico", http.FileServer(helper.AssetsFS)).Methods("GET")
-	subRouter.PathPrefix("/static/").Handler(
-		netpkg.MakeHTTPGzipHandler(http.StripPrefix("/static/", http.FileServer(helper.AssetsFS))),
-	).Methods("GET")
-	subRouter.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/static/", http.StatusMovedPermanently)
-	})
 }
 
 func healthz(w http.ResponseWriter, _ *http.Request) {

--- a/client/service.go
+++ b/client/service.go
@@ -189,7 +189,7 @@ func NewService(options ServiceOptions) (*Service, error) {
 	// leaked when an earlier error causes NewService to return.
 	var webServer *httppkg.Server
 	if options.Common.WebServer.Port > 0 {
-		ws, err := httppkg.NewServer(options.Common.WebServer)
+		ws, err := httppkg.NewServerWithOptions(options.Common.WebServer, httppkg.WithSessionCookieName("frpc_session"))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/http/auth.go
+++ b/pkg/util/http/auth.go
@@ -1,0 +1,252 @@
+// Copyright 2025 The frp Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/fatedier/frp/pkg/util/util"
+)
+
+const (
+	// defaultSessionCookieName is used when no specific name is provided.
+	// frps and frpc pass distinct names ("frps_session" / "frpc_session") so
+	// that both dashboards can be logged into simultaneously when they run on
+	// the same host: cookies are scoped by host name only, not by port.
+	defaultSessionCookieName = "frp_session"
+	sessionDuration          = 7 * 24 * time.Hour
+)
+
+// sessionManager issues and verifies stateless HMAC-signed session tokens.
+// Tokens are signed with a random per-process secret, so all sessions become
+// invalid after a restart.
+type sessionManager struct {
+	secret []byte
+}
+
+func newSessionManager() (*sessionManager, error) {
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		return nil, err
+	}
+	return &sessionManager{secret: secret}, nil
+}
+
+func (m *sessionManager) sign(expireAt int64, nonce []byte) string {
+	payload := fmt.Sprintf("%d:%s", expireAt, hex.EncodeToString(nonce))
+	mac := hmac.New(sha256.New, m.secret)
+	mac.Write([]byte(payload))
+	return fmt.Sprintf("%d.%s.%s", expireAt, hex.EncodeToString(nonce), hex.EncodeToString(mac.Sum(nil)))
+}
+
+// issue creates a signed token valid for sessionDuration from now.
+func (m *sessionManager) issue() (string, error) {
+	nonce := make([]byte, 16)
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+	return m.sign(time.Now().Add(sessionDuration).Unix(), nonce), nil
+}
+
+// verify checks both the signature and the expiry of a token.
+func (m *sessionManager) verify(token string) bool {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	expireAt, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return false
+	}
+	nonce, err := hex.DecodeString(parts[1])
+	if err != nil {
+		return false
+	}
+	if time.Now().Unix() >= expireAt {
+		return false
+	}
+	return util.ConstantTimeEqString(token, m.sign(expireAt, nonce))
+}
+
+// SessionAuthMiddleware authenticates requests either by a signed session
+// cookie (set by the login endpoint, used by the dashboard web UI) or by HTTP
+// basic auth (kept for API clients such as the frp SDK).
+type SessionAuthMiddleware struct {
+	user          string
+	passwd        string
+	cookieName    string
+	sessions      *sessionManager
+	authFailDelay time.Duration
+}
+
+// NewSessionAuthMiddleware creates the middleware. cookieName scopes the
+// session cookie and should be distinct per binary (frps/frpc) to avoid the
+// two dashboards overwriting each other's session cookie when served from
+// the same host.
+func NewSessionAuthMiddleware(user, passwd, cookieName string, sessions *sessionManager) *SessionAuthMiddleware {
+	if cookieName == "" {
+		cookieName = defaultSessionCookieName
+	}
+	return &SessionAuthMiddleware{
+		user:       user,
+		passwd:     passwd,
+		cookieName: cookieName,
+		sessions:   sessions,
+	}
+}
+
+func (m *SessionAuthMiddleware) SetAuthFailDelay(delay time.Duration) *SessionAuthMiddleware {
+	m.authFailDelay = delay
+	return m
+}
+
+func (m *SessionAuthMiddleware) authorized(r *http.Request) bool {
+	if m.user == "" && m.passwd == "" {
+		return true
+	}
+	reqUser, reqPasswd, hasAuth := r.BasicAuth()
+	if hasAuth && util.ConstantTimeEqString(reqUser, m.user) &&
+		util.ConstantTimeEqString(reqPasswd, m.passwd) {
+		return true
+	}
+	return m.hasValidSession(r)
+}
+
+func (m *SessionAuthMiddleware) hasValidSession(r *http.Request) bool {
+	if m.sessions == nil {
+		return false
+	}
+	c, err := r.Cookie(m.cookieName)
+	if err != nil || c.Value == "" {
+		return false
+	}
+	return m.sessions.verify(c.Value)
+}
+
+func (m *SessionAuthMiddleware) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if m.authorized(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if m.authFailDelay > 0 {
+			time.Sleep(m.authFailDelay)
+		}
+		// Only send the basic auth challenge to clients that already attempted
+		// basic auth or to non-API requests, so that browser fetches from the
+		// dashboard SPA handle 401 in JavaScript instead of triggering the
+		// native popup.
+		_, _, hasAuth := r.BasicAuth()
+		if hasAuth || !strings.HasPrefix(r.URL.Path, "/api/") {
+			w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+		}
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+	})
+}
+
+type loginRequest struct {
+	User     string `json:"user"`
+	Password string `json:"password"`
+}
+
+// LoginHandler validates credentials from a JSON body and issues a session
+// cookie on success.
+func (m *SessionAuthMiddleware) LoginHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req loginRequest
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&req); err != nil {
+			m.writeJSONError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		if m.authorizedCredentials(req.User, req.Password) {
+			token, err := m.sessions.issue()
+			if err != nil {
+				m.writeJSONError(w, http.StatusInternalServerError, "internal error")
+				return
+			}
+			http.SetCookie(w, m.newSessionCookie(token, int(sessionDuration/time.Second), r))
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(GeneralResponse{Code: http.StatusOK, Msg: "success"})
+			return
+		}
+		if m.authFailDelay > 0 {
+			time.Sleep(m.authFailDelay)
+		}
+		m.writeJSONError(w, http.StatusUnauthorized, "invalid user or password")
+	})
+}
+
+func (m *SessionAuthMiddleware) authorizedCredentials(user, passwd string) bool {
+	if m.user == "" && m.passwd == "" {
+		return true
+	}
+	return util.ConstantTimeEqString(user, m.user) && util.ConstantTimeEqString(passwd, m.passwd)
+}
+
+// LogoutHandler clears the session cookie.
+func (m *SessionAuthMiddleware) LogoutHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, m.newSessionCookie("", -1, r))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(GeneralResponse{Code: http.StatusOK, Msg: "success"})
+	})
+}
+
+// CheckHandler reports whether the SPA has a login session: 204 if a valid
+// session cookie is present, 401 otherwise. It deliberately does NOT accept
+// basic auth: browsers silently attach cached basic credentials from earlier
+// popup logins, which would resurrect the dashboard after a logout.
+func (m *SessionAuthMiddleware) CheckHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if (m.user == "" && m.passwd == "") || m.hasValidSession(r) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+}
+
+func (m *SessionAuthMiddleware) newSessionCookie(value string, maxAge int, r *http.Request) *http.Cookie {
+	cookie := &http.Cookie{
+		Name:     m.cookieName,
+		Value:    value,
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   maxAge,
+	}
+	// Mark the cookie Secure both for direct TLS and for TLS terminated at a
+	// reverse proxy in front of frp. A spoofed X-Forwarded-Proto can only
+	// force the Secure flag on, which is harmless.
+	if r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https") {
+		cookie.Secure = true
+	}
+	return cookie
+}
+
+func (m *SessionAuthMiddleware) writeJSONError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(GeneralResponse{Code: code, Msg: msg})
+}

--- a/pkg/util/http/auth_test.go
+++ b/pkg/util/http/auth_test.go
@@ -1,0 +1,316 @@
+// Copyright 2025 The frp Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/fatedier/frp/pkg/config/v1"
+)
+
+const testCookieName = "frps_session"
+
+func newTestAuthMiddleware(t *testing.T, user, passwd string) *SessionAuthMiddleware {
+	t.Helper()
+	sessions, err := newSessionManager()
+	require.NoError(t, err)
+	return NewSessionAuthMiddleware(user, passwd, testCookieName, sessions)
+}
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestSessionManagerIssueAndVerify(t *testing.T) {
+	sessions, err := newSessionManager()
+	require.NoError(t, err)
+
+	token, err := sessions.issue()
+	require.NoError(t, err)
+	assert.True(t, sessions.verify(token))
+
+	// Tampered token must fail.
+	assert.False(t, sessions.verify(token+"x"))
+	assert.False(t, sessions.verify("not-a-token"))
+	assert.False(t, sessions.verify(""))
+
+	// Token signed by another secret must fail.
+	other, err := newSessionManager()
+	require.NoError(t, err)
+	assert.False(t, other.verify(token))
+
+	// Expired token must fail.
+	nonce := make([]byte, 16)
+	expired := sessions.sign(time.Now().Add(-time.Second).Unix(), nonce)
+	assert.False(t, sessions.verify(expired))
+}
+
+func TestSessionAuthMiddlewareAuthDisabled(t *testing.T) {
+	m := newTestAuthMiddleware(t, "", "")
+	req := httptest.NewRequest(http.MethodGet, "/api/serverinfo", nil)
+	rec := httptest.NewRecorder()
+	m.Middleware(okHandler()).ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestSessionAuthMiddlewareBasicAuth(t *testing.T) {
+	m := newTestAuthMiddleware(t, "admin", "secret")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/serverinfo", nil)
+	req.SetBasicAuth("admin", "secret")
+	rec := httptest.NewRecorder()
+	m.Middleware(okHandler()).ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Wrong password: 401. Since an Authorization header was sent, the basic
+	// auth challenge is included for API clients.
+	req = httptest.NewRequest(http.MethodGet, "/api/serverinfo", nil)
+	req.SetBasicAuth("admin", "wrong")
+	rec = httptest.NewRecorder()
+	m.Middleware(okHandler()).ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Equal(t, `Basic realm="Restricted"`, rec.Header().Get("WWW-Authenticate"))
+}
+
+func TestSessionAuthMiddlewareSessionCookie(t *testing.T) {
+	m := newTestAuthMiddleware(t, "admin", "secret")
+
+	// Obtain a session cookie from the login handler.
+	login := m.LoginHandler()
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"user":"admin","password":"secret"}`))
+	rec := httptest.NewRecorder()
+	login.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	cookies := rec.Result().Cookies()
+	require.Len(t, cookies, 1)
+	assert.Equal(t, testCookieName, cookies[0].Name)
+	assert.True(t, cookies[0].HttpOnly)
+
+	// The cookie must authenticate API requests without basic auth and the
+	// response must not carry a challenge.
+	req = httptest.NewRequest(http.MethodGet, "/api/serverinfo", nil)
+	req.AddCookie(cookies[0])
+	rec = httptest.NewRecorder()
+	m.Middleware(okHandler()).ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestSessionAuthMiddlewareUnauthorizedAPI(t *testing.T) {
+	m := newTestAuthMiddleware(t, "admin", "secret").SetAuthFailDelay(0)
+
+	// API request without credentials: 401 without the WWW-Authenticate
+	// challenge so browser fetches do not trigger the native popup.
+	req := httptest.NewRequest(http.MethodGet, "/api/serverinfo", nil)
+	rec := httptest.NewRecorder()
+	m.Middleware(okHandler()).ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Empty(t, rec.Header().Get("WWW-Authenticate"))
+
+	// Forged cookie must be rejected.
+	req = httptest.NewRequest(http.MethodGet, "/api/serverinfo", nil)
+	req.AddCookie(&http.Cookie{Name: testCookieName, Value: "1.00.ff"})
+	rec = httptest.NewRecorder()
+	m.Middleware(okHandler()).ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestLoginHandler(t *testing.T) {
+	m := newTestAuthMiddleware(t, "admin", "secret").SetAuthFailDelay(0)
+	login := m.LoginHandler()
+
+	// Bad request body.
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader("not json"))
+	rec := httptest.NewRecorder()
+	login.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// Wrong credentials.
+	req = httptest.NewRequest(http.MethodPost, "/api/auth/login",
+		strings.NewReader(`{"user":"admin","password":"wrong"}`))
+	rec = httptest.NewRecorder()
+	login.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Empty(t, rec.Result().Cookies())
+
+	// Correct credentials.
+	req = httptest.NewRequest(http.MethodPost, "/api/auth/login",
+		strings.NewReader(`{"user":"admin","password":"secret"}`))
+	rec = httptest.NewRecorder()
+	login.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Len(t, rec.Result().Cookies(), 1)
+}
+
+func TestLogoutHandler(t *testing.T) {
+	m := newTestAuthMiddleware(t, "admin", "secret")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	rec := httptest.NewRecorder()
+	m.LogoutHandler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	cookies := rec.Result().Cookies()
+	require.Len(t, cookies, 1)
+	assert.Equal(t, testCookieName, cookies[0].Name)
+	assert.LessOrEqual(t, cookies[0].MaxAge, 0)
+}
+
+func TestSessionCookieSecureBehindTLSProxy(t *testing.T) {
+	m := newTestAuthMiddleware(t, "admin", "secret")
+
+	// X-Forwarded-Proto: https from a TLS-terminating reverse proxy must mark
+	// the cookie Secure even though the request itself is plain HTTP.
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login",
+		strings.NewReader(`{"user":"admin","password":"secret"}`))
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rec := httptest.NewRecorder()
+	m.LoginHandler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	cookies := rec.Result().Cookies()
+	require.Len(t, cookies, 1)
+	assert.True(t, cookies[0].Secure)
+
+	// Without the header and without TLS the cookie stays non-Secure.
+	req = httptest.NewRequest(http.MethodPost, "/api/auth/login",
+		strings.NewReader(`{"user":"admin","password":"secret"}`))
+	rec = httptest.NewRecorder()
+	m.LoginHandler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.False(t, rec.Result().Cookies()[0].Secure)
+}
+
+func TestNewServerSessionCookieNameOption(t *testing.T) {
+	loginBody := `{"user":"admin","password":"secret"}`
+
+	// Legacy callers without options keep compiling and get the default
+	// cookie name.
+	s, err := NewServer(v1.WebServerConfig{Addr: "127.0.0.1", Port: 0, User: "admin", Password: "secret"})
+	require.NoError(t, err)
+	defer s.Close()
+
+	ts := httptest.NewServer(s.router)
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/api/auth/login", "application/json", strings.NewReader(loginBody))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	cookies := resp.Cookies()
+	require.Len(t, cookies, 1)
+	assert.Equal(t, defaultSessionCookieName, cookies[0].Name)
+
+	// Callers that pass WithSessionCookieName get that name instead.
+	s2, err := NewServerWithOptions(v1.WebServerConfig{Addr: "127.0.0.1", Port: 0, User: "admin", Password: "secret"},
+		WithSessionCookieName("frpc_session"))
+	require.NoError(t, err)
+	defer s2.Close()
+
+	ts2 := httptest.NewServer(s2.router)
+	defer ts2.Close()
+
+	resp2, err := http.Post(ts2.URL+"/api/auth/login", "application/json", strings.NewReader(loginBody))
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	require.Equal(t, http.StatusOK, resp2.StatusCode)
+	cookies2 := resp2.Cookies()
+	require.Len(t, cookies2, 1)
+	assert.Equal(t, "frpc_session", cookies2[0].Name)
+}
+
+func TestDistinctCookieNamesDoNotCrossAuthenticate(t *testing.T) {
+	// Simulate frps and frpc dashboards on the same host: cookies are scoped
+	// by host only, so isolation relies on distinct cookie names.
+	svr := newTestAuthMiddleware(t, "admin", "secret")
+	sessions, err := newSessionManager()
+	require.NoError(t, err)
+	clt := NewSessionAuthMiddleware("admin", "secret", "frpc_session", sessions)
+
+	// Log in to the "server" and use its cookie on the "client": must fail.
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login",
+		strings.NewReader(`{"user":"admin","password":"secret"}`))
+	rec := httptest.NewRecorder()
+	svr.LoginHandler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	apiReq := httptest.NewRequest(http.MethodGet, "/api/serverinfo", nil)
+	apiReq.AddCookie(rec.Result().Cookies()[0])
+	apiRec := httptest.NewRecorder()
+	clt.Middleware(okHandler()).ServeHTTP(apiRec, apiReq)
+	assert.Equal(t, http.StatusUnauthorized, apiRec.Code)
+
+	// The server still accepts its own cookie.
+	apiRec = httptest.NewRecorder()
+	svr.Middleware(okHandler()).ServeHTTP(apiRec, apiReq)
+	assert.Equal(t, http.StatusOK, apiRec.Code)
+}
+
+func TestCheckHandler(t *testing.T) {
+	m := newTestAuthMiddleware(t, "admin", "secret").SetAuthFailDelay(0)
+	check := m.CheckHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/check", nil)
+	rec := httptest.NewRecorder()
+	check.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// Login first, then check with the issued cookie.
+	loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login",
+		strings.NewReader(`{"user":"admin","password":"secret"}`))
+	loginRec := httptest.NewRecorder()
+	m.LoginHandler().ServeHTTP(loginRec, loginReq)
+	require.Equal(t, http.StatusOK, loginRec.Code)
+
+	req = httptest.NewRequest(http.MethodGet, "/api/auth/check", nil)
+	req.AddCookie(loginRec.Result().Cookies()[0])
+	rec = httptest.NewRecorder()
+	check.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Basic auth must NOT pass the check endpoint: browsers silently attach
+	// cached basic credentials, which would resurrect the dashboard after a
+	// logout. Basic auth still works for data APIs through the middleware.
+	req = httptest.NewRequest(http.MethodGet, "/api/auth/check", nil)
+	req.SetBasicAuth("admin", "secret")
+	rec = httptest.NewRecorder()
+	check.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestLoginErrorResponseBody(t *testing.T) {
+	m := newTestAuthMiddleware(t, "admin", "secret").SetAuthFailDelay(0)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login",
+		strings.NewReader(`{"user":"admin","password":"wrong"}`))
+	rec := httptest.NewRecorder()
+	m.LoginHandler().ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	var resp GeneralResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, http.StatusUnauthorized, resp.Code)
+	assert.NotEmpty(t, resp.Msg)
+}

--- a/pkg/util/http/server.go
+++ b/pkg/util/http/server.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/fatedier/frp/assets"
 	v1 "github.com/fatedier/frp/pkg/config/v1"
-	netpkg "github.com/fatedier/frp/pkg/util/net"
 )
 
 var (
@@ -45,7 +44,38 @@ type Server struct {
 	authMiddleware mux.MiddlewareFunc
 }
 
+type serverOptions struct {
+	sessionCookieName string
+}
+
+// ServerOption is an optional setting for NewServer.
+type ServerOption func(*serverOptions)
+
+// WithSessionCookieName overrides the login session cookie name. frps and
+// frpc set distinct names ("frps_session" / "frpc_session") so both
+// dashboards can hold independent sessions when served from the same host,
+// since cookies are scoped by host name only, not by port.
+func WithSessionCookieName(name string) ServerOption {
+	return func(o *serverOptions) {
+		o.sessionCookieName = name
+	}
+}
+
+// NewServer creates the dashboard web server with the default session cookie
+// name. Its signature is kept unchanged for downstream callers; use
+// NewServerWithOptions to customize the session cookie name.
 func NewServer(cfg v1.WebServerConfig) (*Server, error) {
+	return NewServerWithOptions(cfg)
+}
+
+// NewServerWithOptions creates the dashboard web server with optional
+// settings.
+func NewServerWithOptions(cfg v1.WebServerConfig, opts ...ServerOption) (*Server, error) {
+	options := &serverOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	assets.Load(cfg.AssetsDir)
 
 	addr := net.JoinHostPort(cfg.Addr, strconv.Itoa(cfg.Port))
@@ -83,8 +113,24 @@ func NewServer(cfg v1.WebServerConfig) (*Server, error) {
 			Certificates: []tls.Certificate{cert},
 		}
 	}
-	s.authMiddleware = netpkg.NewHTTPAuthMiddleware(cfg.User, cfg.Password).SetAuthFailDelay(200 * time.Millisecond).Middleware
+	sessions, err := newSessionManager()
+	if err != nil {
+		return nil, err
+	}
+	authMid := NewSessionAuthMiddleware(cfg.User, cfg.Password, options.sessionCookieName, sessions).
+		SetAuthFailDelay(200 * time.Millisecond)
+	s.registerAuthHandlers(authMid)
+	s.authMiddleware = authMid.Middleware
 	return s, nil
+}
+
+// registerAuthHandlers exposes the public auth endpoints used by the dashboard
+// web UI. They must be registered before RouteRegister adds the protected
+// /api routes, since the mux router matches routes in registration order.
+func (s *Server) registerAuthHandlers(authMid *SessionAuthMiddleware) {
+	s.router.Handle("/api/auth/login", authMid.LoginHandler()).Methods(http.MethodPost)
+	s.router.Handle("/api/auth/logout", authMid.LogoutHandler()).Methods(http.MethodPost)
+	s.router.Handle("/api/auth/check", authMid.CheckHandler()).Methods(http.MethodGet)
 }
 
 func (s *Server) Address() string {

--- a/server/api_router.go
+++ b/server/api_router.go
@@ -26,6 +26,19 @@ import (
 
 func (svr *Service) registerRouteHandlers(helper *httppkg.RouterRegisterHelper) {
 	helper.Router.HandleFunc("/healthz", healthz)
+
+	// Public view routes: the SPA shell contains no sensitive data, all data
+	// APIs registered on the subrouter below stay behind the auth middleware.
+	// They must be registered before the subrouter because the mux router
+	// matches routes in registration order.
+	helper.Router.Handle("/favicon.ico", http.FileServer(helper.AssetsFS)).Methods("GET")
+	helper.Router.PathPrefix("/static/").Handler(
+		netpkg.MakeHTTPGzipHandler(http.StripPrefix("/static/", http.FileServer(helper.AssetsFS))),
+	).Methods("GET")
+	helper.Router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/static/", http.StatusMovedPermanently)
+	})
+
 	subRouter := helper.Router.NewRoute().Subrouter()
 
 	subRouter.Use(helper.AuthMiddleware)
@@ -58,16 +71,6 @@ func (svr *Service) registerRouteHandlers(helper *httppkg.RouterRegisterHelper) 
 	subRouter.HandleFunc("/api/v2/proxies", httppkg.MakeHTTPHandlerFuncV2(apiController.APIV2ProxyList)).Methods("GET")
 	v2EncodedPathRouter.HandleFunc("/api/v2/proxies/{name}/traffic", httppkg.MakeHTTPHandlerFuncV2(apiController.APIV2ProxyTraffic)).Methods("GET")
 	v2EncodedPathRouter.HandleFunc("/api/v2/proxies/{name}", httppkg.MakeHTTPHandlerFuncV2(apiController.APIV2ProxyDetail)).Methods("GET")
-
-	// view
-	subRouter.Handle("/favicon.ico", http.FileServer(helper.AssetsFS)).Methods("GET")
-	subRouter.PathPrefix("/static/").Handler(
-		netpkg.MakeHTTPGzipHandler(http.StripPrefix("/static/", http.FileServer(helper.AssetsFS))),
-	).Methods("GET")
-
-	subRouter.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/static/", http.StatusMovedPermanently)
-	})
 }
 
 func healthz(w http.ResponseWriter, _ *http.Request) {

--- a/server/service.go
+++ b/server/service.go
@@ -147,7 +147,7 @@ func NewService(cfg *v1.ServerConfig) (*Service, error) {
 
 	var webServer *httppkg.Server
 	if cfg.WebServer.Port > 0 {
-		ws, err := httppkg.NewServer(cfg.WebServer)
+		ws, err := httppkg.NewServerWithOptions(cfg.WebServer, httppkg.WithSessionCookieName("frps_session"))
 		if err != nil {
 			return nil, err
 		}

--- a/test/e2e/legacy/basic/client.go
+++ b/test/e2e/legacy/basic/client.go
@@ -97,7 +97,7 @@ var _ = ginkgo.Describe("[Feature: ClientManage]", func() {
 		}).Port(dashboardPort).ExpectResp([]byte("")).Ensure()
 
 		framework.NewRequestExpect(f).RequestModify(func(r *request.Request) {
-			r.HTTP().HTTPPath("/")
+			r.HTTP().HTTPPath("/api/status")
 		}).Port(dashboardPort).
 			Ensure(framework.ExpectResponseCode(401))
 	})

--- a/test/e2e/legacy/basic/server.go
+++ b/test/e2e/legacy/basic/server.go
@@ -174,7 +174,7 @@ var _ = ginkgo.Describe("[Feature: Server Manager]", func() {
 		}).Port(dashboardPort).ExpectResp([]byte("")).Ensure()
 
 		framework.NewRequestExpect(f).RequestModify(func(r *request.Request) {
-			r.HTTP().HTTPPath("/")
+			r.HTTP().HTTPPath("/api/serverinfo")
 		}).Port(dashboardPort).
 			Ensure(framework.ExpectResponseCode(401))
 	})

--- a/test/e2e/v1/basic/client.go
+++ b/test/e2e/v1/basic/client.go
@@ -100,7 +100,7 @@ var _ = ginkgo.Describe("[Feature: ClientManage]", func() {
 		}).Port(dashboardPort).ExpectResp([]byte("")).Ensure()
 
 		framework.NewRequestExpect(f).RequestModify(func(r *request.Request) {
-			r.HTTP().HTTPPath("/")
+			r.HTTP().HTTPPath("/api/status")
 		}).Port(dashboardPort).
 			Ensure(framework.ExpectResponseCode(401))
 	})

--- a/test/e2e/v1/basic/server.go
+++ b/test/e2e/v1/basic/server.go
@@ -187,7 +187,7 @@ var _ = ginkgo.Describe("[Feature: Server Manager]", func() {
 		}).Port(dashboardPort).ExpectResp([]byte("")).Ensure()
 
 		framework.NewRequestExpect(f).RequestModify(func(r *request.Request) {
-			r.HTTP().HTTPPath("/")
+			r.HTTP().HTTPPath("/api/serverinfo")
 		}).Port(dashboardPort).
 			Ensure(framework.ExpectResponseCode(401))
 	})

--- a/web/frpc/components.d.ts
+++ b/web/frpc/components.d.ts
@@ -13,6 +13,7 @@ declare module 'vue' {
   export interface GlobalComponents {
     ConfigField: typeof import('./src/components/ConfigField.vue')['default']
     ConfigSection: typeof import('./src/components/ConfigSection.vue')['default']
+    ElButton: typeof import('element-plus/es')['ElButton']
     ElDialog: typeof import('element-plus/es')['ElDialog']
     ElForm: typeof import('element-plus/es')['ElForm']
     ElFormItem: typeof import('element-plus/es')['ElFormItem']
@@ -22,6 +23,7 @@ declare module 'vue' {
     ElRadio: typeof import('element-plus/es')['ElRadio']
     ElRadioGroup: typeof import('element-plus/es')['ElRadioGroup']
     ElSwitch: typeof import('element-plus/es')['ElSwitch']
+    ElTooltip: typeof import('element-plus/es')['ElTooltip']
     KeyValueEditor: typeof import('./src/components/KeyValueEditor.vue')['default']
     ProxyAuthSection: typeof import('./src/components/proxy-form/ProxyAuthSection.vue')['default']
     ProxyBackendSection: typeof import('./src/components/proxy-form/ProxyBackendSection.vue')['default']

--- a/web/frpc/eslint.config.js
+++ b/web/frpc/eslint.config.js
@@ -27,7 +27,7 @@ export default [
       'vue/multi-word-component-names': [
         'error',
         {
-          ignores: ['Overview'],
+          ignores: ['Overview', 'Login'],
         },
       ],
     },

--- a/web/frpc/src/App.vue
+++ b/web/frpc/src/App.vue
@@ -1,6 +1,9 @@
 <template>
   <div id="app">
-    <header class="header">
+    <router-view v-if="isLoginPage"></router-view>
+
+    <template v-else>
+      <header class="header">
       <div class="header-content">
         <div class="brand-section">
           <button v-if="isMobile" class="hamburger-btn" @click="toggleSidebar" aria-label="Toggle menu">
@@ -30,6 +33,16 @@
             :inactive-icon="Sunny"
             class="theme-switch"
           />
+          <el-tooltip content="Sign out" placement="bottom">
+            <button
+              type="button"
+              class="logout-btn"
+              aria-label="Sign out"
+              @click="handleLogout"
+            >
+              <el-icon><SwitchButton /></el-icon>
+            </button>
+          </el-tooltip>
         </div>
       </div>
     </header>
@@ -75,26 +88,47 @@
         <router-view></router-view>
       </main>
     </div>
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useDark } from '@vueuse/core'
-import { Moon, Sunny } from '@element-plus/icons-vue'
+import { ElMessage } from 'element-plus'
+import { Moon, Sunny, SwitchButton } from '@element-plus/icons-vue'
 import GitHubIcon from './assets/icons/github.svg?component'
 import LogoIcon from './assets/icons/logo.svg?component'
 import { useResponsive } from './composables/useResponsive'
+import { logoutRequest } from './api/auth'
+import { resetAuthState } from './stores/auth'
 
 const route = useRoute()
+const router = useRouter()
 const isDark = useDark()
 const { isMobile } = useResponsive()
+
+const isLoginPage = computed(() => route.name === 'Login')
 
 const sidebarOpen = ref(false)
 
 const toggleSidebar = () => {
   sidebarOpen.value = !sidebarOpen.value
+}
+
+const handleLogout = async () => {
+  try {
+    await logoutRequest()
+  } catch {
+    // The session cookie is HttpOnly, so it can only be cleared by the
+    // server; if the request failed the session is still alive and we must
+    // not pretend the user is signed out.
+    ElMessage.error('Sign out failed, please try again')
+    return
+  }
+  resetAuthState()
+  await router.push('/login')
 }
 
 const closeSidebar = () => {
@@ -227,6 +261,26 @@ html.dark .theme-switch {
 
 .theme-switch .el-switch__core .el-switch__inner .el-icon {
   color: #909399 !important;
+}
+
+// Logout button
+.logout-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--el-color-danger, #f56c6c);
+  font-size: 16px;
+  transition: all 0.15s ease;
+}
+
+.logout-btn:hover {
+  background: rgba(245, 108, 108, 0.12);
 }
 
 // Layout

--- a/web/frpc/src/api/auth.ts
+++ b/web/frpc/src/api/auth.ts
@@ -1,0 +1,9 @@
+import { http } from './http'
+
+export const loginRequest = (user: string, password: string) =>
+  http.post('../api/auth/login', { user, password })
+
+export const logoutRequest = () => http.post('../api/auth/logout')
+
+export const checkAuthRequest = () =>
+  http.get('../api/auth/check', { cache: 'no-store' })

--- a/web/frpc/src/api/http.ts
+++ b/web/frpc/src/api/http.ts
@@ -1,4 +1,5 @@
 // http.ts - Base HTTP client
+import { resetAuthState } from '../stores/authState'
 
 class HTTPError extends Error {
   status: number
@@ -11,6 +12,18 @@ class HTTPError extends Error {
   }
 }
 
+// redirectOnUnauthorized sends the SPA to the login page when a request fails
+// with 401 (e.g. the session expired mid-use). The cached auth state is
+// dropped first, otherwise the router guard would trust the stale "already
+// authenticated" cache and bounce the user right back. Navigation happens
+// through the hash so the router picks it up.
+function redirectOnUnauthorized() {
+  resetAuthState()
+  if (window.location.hash.startsWith('#/login')) return
+  const current = window.location.hash.slice(1) || '/'
+  window.location.hash = `#/login?redirect=${encodeURIComponent(current)}`
+}
+
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
   const defaultOptions: RequestInit = {
     credentials: 'include',
@@ -19,6 +32,9 @@ async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
   const response = await fetch(url, { ...defaultOptions, ...options })
 
   if (!response.ok) {
+    if (response.status === 401) {
+      redirectOnUnauthorized()
+    }
     throw new HTTPError(
       response.status,
       response.statusText,

--- a/web/frpc/src/router/index.ts
+++ b/web/frpc/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHashHistory } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import ClientConfigure from '../views/ClientConfigure.vue'
+import Login from '../views/Login.vue'
 import ProxyDetail from '../views/ProxyDetail.vue'
 import ProxyEdit from '../views/ProxyEdit.vue'
 import ProxyList from '../views/ProxyList.vue'
@@ -8,10 +9,17 @@ import VisitorDetail from '../views/VisitorDetail.vue'
 import VisitorEdit from '../views/VisitorEdit.vue'
 import VisitorList from '../views/VisitorList.vue'
 import { useProxyStore } from '../stores/proxy'
+import { checkAuthState } from '../stores/auth'
 
 const router = createRouter({
   history: createWebHashHistory(),
   routes: [
+    {
+      path: '/login',
+      name: 'Login',
+      component: Login,
+      meta: { public: true },
+    },
     {
       path: '/',
       redirect: '/proxies',
@@ -69,6 +77,18 @@ const router = createRouter({
 })
 
 router.beforeEach(async (to) => {
+  const authed = await checkAuthState()
+  if (to.meta.public) {
+    // Already authenticated users are sent back to the dashboard.
+    if (authed && to.name === 'Login') {
+      return { path: '/' }
+    }
+    return true
+  }
+  if (!authed) {
+    return { name: 'Login', query: { redirect: to.fullPath } }
+  }
+
   if (!to.matched.some((record) => record.meta.requiresStore)) {
     return true
   }

--- a/web/frpc/src/stores/auth.ts
+++ b/web/frpc/src/stores/auth.ts
@@ -1,0 +1,19 @@
+import { checkAuthRequest } from '../api/auth'
+import { authenticated, checked, resetAuthState, setAuthenticated } from './authState'
+
+export { authenticated, checked, resetAuthState, setAuthenticated }
+
+// checkAuthState probes the server once and caches the result. It is called
+// by the router guard on the first navigation; after a login or a mid-session
+// 401 the cache is updated through setAuthenticated/resetAuthState.
+export async function checkAuthState(): Promise<boolean> {
+  if (checked.value) return authenticated.value
+  try {
+    await checkAuthRequest()
+    authenticated.value = true
+  } catch {
+    authenticated.value = false
+  }
+  checked.value = true
+  return authenticated.value
+}

--- a/web/frpc/src/stores/authState.ts
+++ b/web/frpc/src/stores/authState.ts
@@ -1,0 +1,17 @@
+import { ref } from 'vue'
+
+// Leaf auth state module: it must not import anything that depends on the
+// http client, so that http.ts can reset the state on a 401 without creating
+// an import cycle.
+export const authenticated = ref(false)
+export const checked = ref(false)
+
+export function setAuthenticated(value: boolean) {
+  authenticated.value = value
+  checked.value = true
+}
+
+export function resetAuthState() {
+  authenticated.value = false
+  checked.value = true
+}

--- a/web/frpc/src/views/Login.vue
+++ b/web/frpc/src/views/Login.vue
@@ -1,0 +1,129 @@
+<template>
+  <div class="login-page">
+    <div class="login-card">
+      <div class="login-header">
+        <LogoIcon class="login-logo" />
+        <span class="login-title">frp</span>
+        <span class="badge login-badge">Client</span>
+      </div>
+
+      <el-form :model="form" @submit.prevent="handleLogin">
+        <el-form-item>
+          <el-input
+            v-model="form.user"
+            placeholder="Username"
+            size="large"
+            :prefix-icon="User"
+            name="username"
+            autocomplete="username"
+          />
+        </el-form-item>
+        <el-form-item>
+          <el-input
+            v-model="form.password"
+            type="password"
+            placeholder="Password"
+            size="large"
+            :prefix-icon="Lock"
+            name="password"
+            autocomplete="current-password"
+            show-password
+            @keyup.enter="handleLogin"
+          />
+        </el-form-item>
+        <el-button
+          type="primary"
+          size="large"
+          class="login-btn"
+          native-type="submit"
+          :loading="loading"
+        >
+          Sign in
+        </el-button>
+      </el-form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import { Lock, User } from '@element-plus/icons-vue'
+import LogoIcon from '../assets/icons/logo.svg?component'
+import { loginRequest } from '../api/auth'
+import { setAuthenticated } from '../stores/auth'
+
+const route = useRoute()
+const router = useRouter()
+
+const form = reactive({
+  user: '',
+  password: '',
+})
+const loading = ref(false)
+
+const handleLogin = async () => {
+  if (!form.user || !form.password || loading.value) return
+  loading.value = true
+  try {
+    await loginRequest(form.user, form.password)
+    setAuthenticated(true)
+    const redirect = typeof route.query.redirect === 'string' ? route.query.redirect : '/'
+    await router.push(redirect)
+  } catch {
+    ElMessage.error('Invalid user or password')
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.login-page {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--color-bg-secondary);
+}
+
+.login-card {
+  width: 360px;
+  padding: 40px 32px 32px;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-light);
+  border-radius: 12px;
+}
+
+.login-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+.login-logo {
+  width: 32px;
+  height: 32px;
+}
+
+.login-title {
+  font-weight: 600;
+  font-size: 20px;
+  color: var(--color-text-primary);
+  letter-spacing: -0.5px;
+}
+
+.login-badge {
+  background: linear-gradient(135deg, #3b82f6 0%, #06b6d4 100%);
+  color: white;
+}
+
+.login-btn {
+  width: 100%;
+  margin-top: 8px;
+}
+</style>

--- a/web/frps/components.d.ts
+++ b/web/frps/components.d.ts
@@ -17,6 +17,8 @@ declare module 'vue' {
     ElCol: typeof import('element-plus/es')['ElCol']
     ElDialog: typeof import('element-plus/es')['ElDialog']
     ElEmpty: typeof import('element-plus/es')['ElEmpty']
+    ElForm: typeof import('element-plus/es')['ElForm']
+    ElFormItem: typeof import('element-plus/es')['ElFormItem']
     ElIcon: typeof import('element-plus/es')['ElIcon']
     ElInput: typeof import('element-plus/es')['ElInput']
     ElRow: typeof import('element-plus/es')['ElRow']

--- a/web/frps/eslint.config.js
+++ b/web/frps/eslint.config.js
@@ -27,7 +27,7 @@ export default [
       'vue/multi-word-component-names': [
         'error',
         {
-          ignores: ['Traffic', 'Proxies', 'Clients'],
+          ignores: ['Traffic', 'Proxies', 'Clients', 'Login'],
         },
       ],
     },

--- a/web/frps/src/App.vue
+++ b/web/frps/src/App.vue
@@ -1,6 +1,9 @@
 <template>
   <div id="app">
-    <header class="header">
+    <router-view v-if="isLoginPage"></router-view>
+
+    <template v-else>
+      <header class="header">
       <div class="header-content">
         <div class="brand-section">
           <button
@@ -35,6 +38,16 @@
             :inactive-icon="Sunny"
             class="theme-switch"
           />
+          <el-tooltip content="Sign out" placement="bottom">
+            <button
+              type="button"
+              class="logout-btn"
+              aria-label="Sign out"
+              @click="handleLogout"
+            >
+              <el-icon><SwitchButton /></el-icon>
+            </button>
+          </el-tooltip>
         </div>
       </div>
     </header>
@@ -87,26 +100,47 @@
         <router-view></router-view>
       </main>
     </div>
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useDark } from '@vueuse/core'
-import { Moon, Sunny } from '@element-plus/icons-vue'
+import { ElMessage } from 'element-plus'
+import { Moon, Sunny, SwitchButton } from '@element-plus/icons-vue'
 import GitHubIcon from './assets/icons/github.svg?component'
 import LogoIcon from './assets/icons/logo.svg?component'
 import { useResponsive } from './composables/useResponsive'
+import { logoutRequest } from './api/auth'
+import { resetAuthState } from './stores/auth'
 
 const route = useRoute()
+const router = useRouter()
 const isDark = useDark()
 const { isMobile } = useResponsive()
+
+const isLoginPage = computed(() => route.name === 'Login')
 
 const sidebarOpen = ref(false)
 
 const toggleSidebar = () => {
   sidebarOpen.value = !sidebarOpen.value
+}
+
+const handleLogout = async () => {
+  try {
+    await logoutRequest()
+  } catch {
+    // The session cookie is HttpOnly, so it can only be cleared by the
+    // server; if the request failed the session is still alive and we must
+    // not pretend the user is signed out.
+    ElMessage.error('Sign out failed, please try again')
+    return
+  }
+  resetAuthState()
+  await router.push('/login')
 }
 
 const closeSidebar = () => {
@@ -282,6 +316,26 @@ html.dark .theme-switch {
 
 .theme-switch .el-switch__core .el-switch__inner .el-icon {
   color: #909399 !important;
+}
+
+/* Logout button */
+.logout-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--el-color-danger, #f56c6c);
+  font-size: 16px;
+  transition: all 0.15s ease;
+}
+
+.logout-btn:hover {
+  background: rgba(245, 108, 108, 0.12);
 }
 
 /* Layout */

--- a/web/frps/src/api/auth.ts
+++ b/web/frps/src/api/auth.ts
@@ -1,0 +1,9 @@
+import { http } from './http'
+
+export const loginRequest = (user: string, password: string) =>
+  http.post('../api/auth/login', { user, password })
+
+export const logoutRequest = () => http.post('../api/auth/logout')
+
+export const checkAuthRequest = () =>
+  http.get('../api/auth/check', { cache: 'no-store' })

--- a/web/frps/src/api/http.ts
+++ b/web/frps/src/api/http.ts
@@ -1,4 +1,5 @@
 // http.ts - Base HTTP client
+import { resetAuthState } from '../stores/authState'
 
 class HTTPError extends Error {
   status: number
@@ -26,6 +27,18 @@ export interface V2Page<T> {
 
 type QueryParamValue = string | number | boolean | null | undefined
 
+// redirectOnUnauthorized sends the SPA to the login page when a request fails
+// with 401 (e.g. the session expired mid-use). The cached auth state is
+// dropped first, otherwise the router guard would trust the stale "already
+// authenticated" cache and bounce the user right back. Navigation happens
+// through the hash so the router picks it up.
+function redirectOnUnauthorized() {
+  resetAuthState()
+  if (window.location.hash.startsWith('#/login')) return
+  const current = window.location.hash.slice(1) || '/'
+  window.location.hash = `#/login?redirect=${encodeURIComponent(current)}`
+}
+
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
   const defaultOptions: RequestInit = {
     credentials: 'include',
@@ -34,6 +47,9 @@ async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
   const response = await fetch(url, { ...defaultOptions, ...options })
 
   if (!response.ok) {
+    if (response.status === 401) {
+      redirectOnUnauthorized()
+    }
     throw new HTTPError(
       response.status,
       response.statusText,
@@ -63,6 +79,9 @@ async function requestV2<T>(
     | null
 
   if (!response.ok) {
+    if (response.status === 401) {
+      redirectOnUnauthorized()
+    }
     throw new HTTPError(
       response.status,
       response.statusText,

--- a/web/frps/src/router/index.ts
+++ b/web/frps/src/router/index.ts
@@ -4,6 +4,8 @@ import Clients from '../views/Clients.vue'
 import ClientDetail from '../views/ClientDetail.vue'
 import Proxies from '../views/Proxies.vue'
 import ProxyDetail from '../views/ProxyDetail.vue'
+import Login from '../views/Login.vue'
+import { checkAuthState } from '../stores/auth'
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -11,6 +13,12 @@ const router = createRouter({
     return { top: 0 }
   },
   routes: [
+    {
+      path: '/login',
+      name: 'Login',
+      component: Login,
+      meta: { public: true },
+    },
     {
       path: '/',
       name: 'ServerOverview',
@@ -37,6 +45,21 @@ const router = createRouter({
       component: ProxyDetail,
     },
   ],
+})
+
+router.beforeEach(async (to) => {
+  const authed = await checkAuthState()
+  if (to.meta.public) {
+    // Already authenticated users are sent back to the dashboard.
+    if (authed && to.name === 'Login') {
+      return { path: '/' }
+    }
+    return true
+  }
+  if (!authed) {
+    return { name: 'Login', query: { redirect: to.fullPath } }
+  }
+  return true
 })
 
 export default router

--- a/web/frps/src/stores/auth.ts
+++ b/web/frps/src/stores/auth.ts
@@ -1,0 +1,19 @@
+import { checkAuthRequest } from '../api/auth'
+import { authenticated, checked, resetAuthState, setAuthenticated } from './authState'
+
+export { authenticated, checked, resetAuthState, setAuthenticated }
+
+// checkAuthState probes the server once and caches the result. It is called
+// by the router guard on the first navigation; after a login or a mid-session
+// 401 the cache is updated through setAuthenticated/resetAuthState.
+export async function checkAuthState(): Promise<boolean> {
+  if (checked.value) return authenticated.value
+  try {
+    await checkAuthRequest()
+    authenticated.value = true
+  } catch {
+    authenticated.value = false
+  }
+  checked.value = true
+  return authenticated.value
+}

--- a/web/frps/src/stores/authState.ts
+++ b/web/frps/src/stores/authState.ts
@@ -1,0 +1,17 @@
+import { ref } from 'vue'
+
+// Leaf auth state module: it must not import anything that depends on the
+// http client, so that http.ts can reset the state on a 401 without creating
+// an import cycle.
+export const authenticated = ref(false)
+export const checked = ref(false)
+
+export function setAuthenticated(value: boolean) {
+  authenticated.value = value
+  checked.value = true
+}
+
+export function resetAuthState() {
+  authenticated.value = false
+  checked.value = true
+}

--- a/web/frps/src/views/Login.vue
+++ b/web/frps/src/views/Login.vue
@@ -1,0 +1,124 @@
+<template>
+  <div class="login-page">
+    <div class="login-card">
+      <div class="login-header">
+        <LogoIcon class="login-logo" />
+        <span class="login-title">frp</span>
+        <span class="badge server-badge">Server</span>
+      </div>
+
+      <el-form :model="form" @submit.prevent="handleLogin">
+        <el-form-item>
+          <el-input
+            v-model="form.user"
+            placeholder="Username"
+            size="large"
+            :prefix-icon="User"
+            name="username"
+            autocomplete="username"
+          />
+        </el-form-item>
+        <el-form-item>
+          <el-input
+            v-model="form.password"
+            type="password"
+            placeholder="Password"
+            size="large"
+            :prefix-icon="Lock"
+            name="password"
+            autocomplete="current-password"
+            show-password
+            @keyup.enter="handleLogin"
+          />
+        </el-form-item>
+        <el-button
+          type="primary"
+          size="large"
+          class="login-btn"
+          native-type="submit"
+          :loading="loading"
+        >
+          Sign in
+        </el-button>
+      </el-form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import { Lock, User } from '@element-plus/icons-vue'
+import LogoIcon from '../assets/icons/logo.svg?component'
+import { loginRequest } from '../api/auth'
+import { setAuthenticated } from '../stores/auth'
+
+const route = useRoute()
+const router = useRouter()
+
+const form = reactive({
+  user: '',
+  password: '',
+})
+const loading = ref(false)
+
+const handleLogin = async () => {
+  if (!form.user || !form.password || loading.value) return
+  loading.value = true
+  try {
+    await loginRequest(form.user, form.password)
+    setAuthenticated(true)
+    const redirect = typeof route.query.redirect === 'string' ? route.query.redirect : '/'
+    await router.push(redirect)
+  } catch {
+    ElMessage.error('Invalid user or password')
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<style scoped>
+.login-page {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--content-bg);
+}
+
+.login-card {
+  width: 360px;
+  padding: 40px 32px 32px;
+  background: var(--sidebar-bg);
+  border: 1px solid var(--header-border);
+  border-radius: 12px;
+}
+
+.login-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+.login-logo {
+  width: 32px;
+  height: 32px;
+}
+
+.login-title {
+  font-weight: 600;
+  font-size: 20px;
+  color: var(--text-primary);
+  letter-spacing: -0.5px;
+}
+
+.login-btn {
+  width: 100%;
+  margin-top: 8px;
+}
+</style>


### PR DESCRIPTION
Replace the browser basic auth popup with a proper login page:

- Stateless HMAC-signed session cookie (frp_session, 7 days, random per-process secret, so sessions reset on restart)
- New public endpoints /api/auth/login, /api/auth/logout, /api/auth/check; check accepts session cookies only, so browsers' cached basic credentials cannot resurrect the dashboard after logout
- Basic auth is kept for API clients (SDK/e2e compatible), with the WWW-Authenticate challenge suppressed for unauthenticated /api requests so browser fetches never trigger the native popup
- Static SPA shell is served publicly; all data APIs stay behind the auth middleware
- Login view, router guard, 401 auto-redirect and logout button in both the frps and frpc dashboards
- e2e healthz tests now assert 401 on an API path instead of /

### WHY

<!-- author to complete -->
