### PR TITLE
nathole: support multiple STUN servers for NAT hole punching (#5504)

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,8 +451,8 @@ Note that it may not work with all types of NAT devices. You might want to fallb
   # frpc.toml
   serverAddr = "x.x.x.x"
   serverPort = 7000
-  # set up a new stun server if the default one is not available.
-  # natHoleStunServer = "xxx"
+  # set up stun servers if the default one is not available.
+  # natHoleStunServer = ["xxx", "yyy"]
 
   [[proxies]]
   name = "p2p_ssh"
@@ -468,8 +468,8 @@ Note that it may not work with all types of NAT devices. You might want to fallb
   # frpc.toml
   serverAddr = "x.x.x.x"
   serverPort = 7000
-  # set up a new stun server if the default one is not available.
-  # natHoleStunServer = "xxx"
+  # set up stun servers if the default one is not available.
+  # natHoleStunServer = ["xxx", "yyy"]
 
   [[visitors]]
   name = "p2p_ssh_visitor"

--- a/client/proxy/xtcp.go
+++ b/client/proxy/xtcp.go
@@ -71,7 +71,7 @@ func (pxy *XTCPProxy) InWorkConn(conn net.Conn, startWorkConnMsg *msg.StartWorkC
 		opts.DisableAssistedAddrs = true
 	}
 
-	prepareResult, err := nathole.Prepare([]string{pxy.clientCfg.NatHoleSTUNServer}, opts)
+	prepareResult, err := nathole.Prepare(pxy.clientCfg.NatHoleSTUNServer, opts)
 	if err != nil {
 		xl.Warnf("nathole prepare error: %v", err)
 		return

--- a/client/visitor/xtcp.go
+++ b/client/visitor/xtcp.go
@@ -266,7 +266,7 @@ func (sv *XTCPVisitor) makeNatHole() {
 		opts.DisableAssistedAddrs = true
 	}
 
-	prepareResult, err := nathole.Prepare([]string{sv.clientCfg.NatHoleSTUNServer}, opts)
+	prepareResult, err := nathole.Prepare(sv.clientCfg.NatHoleSTUNServer, opts)
 	if err != nil {
 		xl.Warnf("nathole prepare error: %v", err)
 		return

--- a/cmd/frpc/sub/nathole.go
+++ b/cmd/frpc/sub/nathole.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/fatedier/frp/pkg/config"
+	"github.com/fatedier/frp/pkg/config/types"
 	v1 "github.com/fatedier/frp/pkg/config/v1"
 	"github.com/fatedier/frp/pkg/nathole"
 )
@@ -57,7 +58,7 @@ var natholeDiscoveryCmd = &cobra.Command{
 			}
 		}
 		if natHoleSTUNServer != "" {
-			cfg.NatHoleSTUNServer = natHoleSTUNServer
+			cfg.NatHoleSTUNServer = types.StringList{natHoleSTUNServer}
 		}
 
 		if err := validateForNatHoleDiscovery(cfg); err != nil {
@@ -65,7 +66,7 @@ var natholeDiscoveryCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		addrs, localAddr, err := nathole.Discover([]string{cfg.NatHoleSTUNServer}, natHoleLocalAddr)
+		addrs, localAddr, err := nathole.Discover(cfg.NatHoleSTUNServer, natHoleLocalAddr)
 		if err != nil {
 			fmt.Println("discover error:", err)
 			os.Exit(1)
@@ -93,7 +94,7 @@ var natholeDiscoveryCmd = &cobra.Command{
 }
 
 func validateForNatHoleDiscovery(cfg *v1.ClientCommonConfig) error {
-	if cfg.NatHoleSTUNServer == "" {
+	if len(cfg.NatHoleSTUNServer) == 0 {
 		return fmt.Errorf("nat_hole_stun_server can not be empty")
 	}
 	return nil

--- a/conf/frpc_full_example.toml
+++ b/conf/frpc_full_example.toml
@@ -11,8 +11,9 @@ user = "your_name"
 serverAddr = "0.0.0.0"
 serverPort = 7000
 
-# STUN server to help penetrate NAT hole.
-# natHoleStunServer = "stun.easyvoip.com:3478"
+# STUN servers to help penetrate NAT hole. Multiple servers improve the
+# punch-through success rate; a single value is also accepted.
+# natHoleStunServer = ["stun.easyvoip.com:3478", "stun2.example.com:3478"]
 
 # Decide if exit program when first login failed, otherwise continuous relogin to frps
 # default is true

--- a/conf/legacy/frpc_legacy_full.ini
+++ b/conf/legacy/frpc_legacy_full.ini
@@ -6,8 +6,8 @@
 server_addr = 0.0.0.0
 server_port = 7000
 
-# STUN server to help penetrate NAT hole.
-# nat_hole_stun_server = stun.easyvoip.com:3478
+# STUN servers to help penetrate NAT hole. A comma-separated list is accepted.
+# nat_hole_stun_server = stun.easyvoip.com:3478,stun2.example.com:3478
 
 # The maximum amount of time a dial to server will wait for a connect to complete. Default value is 10 seconds.
 # dial_server_timeout = 10

--- a/pkg/config/legacy/conversion.go
+++ b/pkg/config/legacy/conversion.go
@@ -43,7 +43,11 @@ func Convert_ClientCommonConf_To_v1(conf *ClientCommonConf) *v1.ClientCommonConf
 
 	out.ServerAddr = conf.ServerAddr
 	out.ServerPort = conf.ServerPort
-	out.NatHoleSTUNServer = conf.NatHoleSTUNServer
+	if conf.NatHoleSTUNServer != "" {
+		// Legacy ini config holds a single value; a comma-separated list is
+		// also accepted so legacy users can specify multiple STUN servers.
+		out.NatHoleSTUNServer = types.StringList(strings.Split(conf.NatHoleSTUNServer, ","))
+	}
 	out.Transport.DialServerTimeout = conf.DialServerTimeout
 	out.Transport.DialServerKeepAlive = conf.DialServerKeepAlive
 	out.Transport.ConnectServerLocalIP = conf.ConnectServerLocalIP

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/fatedier/frp/pkg/config/types"
 	v1 "github.com/fatedier/frp/pkg/config/v1"
 )
 
@@ -189,6 +190,47 @@ unixPath = "/tmp/uds.sock"
 	pluginStr += `unknown = "unknown"`
 	err = LoadConfigure([]byte(pluginStr), &clientCfg, true)
 	require.Error(err)
+}
+
+func TestLoadClientConfigNatHoleSTUNServerAcceptsStringAndList(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    types.StringList
+	}{
+		{
+			name: "toml single value for backward compatibility",
+			content: `
+natHoleStunServer = "stun.easyvoip.com:3478"
+`,
+			want: types.StringList{"stun.easyvoip.com:3478"},
+		},
+		{
+			name: "toml multiple values",
+			content: `
+natHoleStunServer = ["stun1.example.com:3478", "stun2.example.com:3478"]
+`,
+			want: types.StringList{"stun1.example.com:3478", "stun2.example.com:3478"},
+		},
+		{
+			name: "yaml multiple values",
+			content: `
+natHoleStunServer:
+- stun1.example.com:3478
+- stun2.example.com:3478
+`,
+			want: types.StringList{"stun1.example.com:3478", "stun2.example.com:3478"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientCfg := v1.ClientConfig{}
+			err := LoadConfigure([]byte(tt.content), &clientCfg, false)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, clientCfg.NatHoleSTUNServer)
+		})
+	}
 }
 
 func TestLoadClientConfigStrictMode_UnknownPluginField(t *testing.T) {

--- a/pkg/config/types/types.go
+++ b/pkg/config/types/types.go
@@ -110,6 +110,31 @@ func (q *BandwidthQuantity) Bytes() int64 {
 	return q.i
 }
 
+// StringList is a list of strings that also accepts a single string value in
+// configuration, so existing single-value configs keep working while new
+// configs can specify multiple values. It is parsed from JSON through the
+// YAML->JSON pipeline used by config loading.
+type StringList []string
+
+func (l *StringList) UnmarshalJSON(b []byte) error {
+	if len(b) == 4 && string(b) == "null" {
+		return nil
+	}
+	if len(b) > 0 && b[0] == '[' {
+		return json.Unmarshal(b, (*[]string)(l))
+	}
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	*l = StringList{s}
+	return nil
+}
+
+func (l StringList) MarshalJSON() ([]byte, error) {
+	return json.Marshal([]string(l))
+}
+
 type PortsRange struct {
 	Start  int `json:"start,omitempty"`
 	End    int `json:"end,omitempty"`

--- a/pkg/config/types/types_test.go
+++ b/pkg/config/types/types_test.go
@@ -64,6 +64,45 @@ func TestBandwidthQuantity_InvalidNumber(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestStringList(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want StringList
+	}{
+		{
+			name: "single value for backward compatibility",
+			json: `"stun.easyvoip.com:3478"`,
+			want: StringList{"stun.easyvoip.com:3478"},
+		},
+		{
+			name: "array",
+			json: `["stun1.example.com:3478","stun2.example.com:3478"]`,
+			want: StringList{"stun1.example.com:3478", "stun2.example.com:3478"},
+		},
+		{
+			name: "null",
+			json: `null`,
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var l StringList
+			err := json.Unmarshal([]byte(tt.json), &l)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, l)
+		})
+	}
+
+	// Marshal always emits an array, even for a single value.
+	l := StringList{"stun.easyvoip.com:3478"}
+	buf, err := json.Marshal(l)
+	require.NoError(t, err)
+	require.Equal(t, `["stun.easyvoip.com:3478"]`, string(buf))
+}
+
 func TestPortsRangeSlice2String(t *testing.T) {
 	require := require.New(t)
 

--- a/pkg/config/v1/client.go
+++ b/pkg/config/v1/client.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/fatedier/frp/pkg/config/types"
 	"github.com/fatedier/frp/pkg/util/util"
 )
 
@@ -46,8 +47,11 @@ type ClientCommonConfig struct {
 	// ServerPort specifies the port to connect to the server on. By default,
 	// this value is 7000.
 	ServerPort int `json:"serverPort,omitempty"`
-	// STUN server to help penetrate NAT hole.
-	NatHoleSTUNServer string `json:"natHoleStunServer,omitempty"`
+	// STUN servers to help penetrate NAT hole. A single value is also
+	// accepted for backward compatibility; specifying multiple servers
+	// improves the NAT hole punching success rate when one of them is
+	// congested.
+	NatHoleSTUNServer types.StringList `json:"natHoleStunServer,omitempty"`
 	// DNSServer specifies a DNS server address for FRPC to use. If this value
 	// is "", the default DNS will be used.
 	DNSServer string `json:"dnsServer,omitempty"`
@@ -86,7 +90,9 @@ func (c *ClientCommonConfig) Complete() error {
 	c.ServerAddr = util.EmptyOr(c.ServerAddr, "0.0.0.0")
 	c.ServerPort = util.EmptyOr(c.ServerPort, 7000)
 	c.LoginFailExit = util.EmptyOr(c.LoginFailExit, lo.ToPtr(true))
-	c.NatHoleSTUNServer = util.EmptyOr(c.NatHoleSTUNServer, "stun.easyvoip.com:3478")
+	if len(c.NatHoleSTUNServer) == 0 {
+		c.NatHoleSTUNServer = types.StringList{"stun.easyvoip.com:3478"}
+	}
 
 	if err := c.Auth.Complete(); err != nil {
 		return err

--- a/pkg/nathole/discovery.go
+++ b/pkg/nathole/discovery.go
@@ -34,13 +34,24 @@ func Discover(stunServers []string, localAddr string) ([]string, net.Addr, error
 	defer discoverConn.Close()
 
 	addresses := make([]string, 0, len(stunServers))
+	var errs []error
 	for _, addr := range stunServers {
 		// get external address from stun server
 		externalAddrs, err := discoverConn.discoverFromStunServer(addr)
 		if err != nil {
-			return nil, nil, err
+			// Try the remaining STUN servers. A single unreachable server must
+			// not abort the whole discovery; the next server may still give us
+			// our external address.
+			errs = append(errs, err)
+			continue
 		}
 		addresses = append(addresses, externalAddrs...)
+	}
+	if len(addresses) == 0 {
+		if len(errs) == 0 {
+			return nil, nil, fmt.Errorf("discover error: no stun server configured")
+		}
+		return nil, nil, fmt.Errorf("discover error: no external address found from any stun server: %v", errors.Join(errs...))
 	}
 	return addresses, discoverConn.localAddr, nil
 }

--- a/pkg/nathole/discovery_test.go
+++ b/pkg/nathole/discovery_test.go
@@ -339,6 +339,93 @@ func TestSTUNTimeoutUsesCallerDeadlineWithoutRetry(t *testing.T) {
 	require.True(t, netErr.Timeout())
 }
 
+func TestDiscoverMergesAddressesFromMultipleSTUNServers(t *testing.T) {
+	server1 := listenTestUDP4(t)
+	server2 := listenTestUDP4(t)
+
+	done1 := serveOneSTUNRequest(server1, func(request []byte, _ *net.UDPAddr) ([]byte, error) {
+		return makeTestSTUNResponse(request, testBindingSuccess,
+			testSTUNAttribute{typ: testAttrXORMapped, value: testIPv4AddressValue(net.ParseIP("198.51.100.10"), 40000, true)},
+		)
+	})
+	done2 := serveOneSTUNRequest(server2, func(request []byte, _ *net.UDPAddr) ([]byte, error) {
+		return makeTestSTUNResponse(request, testBindingSuccess,
+			testSTUNAttribute{typ: testAttrXORMapped, value: testIPv4AddressValue(net.ParseIP("203.0.113.20"), 50000, true)},
+		)
+	})
+
+	addresses, _, err := Discover(
+		[]string{server1.LocalAddr().String(), server2.LocalAddr().String()}, "")
+	require.NoError(t, err)
+	require.Equal(t, []string{"198.51.100.10:40000", "203.0.113.20:50000"}, addresses)
+
+	waitSTUNExchange(t, done1)
+	waitSTUNExchange(t, done2)
+}
+
+func TestDiscoverFallsBackToNextSTUNServer(t *testing.T) {
+	originalTimeout := responseTimeout
+	responseTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { responseTimeout = originalTimeout })
+
+	// First server never replies, so discovery must fall through to the next one.
+	deadServer := listenTestUDP4(t)
+	deadDone := serveOneSTUNRequest(deadServer, nil)
+
+	aliveServer := listenTestUDP4(t)
+	aliveDone := serveOneSTUNRequest(aliveServer, func(request []byte, _ *net.UDPAddr) ([]byte, error) {
+		return makeTestSTUNResponse(request, testBindingSuccess,
+			testSTUNAttribute{typ: testAttrXORMapped, value: testIPv4AddressValue(net.ParseIP("198.51.100.10"), 40000, true)},
+		)
+	})
+
+	addresses, _, err := Discover(
+		[]string{deadServer.LocalAddr().String(), aliveServer.LocalAddr().String()}, "")
+	require.NoError(t, err)
+	require.Equal(t, []string{"198.51.100.10:40000"}, addresses)
+
+	waitSTUNExchange(t, deadDone)
+	waitSTUNExchange(t, aliveDone)
+}
+
+func TestDiscoverIgnoresSubsequentServerFailure(t *testing.T) {
+	originalTimeout := responseTimeout
+	responseTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { responseTimeout = originalTimeout })
+
+	aliveServer := listenTestUDP4(t)
+	aliveDone := serveOneSTUNRequest(aliveServer, func(request []byte, _ *net.UDPAddr) ([]byte, error) {
+		return makeTestSTUNResponse(request, testBindingSuccess,
+			testSTUNAttribute{typ: testAttrXORMapped, value: testIPv4AddressValue(net.ParseIP("198.51.100.10"), 40000, true)},
+		)
+	})
+
+	// Second server never replies; the successful first server must win.
+	deadServer := listenTestUDP4(t)
+	deadDone := serveOneSTUNRequest(deadServer, nil)
+
+	addresses, _, err := Discover(
+		[]string{aliveServer.LocalAddr().String(), deadServer.LocalAddr().String()}, "")
+	require.NoError(t, err)
+	require.Equal(t, []string{"198.51.100.10:40000"}, addresses)
+
+	waitSTUNExchange(t, aliveDone)
+	waitSTUNExchange(t, deadDone)
+}
+
+func TestDiscoverReturnsErrorWhenAllSTUNServersFail(t *testing.T) {
+	originalTimeout := responseTimeout
+	responseTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { responseTimeout = originalTimeout })
+
+	server := listenTestUDP4(t)
+	done := serveOneSTUNRequest(server, nil)
+
+	_, _, err := Discover([]string{server.LocalAddr().String()}, "")
+	require.ErrorContains(t, err, "no external address found from any stun server")
+	waitSTUNExchange(t, done)
+}
+
 func TestSTUNClientLeavesSocketAndDeadlineWithCaller(t *testing.T) {
 	originalTimeout := responseTimeout
 	responseTimeout = 100 * time.Millisecond


### PR DESCRIPTION
## What

Closes #5504 — make the `natHoleStunServer` config support **multiple STUN servers** with real fallback behavior, instead of a single value that aborts discovery on the first failure.

### The bug

`pkg/nathole/discovery.go` already accepted a `[]string` of STUN servers, but any single server failure immediately returned an error, so configuring more than one server had **no effect** — the first unreachable server killed the whole discovery. Meanwhile the config type could only ever carry one value, so users couldn't even try the second server manually.

## Changes

- **`nathole.Discover`**: on per-server failure, `continue` to the next server and aggregate the errors. Only fail when *every* server fails (or none are configured). No dedup needed: `ClassifyNATFeature` compares every address against the first one, so duplicate external addresses are harmless.
- **Config type**: new `types.StringList` (`UnmarshalJSON` accepts both a bare string and an array) so single-value configs keep working unchanged while new configs can list several servers.
- **v1 config**: `natHoleStunServer` now `types.StringList`; `Complete()` keeps the `stun.easyvoip.com:3478` default.
- **legacy ini**: `nat_hole_stun_server` accepts a comma-separated list via conversion.
- **CLI** `frpc nathole discover`: passes the full server list through.
- **Call sites** `client/proxy/xtcp.go` / `client/visitor/xtcp.go`: pass the full list to `Prepare`.

## Tests

- `types.StringList`: single value / array / null parse + marshal.
- `TestDiscoverMergesAddressesFromMultipleSTUNServers`: two live servers → both addresses returned.
- `TestDiscoverFallsBackToNextSTUNServer`: first server silent → falls through to second.
- `TestDiscoverIgnoresSubsequentServerFailure`: first succeeds → second failure ignored.
- `TestDiscoverReturnsErrorWhenAllSTUNServersFail`: all silent → aggregated error.
- `TestLoadClientConfigNatHoleSTUNServerAcceptsStringAndList`: TOML string, TOML array, YAML list all parse into the same `StringList`.

All affected package tests pass (`pkg/config/...`, `pkg/nathole/...`), full `go build -tags noweb ./...` is clean, and all changed Go files are gofmt-clean.