### PR TITLE
fix(vhost): relay the origin's Content-Encoding instead of inflating …

### DIFF
--- a/pkg/util/vhost/http.go
+++ b/pkg/util/vhost/http.go
@@ -105,6 +105,7 @@ func NewHTTPReverseProxy(option HTTPReverseProxyOptions, vhostRouter *Routers) *
 			ResponseHeaderTimeout: rp.responseHeaderTimeout,
 			IdleConnTimeout:       60 * time.Second,
 			MaxIdleConnsPerHost:   5,
+			DisableCompression:    true,
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				return rp.CreateConnection(ctx.Value(RouteInfoKey).(*RequestRouteInfo), true)
 			},


### PR DESCRIPTION
### WHY

`pkg/util/vhost/http.go` builds the HTTP reverse proxy's `http.Transport` without setting `DisableCompression`. That field defaults to `false`, so when a client sends **no** `Accept-Encoding`, the Transport adds `Accept-Encoding: gzip` on its own behalf, transparently decodes the response, and strips `Content-Encoding` and `Content-Length`.

That is the right convenience for application code using `http.Client`. In a reverse proxy it means the client receives a representation neither it nor the origin asked for.

This looks inherited rather than chosen. The Transport is constructed deliberately — `ResponseHeaderTimeout`, `IdleConnTimeout`, `MaxIdleConnsPerHost`, a custom `DialContext` and `Proxy` — but compression is left at the stdlib default, and `DisableCompression` appears nowhere in the repository, nor in any issue or prior PR. If the inflation is intended, this PR is wrong and I would rather be told so; if it is not, it is a one-line change.

### Measured

A local server behind `frpc` serving a pre-gzipped 262,107-byte file, requested through `frps`:

| client `Accept-Encoding` | bytes delivered | `content-encoding` | `content-length` |
|---|---:|---|---|
| `gzip` | 262,107 | gzip | present |
| `identity` | 262,107 | gzip | present |
| `deflate` | 262,107 | gzip | present |
| `foobar` | 262,107 | gzip | present |
| **absent (or empty)** | **1,239,673** | **(none)** | **absent, chunked** |

The origin sent 262,107 bytes with `Content-Encoding: gzip` in every one of these cases — confirmed by querying it directly with no proxy in the path, byte-identical with and without the header. Only the absent-header case is rewritten, and the response also loses `Content-Length` and becomes chunked, which is the tell for on-the-fly inflation.

### What triggers it

The condition is in `net/http`'s `Transport`:

```go
if !pc.t.DisableCompression &&
	req.Header.Get("Accept-Encoding") == "" &&
	req.Header.Get("Range") == "" &&
	req.Method != "HEAD" {
	requestedGzip = true
	req.extraHeaders().Set("Accept-Encoding", "gzip")
}
```

`Header.Get` returns `""` for both an absent header and a present-but-empty one, so both take this path; a `Range` request or a `HEAD` suppresses it.

The `foobar` row is what isolates this to the Go Transport. A gunzip filter in a front proxy decompresses when the client does *not* accept gzip, so it would have inflated that row too. It came back compressed. Only the absent header triggers the rewrite.

### Why this is worth fixing

- **`no-transform` is not honoured.** [RFC 9111 §5.2.2.6](https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.6): the directive "indicates that an intermediary (regardless of whether it implements a cache) **MUST NOT** transform the content". `net/http` has no notion of it — `grep -rn "no-transform" net/http` returns nothing — so these responses are inflated like any other. This one is unconditional.
- **Nobody asked for the transformation.** [RFC 9110 §12.5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.3): an absent `Accept-Encoding` means any content coding is acceptable. [§7.7](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.7) does permit a proxy to transform content that is not marked `no-transform`, so this is not a blanket violation — but the client expressed no preference and the origin chose gzip, and frp converts that into a decision to decompress that no party requested.
- **Egress.** 4.7× the bytes on this response, spent on the tunnel the proxy exists to carry traffic over. `Content-Length` is lost too, so the response becomes chunked and downstream consumers lose progress and sizing information.
- **Correctness.** A client that treats a `.gz` URL as an actual gzip file receives plain text under a `.gz` name and fails to decode it.
- **It hides.** Any request carrying `Accept-Encoding: gzip` — most clients, and every `curl --compressed` — behaves correctly. Only a client sending no header at all sees it, and those tend to be other proxies and embedded HTTP clients rather than browsers.

### Not specific to frp

