### PR TITLE
server/visitor: use constant time comparison for visitor auth key

### DIFF
--- a/server/visitor/visitor.go
+++ b/server/visitor/visitor.go
@@ -75,7 +75,7 @@ func (vm *Manager) NewConn(name string, conn net.Conn, timestamp int64, signKey 
 	defer vm.mu.RUnlock()
 
 	if l, ok := vm.listeners[name]; ok {
-		if util.GetAuthKey(l.sk, timestamp) != signKey {
+		if !util.ConstantTimeEqString(util.GetAuthKey(l.sk, timestamp), signKey) {
 			err = fmt.Errorf("visitor connection of [%s] auth failed", name)
 			return
 		}


### PR DESCRIPTION
### WHY

`server/visitor/visitor.go` authenticates the visitor connection for STCP/XTCP/SUDP with a plain `!=`:

```go
if util.GetAuthKey(l.sk, timestamp) != signKey {
```

Every other place in the tree that does this same check goes through `util.ConstantTimeEqString`, added in 4915852 ("use constant time comparison", #3452). The closest parallel is `pkg/nathole/controller.go`:

```go
if !util.ConstantTimeEqString(m.SignKey, util.GetAuthKey(clientCfg.sk, m.Timestamp)) {
```

Same `GetAuthKey(sk, timestamp)`, same client-supplied sign key, but constant-time. `pkg/auth/token.go` does the same in three more places.

This line was added in #3472, a few days after #3452 landed, so it looks like it just missed the sweep rather than being a deliberate exception.

To be upfront about scope: this is consistency with a policy the project already adopted, not a demonstrated exploit. The compared value is an MD5 of the secret plus a timestamp, and the timestamp window limits how useful a byte-at-a-time oracle would be. I didn't try to build an attack — the point is that this is the last place still doing the check the old way.

Behaviour is unchanged: `ConstantTimeEqString` is true exactly when the strings are equal, including the length-mismatch and empty-string cases, so accept/reject outcomes are identical.

`go build ./...`, `go vet`, and `go test ./server/visitor/... ./pkg/auth/... ./pkg/util/util/... ./pkg/nathole/...` all pass.

I left the basic-auth comparisons in `pkg/util/vhost/http.go` and `pkg/util/tcpmux/httpconnect.go` alone. Those compare plaintext user/password joined by `&&`, so doing them properly means evaluating both halves unconditionally — a different change that I didn't want to fold into a one-liner. Happy to send a follow-up if you'd like those covered too.
