### PR TITLE
fix: report real client IP for ws/wss connections

### DIFF
--- a/client/connector.go
+++ b/client/connector.go
@@ -215,7 +215,7 @@ func (c *defaultConnectorImpl) realConnect() (net.Conn, error) {
 	switch protocol {
 	case "websocket":
 		protocol = "tcp"
-		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{Hook: netpkg.DialHookWebsocket(protocol, "")}))
+		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{Hook: netpkg.DialHookWebsocket(protocol, "", c.cfg.Transport.WebsocketPath)}))
 		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{
 			Hook: netpkg.DialHookCustomTLSHeadByte(tlsConfig != nil, lo.FromPtr(c.cfg.Transport.TLS.DisableCustomTLSFirstByte)),
 		}))
@@ -224,7 +224,7 @@ func (c *defaultConnectorImpl) realConnect() (net.Conn, error) {
 		protocol = "tcp"
 		dialOptions = append(dialOptions, libnet.WithTLSConfigAndPriority(100, tlsConfig))
 		// Make sure that if it is wss, the websocket hook is executed after the tls hook.
-		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{Hook: netpkg.DialHookWebsocket(protocol, tlsConfig.ServerName), Priority: 110}))
+		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{Hook: netpkg.DialHookWebsocket(protocol, tlsConfig.ServerName, c.cfg.Transport.WebsocketPath), Priority: 110}))
 	default:
 		dialOptions = append(dialOptions, libnet.WithAfterHook(libnet.AfterHook{
 			Hook: netpkg.DialHookCustomTLSHeadByte(tlsConfig != nil, lo.FromPtr(c.cfg.Transport.TLS.DisableCustomTLSFirstByte)),

--- a/conf/frpc_full_example.toml
+++ b/conf/frpc_full_example.toml
@@ -136,6 +136,24 @@ transport.tls.enable = true
 # Since v0.50.0, the default value has been changed to true, and the first custom byte is disabled by default.
 # transport.tls.disableCustomTLSFirstByte = true
 
+# transport.websocketPath specifies the URL path used when protocol is
+# "websocket" or "wss". It must match one of the paths configured on frps via
+# transport.websocketPaths; otherwise the connection will be rejected.
+#
+# If empty, the default path "/~!frp" is used. The value is automatically
+# prefixed with "/" if it does not already start with one.
+#
+# Example (connect to a custom websocket endpoint configured on frps):
+# transport.protocol = "websocket"
+# transport.websocketPath = "/custom/path"
+#
+# Combined with frps side:
+#   # frps.toml
+#   transport.websocketPaths = ["/~!frp", "/custom/path"]
+#   # frpc.toml
+#   transport.protocol = "websocket"
+#   transport.websocketPath = "/custom/path"
+
 # Heartbeat configure, it's not recommended to modify the default value.
 # The default value of heartbeatInterval is 10 and heartbeatTimeout is 90. Set negative value
 # to disable it.

--- a/conf/frps_full_example.toml
+++ b/conf/frps_full_example.toml
@@ -47,6 +47,23 @@ transport.tls.force = false
 # transport.tls.keyFile = "server.key"
 # transport.tls.trustedCaFile = "ca.crt"
 
+# transport.websocketPaths specifies the URL paths that frps accepts websocket
+# upgrade requests on. frpc must connect using one of these paths (see
+# transport.websocketPath in frpc's config).
+#
+# Multiple paths can be configured so that frpc can connect through different
+# entry points, for example behind different reverse proxies / locations, or
+# when you want to expose frp over websocket on more than one endpoint.
+#
+# If empty, the default path "/~!frp" is used. Each path is automatically
+# prefixed with "/" if it does not already start with one.
+#
+# Example: accept websocket connections on several endpoints:
+# transport.websocketPaths = ["/~!frp", "/frp-ws", "/custom/path"]
+#
+# Note: this option only takes effect when transport.protocol on the frpc side
+# is set to "websocket" or "wss".
+
 # If you want to support virtual host, you must set the http port for listening (optional)
 # Note: http port and https port can be same with bindPort
 vhostHTTPPort = 80

--- a/pkg/config/v1/client.go
+++ b/pkg/config/v1/client.go
@@ -16,6 +16,7 @@ package v1
 
 import (
 	"os"
+	"strings"
 
 	"github.com/samber/lo"
 
@@ -142,6 +143,11 @@ type ClientTransportConfig struct {
 	HeartbeatTimeout int64 `json:"heartbeatTimeout,omitempty"`
 	// TLS specifies TLS settings for the connection to the server.
 	TLS TLSClientConfig `json:"tls,omitempty"`
+	// WebsocketPath specifies the URL path used when connecting to the server
+	// over the "websocket" or "wss" protocol. It must match one of the paths
+	// configured on frps via transport.websocketPaths. If empty, the default
+	// path "/~!frp" is used.
+	WebsocketPath string `json:"websocketPath,omitempty"`
 }
 
 func (c *ClientTransportConfig) Complete() {
@@ -163,6 +169,12 @@ func (c *ClientTransportConfig) Complete() {
 	}
 	c.QUIC.Complete()
 	c.TLS.Complete()
+	// Normalize the websocket path so a value without a leading "/" (e.g.
+	// "custom/path") produces a valid URL. The server side does the same in
+	// ServerTransportConfig.Complete(); keep the client consistent.
+	if c.WebsocketPath != "" && !strings.HasPrefix(c.WebsocketPath, "/") {
+		c.WebsocketPath = "/" + c.WebsocketPath
+	}
 }
 
 type TLSClientConfig struct {

--- a/pkg/config/v1/server.go
+++ b/pkg/config/v1/server.go
@@ -15,6 +15,8 @@
 package v1
 
 import (
+	"strings"
+
 	"github.com/samber/lo"
 
 	"github.com/fatedier/frp/pkg/config/types"
@@ -177,6 +179,16 @@ type ServerTransportConfig struct {
 	QUIC QUICOptions `json:"quic,omitempty"`
 	// TLS specifies TLS settings for the connection from the client.
 	TLS TLSServerConfig `json:"tls,omitempty"`
+	// WebsocketPaths specifies the URL paths that the server accepts websocket
+	// upgrade requests on. Multiple paths can be configured so that frpc can
+	// connect through different entry points (e.g. behind different reverse
+	// proxies). It also enables wss (websocket over TLS): after TLS termination
+	// frps inspects each client connection for a websocket upgrade request
+	// matching one of these paths. This detection only runs when at least one
+	// path is configured here, so default frps (no websocketPaths set) pays no
+	// per-connection peeking cost. When empty, the plaintext websocket listener
+	// still serves the default path "/~!frp".
+	WebsocketPaths []string `json:"websocketPaths,omitempty"`
 }
 
 func (c *ServerTransportConfig) Complete() {
@@ -193,6 +205,11 @@ func (c *ServerTransportConfig) Complete() {
 	c.QUIC.Complete()
 	if c.TLS.TrustedCaFile != "" {
 		c.TLS.Force = true
+	}
+	for i, p := range c.WebsocketPaths {
+		if !strings.HasPrefix(p, "/") {
+			c.WebsocketPaths[i] = "/" + p
+		}
 	}
 }
 

--- a/pkg/util/net/dial.go
+++ b/pkg/util/net/dial.go
@@ -21,7 +21,7 @@ func DialHookCustomTLSHeadByte(enableTLS bool, disableCustomTLSHeadByte bool) li
 	}
 }
 
-func DialHookWebsocket(protocol string, host string) libnet.AfterHookFunc {
+func DialHookWebsocket(protocol string, host string, path string) libnet.AfterHookFunc {
 	return func(ctx context.Context, c net.Conn, addr string) (context.Context, net.Conn, error) {
 		if protocol != "wss" {
 			protocol = "ws"
@@ -29,7 +29,10 @@ func DialHookWebsocket(protocol string, host string) libnet.AfterHookFunc {
 		if host == "" {
 			host = addr
 		}
-		addr = protocol + "://" + host + FrpWebsocketPath
+		if path == "" {
+			path = FrpWebsocketPath
+		}
+		addr = protocol + "://" + host + path
 		uri, err := url.Parse(addr)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/util/net/websocket.go
+++ b/pkg/util/net/websocket.go
@@ -1,6 +1,8 @@
 package net
 
 import (
+	"bufio"
+	"bytes"
 	"errors"
 	"net"
 	"net/http"
@@ -19,19 +21,72 @@ type WebsocketListener struct {
 	ln       net.Listener
 	acceptCh chan net.Conn
 
-	server *http.Server
+	// paths are the URL paths accepted for websocket upgrade.
+	paths []string
+	// wsServer handles a single websocket upgrade on an already-prepared
+	// connection. It is used both by the plaintext listener and by wss after
+	// TLS termination (see HandleConn).
+	wsServer *websocket.Server
+	server   *http.Server
+}
+
+// IsWebsocketRequest reports whether the initial bytes read from a connection
+// look like a websocket upgrade request targeting one of the given paths.
+func IsWebsocketRequest(data []byte, paths []string) bool {
+	const prefix = "GET "
+	if len(data) < len(prefix) {
+		return false
+	}
+	if !bytes.HasPrefix(data, []byte(prefix)) {
+		return false
+	}
+	rest := data[len(prefix):]
+	for _, p := range paths {
+		if len(rest) >= len(p) && bytes.Equal(rest[:len(p)], []byte(p)) {
+			// Make sure the matched path is not a prefix of a longer one,
+			// i.e. it is followed by a space (end of request line) or the
+			// data we have read ends exactly at the path.
+			if len(rest) == len(p) || rest[len(p)] == ' ' {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// maxWebsocketPrefixLen returns the number of bytes that must be read so the
+// muxer (or a peek) can decide whether a request targets one of paths.
+func maxWebsocketPrefixLen(paths []string) int {
+	n := len("GET ") + len(FrpWebsocketPath)
+	for _, p := range paths {
+		if l := len("GET ") + len(p); l > n {
+			n = l
+		}
+	}
+	return n
 }
 
 // NewWebsocketListener to handle websocket connections
 // ln: tcp listener for websocket connections
-func NewWebsocketListener(ln net.Listener) (wl *WebsocketListener) {
+// paths: the URL paths that are accepted for websocket upgrade. When empty,
+// the default FrpWebsocketPath is used.
+func NewWebsocketListener(ln net.Listener, paths ...string) (wl *WebsocketListener) {
 	wl = &WebsocketListener{
 		ln:       ln,
 		acceptCh: make(chan net.Conn),
 	}
 
-	muxer := http.NewServeMux()
-	muxer.Handle(FrpWebsocketPath, websocket.Handler(func(c *websocket.Conn) {
+	if len(paths) == 0 {
+		paths = []string{FrpWebsocketPath}
+	}
+	wl.paths = paths
+
+	handler := func(c *websocket.Conn) {
+		// Reject requests whose path is not one of the configured paths.
+		if !pathAllowed(c.Request().URL.Path, wl.paths) {
+			c.Close()
+			return
+		}
 		// The tunnel payload is a raw byte stream (yamux), not UTF-8 text.
 		// Send it as binary frames; otherwise RFC 6455-compliant intermediaries
 		// (e.g. API gateways/reverse proxies) UTF-8-validate the default text
@@ -43,11 +98,31 @@ func NewWebsocketListener(ln net.Listener) (wl *WebsocketListener) {
 		})
 		wl.acceptCh <- conn
 		<-notifyCh
-	}))
+	}
 
+	wl.wsServer = &websocket.Server{
+		Handler: websocket.Handler(handler),
+		// Populate config.Origin during the handshake. *websocket.Conn's
+		// RemoteAddr() returns the origin URL, so without this it would be
+		// nil and RemoteAddr().String() would panic. This mirrors the
+		// default checkOrigin behaviour used by websocket.Handler (which the
+		// plaintext ws path relies on), while keeping frp's token-based auth
+		// as the real access control.
+		Handshake: func(config *websocket.Config, req *http.Request) error {
+			origin, err := websocket.Origin(config, req)
+			if err != nil {
+				return err
+			}
+			if origin == nil {
+				return errors.New("null origin")
+			}
+			config.Origin = origin
+			return nil
+		},
+	}
 	wl.server = &http.Server{
 		Addr:              ln.Addr().String(),
-		Handler:           muxer,
+		Handler:           wl.wsServer,
 		ReadHeaderTimeout: 60 * time.Second,
 	}
 
@@ -55,6 +130,22 @@ func NewWebsocketListener(ln net.Listener) (wl *WebsocketListener) {
 		_ = wl.server.Serve(ln)
 	}()
 	return
+}
+
+// HandleConn upgrades an already-prepared connection (e.g. one whose TLS has
+// already been terminated by the caller) to a websocket connection and hands
+// it to the listener. It is used to support wss (websocket over TLS) where the
+// TLS termination happens before the websocket muxer can see the plaintext
+// "GET" request.
+func (wl *WebsocketListener) HandleConn(c net.Conn) error {
+	br := bufio.NewReader(c)
+	req, err := http.ReadRequest(br)
+	if err != nil {
+		return err
+	}
+	w := &hijackResponseWriter{conn: c, buf: br}
+	wl.wsServer.ServeHTTP(w, req)
+	return nil
 }
 
 func (p *WebsocketListener) Accept() (net.Conn, error) {
@@ -71,4 +162,79 @@ func (p *WebsocketListener) Close() error {
 
 func (p *WebsocketListener) Addr() net.Addr {
 	return p.ln.Addr()
+}
+
+// TryWebsocket peeks the initial bytes of a (TLS-terminated) connection to
+// decide whether it is a websocket upgrade request for one of the given paths.
+// It always returns a connection with the peeked bytes preserved so the caller
+// can keep using it regardless of the result. The boolean reports whether the
+// connection looks like a websocket request.
+func TryWebsocket(c net.Conn, paths []string) (net.Conn, bool) {
+	n := maxWebsocketPrefixLen(paths)
+	if n < 256 {
+		n = 256
+	}
+	buf := make([]byte, n)
+	total := 0
+	_ = c.SetReadDeadline(time.Now().Add(3 * time.Second))
+	for total < n {
+		m, err := c.Read(buf[total:])
+		if m > 0 {
+			total += m
+		}
+		if err != nil {
+			break
+		}
+		if bytes.Contains(buf[:total], []byte("\n")) {
+			break
+		}
+	}
+	_ = c.SetReadDeadline(time.Time{})
+	data := buf[:total]
+	restored := &peekedConn{Conn: c, buf: bytes.NewBuffer(data)}
+	return restored, IsWebsocketRequest(data, paths)
+}
+
+func pathAllowed(path string, allowed []string) bool {
+	for _, p := range allowed {
+		if p == path {
+			return true
+		}
+	}
+	return false
+}
+
+// peekedConn wraps a net.Conn and replays previously read bytes before reading
+// from the underlying connection.
+type peekedConn struct {
+	net.Conn
+	buf *bytes.Buffer
+}
+
+func (p *peekedConn) Read(b []byte) (int, error) {
+	if p.buf.Len() > 0 {
+		return p.buf.Read(b)
+	}
+	return p.Conn.Read(b)
+}
+
+// hijackResponseWriter is a minimal http.ResponseWriter/http.Hijacker used to
+// drive websocket.Server.ServeHTTP against a raw connection.
+type hijackResponseWriter struct {
+	conn net.Conn
+	buf  *bufio.Reader
+}
+
+func (h *hijackResponseWriter) Header() http.Header {
+	return make(http.Header)
+}
+
+func (h *hijackResponseWriter) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+
+func (h *hijackResponseWriter) WriteHeader(int) {}
+
+func (h *hijackResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return h.conn, bufio.NewReadWriter(h.buf, bufio.NewWriter(h.conn)), nil
 }

--- a/pkg/util/net/websocket.go
+++ b/pkg/util/net/websocket.go
@@ -93,7 +93,11 @@ func NewWebsocketListener(ln net.Listener, paths ...string) (wl *WebsocketListen
 		// frames and close the connection on invalid bytes.
 		c.PayloadType = websocket.BinaryFrame
 		notifyCh := make(chan struct{})
-		conn := WrapCloseNotifyConn(c, func(_ error) {
+		// *websocket.Conn.RemoteAddr() reports the websocket origin URL rather
+		// than the real client address, so surface the actual peer address
+		// (recorded on the upgrade request) to frps.
+		ra := remoteAddrFromRequest(c.Request(), c.RemoteAddr())
+		conn := WrapCloseNotifyConn(&wsRemoteAddrConn{Conn: c, remoteAddr: ra}, func(_ error) {
 			close(notifyCh)
 		})
 		wl.acceptCh <- conn
@@ -143,10 +147,45 @@ func (wl *WebsocketListener) HandleConn(c net.Conn) error {
 	if err != nil {
 		return err
 	}
+	// http.Server normally sets Request.RemoteAddr before invoking the
+	// handler, but here we drive ServeHTTP directly, so record the real
+	// client address (the underlying connection peer) ourselves. frps uses
+	// it as the client address instead of the websocket origin URL.
+	if req.RemoteAddr == "" {
+		req.RemoteAddr = c.RemoteAddr().String()
+	}
 	w := &hijackResponseWriter{conn: c, buf: br}
 	wl.wsServer.ServeHTTP(w, req)
 	return nil
 }
+
+// wsRemoteAddrConn overrides RemoteAddr so that frps sees the real client
+// address (from the upgrade request) instead of the websocket origin URL that
+// *websocket.Conn.RemoteAddr would otherwise report.
+type wsRemoteAddrConn struct {
+	*websocket.Conn
+	remoteAddr net.Addr
+}
+
+func (w *wsRemoteAddrConn) RemoteAddr() net.Addr { return w.remoteAddr }
+
+// remoteAddrFromRequest returns the real client network address recorded on
+// the websocket upgrade request. When it is unavailable, fallback (the
+// websocket origin) is returned to avoid breaking existing behaviour.
+func remoteAddrFromRequest(req *http.Request, fallback net.Addr) net.Addr {
+	if req != nil && req.RemoteAddr != "" {
+		if tcp, err := net.ResolveTCPAddr("tcp", req.RemoteAddr); err == nil {
+			return tcp
+		}
+		return stringAddr(req.RemoteAddr)
+	}
+	return fallback
+}
+
+type stringAddr string
+
+func (a stringAddr) Network() string { return "tcp" }
+func (a stringAddr) String() string { return string(a) }
 
 func (p *WebsocketListener) Accept() (net.Conn, error) {
 	c, ok := <-p.acceptCh

--- a/pkg/util/net/websocket_test.go
+++ b/pkg/util/net/websocket_test.go
@@ -1,0 +1,158 @@
+package net
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"golang.org/x/net/websocket"
+)
+
+// genTestCert returns a self-signed TLS certificate for use in tests.
+func genTestCert(t *testing.T) tls.Certificate {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{"localhost"},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	keyBytes, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("x509 key pair: %v", err)
+	}
+	return cert
+}
+
+func TestWebsocketListenerHandleConnWSS(t *testing.T) {
+	cert := genTestCert(t)
+	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
+
+	// A throwaway listener keeps NewWebsocketListener's internal HTTP server
+	// busy without interfering with the wss test below.
+	dummy, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("dummy listen: %v", err)
+	}
+	defer dummy.Close()
+	wl := NewWebsocketListener(dummy, "/~!frp", "/api/message")
+	defer wl.Close()
+
+	// The actual wss endpoint: a plain TCP listener that, after manually
+	// terminating TLS (mirroring frps' CheckAndEnableTLS), hands the
+	// plaintext connection to HandleConn.
+	tlsLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("tls listen: %v", err)
+	}
+	defer tlsLn.Close()
+
+	go func() {
+		conn, err := tlsLn.Accept()
+		if err != nil {
+			return
+		}
+		tlsConn := tls.Server(conn, tlsConfig)
+		if err := tlsConn.Handshake(); err != nil {
+			return
+		}
+		_ = wl.HandleConn(tlsConn)
+	}()
+
+	// Client connects via wss to /api/message.
+	origin := "https://" + tlsLn.Addr().String()
+	cfg, err := websocket.NewConfig("wss://"+tlsLn.Addr().String()+"/api/message", origin)
+	if err != nil {
+		t.Fatalf("ws config: %v", err)
+	}
+	cfg.TlsConfig = &tls.Config{InsecureSkipVerify: true}
+	client, err := websocket.DialConfig(cfg)
+	if err != nil {
+		t.Fatalf("ws dial: %v", err)
+	}
+	defer client.Close()
+
+	// Server should accept the upgraded connection through Accept().
+	srvConn, err := wl.Accept()
+	if err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+	defer srvConn.Close()
+
+	// Regression: *websocket.Conn.RemoteAddr() resolves the origin URL, which
+	// must not be nil (would panic before config.Origin was populated).
+	if addr := srvConn.RemoteAddr().String(); addr == "" {
+		t.Fatalf("RemoteAddr() returned empty string")
+	}
+
+	// Exchange a payload to prove the tunnel works end to end.
+	if _, err := client.Write([]byte("hello")); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	buf := make([]byte, 5)
+	if _, err := srvConn.Read(buf); err != nil {
+		t.Fatalf("server read: %v", err)
+	}
+	if string(buf) != "hello" {
+		t.Fatalf("unexpected payload: %q", string(buf))
+	}
+}
+
+func TestTryWebsocket(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	// Simulate a client that immediately sends a websocket upgrade request.
+	go func() {
+		_, _ = client.Write([]byte("GET /api/message HTTP/1.1\r\nUpgrade: websocket\r\n\r\n"))
+	}()
+
+	restored, ok := TryWebsocket(server, []string{"/~!frp", "/api/message"})
+	if !ok {
+		t.Fatalf("TryWebsocket should detect the websocket upgrade")
+	}
+	// The peeked bytes must be preserved so the websocket handshake can
+	// continue using the restored connection.
+	buf := make([]byte, 64)
+	n, err := restored.Read(buf)
+	if err != nil {
+		t.Fatalf("read restored: %v", err)
+	}
+	if !containsBytes(buf[:n], []byte("GET /api/message")) {
+		t.Fatalf("peeked bytes not preserved: %q", string(buf[:n]))
+	}
+}
+
+func containsBytes(haystack, needle []byte) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if string(haystack[i:i+len(needle)]) == string(needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/net/websocket_test.go
+++ b/pkg/util/net/websocket_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/pem"
 	"math/big"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -103,10 +104,17 @@ func TestWebsocketListenerHandleConnWSS(t *testing.T) {
 	}
 	defer srvConn.Close()
 
-	// Regression: *websocket.Conn.RemoteAddr() resolves the origin URL, which
-	// must not be nil (would panic before config.Origin was populated).
-	if addr := srvConn.RemoteAddr().String(); addr == "" {
+	// Regression: RemoteAddr() must report the real client TCP address, not
+	// the websocket origin URL (e.g. "http://ssps.sazas.cn:1000").
+	addr := srvConn.RemoteAddr().String()
+	if addr == "" {
 		t.Fatalf("RemoteAddr() returned empty string")
+	}
+	if !strings.HasPrefix(addr, "127.0.0.1:") {
+		t.Fatalf("RemoteAddr() = %q, want the real client address (127.0.0.1:*)", addr)
+	}
+	if strings.Contains(addr, "ssps.sazas.cn") {
+		t.Fatalf("RemoteAddr() returned the websocket origin URL: %q", addr)
 	}
 
 	// Exchange a payload to prove the tunnel works end to end.

--- a/server/service.go
+++ b/server/service.go
@@ -15,7 +15,6 @@
 package server
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -92,7 +91,7 @@ type Service struct {
 	quicListener *quic.Listener
 
 	// Accept connections using websocket
-	websocketListener net.Listener
+	websocketListener *netpkg.WebsocketListener
 
 	// Accept frp tls connections
 	tlsListener net.Listener
@@ -287,11 +286,22 @@ func NewService(cfg *v1.ServerConfig) (*Service, error) {
 	}
 
 	// Listen for accepting connections from client using websocket protocol.
-	websocketPrefix := []byte("GET " + netpkg.FrpWebsocketPath)
-	websocketLn := svr.muxer.Listen(0, uint32(len(websocketPrefix)), func(data []byte) bool {
-		return bytes.Equal(data, websocketPrefix)
+	websocketPaths := cfg.Transport.WebsocketPaths
+	if len(websocketPaths) == 0 {
+		websocketPaths = []string{netpkg.FrpWebsocketPath}
+	}
+	// The muxer needs to read enough bytes to cover the longest "GET <path>"
+	// prefix so it can decide which listener should handle the connection.
+	maxPrefixLen := len("GET ") + len(netpkg.FrpWebsocketPath)
+	for _, p := range websocketPaths {
+		if l := len("GET ") + len(p); l > maxPrefixLen {
+			maxPrefixLen = l
+		}
+	}
+	websocketLn := svr.muxer.Listen(0, uint32(maxPrefixLen), func(data []byte) bool {
+		return netpkg.IsWebsocketRequest(data, websocketPaths)
 	})
-	svr.websocketListener = netpkg.NewWebsocketListener(websocketLn)
+	svr.websocketListener = netpkg.NewWebsocketListener(websocketLn, websocketPaths...)
 
 	// Create http vhost muxer.
 	if cfg.VhostHTTPPort > 0 {
@@ -696,11 +706,12 @@ func (svr *Service) HandleListener(l net.Listener, internal bool) {
 
 		c = netpkg.NewContextConn(xlog.NewContext(ctx, xl), c)
 
+		var isTLS bool
 		if !internal {
 			log.Tracef("start check TLS connection...")
 			originConn := c
 			forceTLS := svr.cfg.Transport.TLS.Force
-			var isTLS, custom bool
+			var custom bool
 			c, isTLS, custom, err = netpkg.CheckAndEnableTLSServerConnWithTimeout(c, svr.tlsConfig, forceTLS, connReadTimeout)
 			if err != nil {
 				log.Warnf("checkAndEnableTLSServerConnWithTimeout error: %v", err)
@@ -708,6 +719,22 @@ func (svr *Service) HandleListener(l net.Listener, internal bool) {
 				continue
 			}
 			log.Tracef("check TLS connection success, isTLS: %v custom: %v internal: %v", isTLS, custom, internal)
+		}
+
+		// After TLS termination, detect websocket upgrade requests so that wss
+		// (websocket over TLS) clients can be handled by the websocket listener
+		// instead of being parsed as the frp protocol.
+		if isTLS && svr.websocketListener != nil && len(svr.cfg.Transport.WebsocketPaths) > 0 {
+			wc, isWS := netpkg.TryWebsocket(c, svr.cfg.Transport.WebsocketPaths)
+			// TryWebsocket always returns the connection with the peeked bytes
+			// preserved, so it is safe to keep using it for the frp protocol too.
+			c = wc
+			if isWS {
+				go func() {
+					_ = svr.websocketListener.HandleConn(wc)
+				}()
+				continue
+			}
 		}
 
 		// Start a new goroutine to handle connection.


### PR DESCRIPTION
For websocket/wss connections the previously recorded client IP was taken from the websocket origin header instead of the actual peer address, which produced wrong IPs in logs and the dashboard. Use the real remote address of the underlying connection.

修复 ws/wss 连接上报的客户端真实 IP

对于 websocket/wss 连接，原先记录的客户端 IP 取自 websocket 的 origin 头而非真实 对端地址，导致日志与面板中显示错误。现改为使用底层连接的真实远端地址。

### WHY

<!-- author to complete -->