`httputil.ReverseProxy` falls back to `http.DefaultTransport` when `Transport` is nil, and `DefaultTransport` leaves `DisableCompression` unset, so any Go reverse proxy that does not explicitly opt out behaves the same way.

<details>
<summary>Standalone reproduction — stdlib only, no frp</summary>

```go
package main

import (
	"bytes"
	"compress/gzip"
	"fmt"
	"io"
	"net/http"
	"net/http/httptest"
	"net/http/httputil"
	"net/url"
	"strings"
)

func main() {
	var buf bytes.Buffer
	zw := gzip.NewWriter(&buf)
	zw.Write([]byte(strings.Repeat("x", 100000)))
	zw.Close()
	body := buf.Bytes()

	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		fmt.Printf("  origin saw Accept-Encoding: %q\n", r.Header.Get("Accept-Encoding"))
		w.Header().Set("Content-Encoding", "gzip")
		w.Header().Set("Content-Length", fmt.Sprint(len(body)))
		w.Write(body)
	}))
	defer origin.Close()

	u, _ := url.Parse(origin.URL)
	proxy := httptest.NewServer(httputil.NewSingleHostReverseProxy(u)) // Transport nil -> DefaultTransport
	defer proxy.Close()

	fmt.Printf("origin serves %d gzipped bytes\n\n", len(body))
	for _, ae := range []string{"gzip", ""} {
		req, _ := http.NewRequest("GET", proxy.URL, nil)
		if ae != "" {
			req.Header.Set("Accept-Encoding", ae)
		}
		fmt.Printf("client sends Accept-Encoding: %q\n", ae)
		resp, _ := (&http.Transport{DisableCompression: true}).RoundTrip(req)
		got, _ := io.ReadAll(resp.Body)
		resp.Body.Close()
		fmt.Printf("  client got %d bytes, content-encoding=%q\n\n", len(got), resp.Header.Get("Content-Encoding"))
	}
}
```

```
origin serves 136 gzipped bytes

client sends Accept-Encoding: "gzip"
  origin saw Accept-Encoding: "gzip"
  client got 136 bytes, content-encoding="gzip"

client sends Accept-Encoding: ""
  origin saw Accept-Encoding: "gzip"      <-- the proxy invented this
  client got 100000 bytes, content-encoding=""
```

The ratio is exaggerated by a trivially compressible payload; the point is the invented request header and the stripped response header, not the number.
</details>

### The change

One line on the Transport:

```go
Transport: &http.Transport{
	ResponseHeaderTimeout: rp.responseHeaderTimeout,
	IdleConnTimeout:       60 * time.Second,
	MaxIdleConnsPerHost:   5,
	DisableCompression:    true,
	DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
		return rp.CreateConnection(ctx.Value(RouteInfoKey).(*RequestRouteInfo), true)
	},
	...
}
```

`Response.Uncompressed` documents this as the intended escape hatch: *"To get the original response from the server, set `Transport.DisableCompression` to true."*

### Trade-off worth stating

This also stops the Transport requesting gzip on its own behalf. For an origin that *honours* `Accept-Encoding`, a client sending no header will now get an uncompressed body where the tunnel previously carried a compressed one.

Correct relaying seems clearly worth that — a client that wants compression should ask for it, and the proxy should not invent a request the client did not make. But it is a real behaviour change for anyone relying on the current inflation as an implicit optimisation, so it is called out rather than buried.

Not affected: `transport.useCompression` / `--uc`. That is snappy on the frpc↔frps work connection, a layer below HTTP, and orthogonal to this.

### Verifying

```sh
curl -s -D- -o /dev/null http://<subdomain>/<a-pre-gzipped-file>
```

`curl` sends no `Accept-Encoding` of its own unless `--compressed` is passed, so this is the absent case. `-H 'Accept-Encoding;'` sends it empty and behaves identically, per the condition above.

- before: no `content-encoding`, no `content-length`, inflated body
- after: `content-encoding: gzip`, `content-length` present, bytes exactly as the origin sent them

Sending `-H 'Accept-Encoding: gzip'` returns the compressed body either way.

### Notes

- `gofmt` and `golangci-lint run` are clean on the change.
- We are running this patch and have verified it end to end: the numbers above are measured before and after, against a real deployment rather than a synthetic reproduction.
- Happy to add an e2e case under `test/e2e/` asserting that a pre-compressed origin response survives with `Content-Encoding` intact when the client sends no `Accept-Encoding`, if you would like the regression pinned down.
