### PR TITLE
feat: hot-reload frps TLS certificate on SIGHUP

### DIFF
--- a/pkg/transport/tls.go
+++ b/pkg/transport/tls.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"sync"
 	"time"
 )
 
@@ -93,36 +94,154 @@ func newCertPool(caPath string) (*x509.CertPool, error) {
 	return pool, nil
 }
 
+// reloadableCertLoader holds the server TLS certificate/key pair (and optional
+// client CA) in memory and reloads it from disk on demand (e.g. when frps
+// receives SIGHUP). Handshakes serve the in-memory material directly via the
+// GetCertificate/GetConfigForClient callbacks, so the hot path has zero extra
+// cost and performs no disk access on its own.
+type reloadableCertLoader struct {
+	certPath string
+	keyPath  string
+	caPath   string
+
+	// base holds the server tls.Config the loader was created for, so that
+	// GetConfigForClient can return a config that preserves any other settings
+	// (MinVersion, cipher suites, etc.) configured on it.
+	base *tls.Config
+
+	mu         sync.RWMutex
+	cert       *tls.Certificate
+	clientCAs  *x509.CertPool
+	clientAuth tls.ClientAuthType
+}
+
+func newReloadableCertLoader(certPath, keyPath, caPath string) (*reloadableCertLoader, error) {
+	l := &reloadableCertLoader{
+		certPath: certPath,
+		keyPath:  keyPath,
+		caPath:   caPath,
+	}
+	if caPath != "" {
+		l.clientAuth = tls.RequireAndVerifyClientCert
+	}
+	if err := l.reload(); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+// reload reads the certificate material from disk and atomically replaces the
+// in-memory copy. On failure it returns an error without mutating the currently
+// loaded material, so a broken update does not break existing connections.
+func (l *reloadableCertLoader) reload() error {
+	cert, err := tls.LoadX509KeyPair(l.certPath, l.keyPath)
+	if err != nil {
+		return fmt.Errorf("load server x509 key pair from %q/%q: %w", l.certPath, l.keyPath, err)
+	}
+	var clientCAs *x509.CertPool
+	if l.caPath != "" {
+		clientCAs, err = newCertPool(l.caPath)
+		if err != nil {
+			return err
+		}
+	}
+	l.mu.Lock()
+	l.cert = &cert
+	l.clientCAs = clientCAs
+	// Keep the seeded static fields in sync so consumers that read
+	// base.Certificates directly also see the reloaded material. The primary
+	// reload path for handshakes is the GetCertificate/GetConfigForClient
+	// callbacks (which serve l.cert). base is only set after construction, so
+	// it is nil during the initial reload and safely skipped there.
+	if l.base != nil {
+		l.base.Certificates = []tls.Certificate{*l.cert}
+		if clientCAs != nil {
+			l.base.ClientCAs = clientCAs
+			l.base.ClientAuth = l.clientAuth
+		}
+	}
+	l.mu.Unlock()
+	return nil
+}
+
+// Reload re-reads the certificate material from disk. It is intended to be
+// triggered by an external event such as a SIGHUP signal.
+func (l *reloadableCertLoader) Reload() error {
+	return l.reload()
+}
+
+func (l *reloadableCertLoader) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	if l.cert == nil {
+		return nil, fmt.Errorf("no server certificate available")
+	}
+	return l.cert, nil
+}
+
+func (l *reloadableCertLoader) GetConfigForClient(*tls.ClientHelloInfo) (*tls.Config, error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	if l.cert == nil {
+		return nil, fmt.Errorf("no server certificate available")
+	}
+	cfg := l.base.Clone()
+	cfg.Certificates = []tls.Certificate{*l.cert}
+	if l.clientCAs != nil {
+		cfg.ClientCAs = l.clientCAs
+		cfg.ClientAuth = l.clientAuth
+	}
+	// Clear the callback on the returned config: crypto/tls invokes
+	// GetConfigForClient again on the result, so leaving it set would recurse
+	// infinitely (stack overflow) on every handshake.
+	cfg.GetConfigForClient = nil
+	return cfg, nil
+}
+
+// NewServerTLSConfig builds a server tls.Config. When a custom certificate is
+// configured it is loaded once into memory; callers that need hot-reload should
+// use NewServerTLSConfigWithReloader and trigger Reload (e.g. on SIGHUP).
 func NewServerTLSConfig(certPath, keyPath, caPath string) (*tls.Config, error) {
+	cfg, _, err := NewServerTLSConfigWithReloader(certPath, keyPath, caPath)
+	return cfg, err
+}
+
+// NewServerTLSConfigWithReloader is like NewServerTLSConfig but additionally
+// returns a Reload function. Call it (for example in response to a SIGHUP
+// signal) to re-read the certificate material from disk and apply it to new TLS
+// handshakes without restarting the process.
+func NewServerTLSConfigWithReloader(certPath, keyPath, caPath string) (*tls.Config, func() error, error) {
 	base := &tls.Config{}
 
 	if certPath == "" || keyPath == "" {
-		// server will generate tls conf by itself
+		// server will generate tls conf by itself; this is an in-memory random
+		// certificate that cannot be hot-reloaded from disk.
 		cert, err := newRandomTLSKeyPair()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		base.Certificates = []tls.Certificate{*cert}
-	} else {
-		cert, err := newCustomTLSKeyPair(certPath, keyPath)
-		if err != nil {
-			return nil, err
-		}
-
-		base.Certificates = []tls.Certificate{*cert}
+		// Auto-generated, in-memory certificate: it cannot be reloaded from
+		// disk, so report no reloader. Callers (e.g. the SIGHUP handler) treat
+		// a nil reloader as "nothing to reload" and skip it.
+		return base, nil, nil
 	}
 
-	if caPath != "" {
-		pool, err := newCertPool(caPath)
-		if err != nil {
-			return nil, err
-		}
-
+	loader, err := newReloadableCertLoader(certPath, keyPath, caPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	loader.base = base
+	base.GetCertificate = loader.GetCertificate
+	base.GetConfigForClient = loader.GetConfigForClient
+	// Seed the static fields as well so non-callback consumers (e.g. QUIC)
+	// have a valid initial certificate.
+	base.Certificates = []tls.Certificate{*loader.cert}
+	if loader.clientCAs != nil {
 		base.ClientAuth = tls.RequireAndVerifyClientCert
-		base.ClientCAs = pool
+		base.ClientCAs = loader.clientCAs
 	}
-
-	return base, nil
+	return base, loader.Reload, nil
 }
 
 func NewClientTLSConfig(certPath, keyPath, caPath, serverName string) (*tls.Config, error) {

--- a/pkg/transport/tls_reload_test.go
+++ b/pkg/transport/tls_reload_test.go
@@ -1,0 +1,176 @@
+package transport
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeRandomCertKey(t *testing.T, dir, certName, keyName string) {
+	t.Helper()
+	cert, err := newRandomTLSKeyPair()
+	if err != nil {
+		t.Fatalf("newRandomTLSKeyPair: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]})
+	key, ok := cert.PrivateKey.(*rsa.PrivateKey)
+	if !ok {
+		t.Fatal("unexpected private key type")
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	if err := os.WriteFile(filepath.Join(dir, certName), certPEM, 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, keyName), keyPEM, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+}
+
+func TestServerTLSConfigHotReload(t *testing.T) {
+	dir, err := os.MkdirTemp("", "frp-tls-reload")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	writeRandomCertKey(t, dir, "cert.pem", "key.pem")
+
+	cfg, reload, err := NewServerTLSConfigWithReloader(certPath, keyPath, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := cfg.GetCertificate(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstDER := first.Certificate[0]
+
+	writeRandomCertKey(t, dir, "cert_new.pem", "key_new.pem")
+	if err := os.Rename(filepath.Join(dir, "cert_new.pem"), certPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(filepath.Join(dir, "key_new.pem"), keyPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := reload(); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := cfg.GetCertificate(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondDER := second.Certificate[0]
+
+	if string(firstDER) == string(secondDER) {
+		t.Fatal("certificate was not reloaded after calling Reload")
+	}
+}
+
+func TestServerTLSConfigReloadPreservesUnchanged(t *testing.T) {
+	dir, err := os.MkdirTemp("", "frp-tls-reload-unchanged")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	writeRandomCertKey(t, dir, "cert.pem", "key.pem")
+
+	cfg, reload, err := NewServerTLSConfigWithReloader(filepath.Join(dir, "cert.pem"), filepath.Join(dir, "key.pem"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := cfg.GetCertificate(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reload(); err != nil {
+		t.Fatal(err)
+	}
+	second, err := cfg.GetCertificate(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first.Certificate[0]) != string(second.Certificate[0]) {
+		t.Fatal("certificate changed unexpectedly when the file was unchanged")
+	}
+}
+
+func TestServerTLSConfigReloadGetConfigForClient(t *testing.T) {
+	dir, err := os.MkdirTemp("", "frp-tls-reload-gcc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	writeRandomCertKey(t, dir, "cert.pem", "key.pem")
+
+	cfg, reload, err := NewServerTLSConfigWithReloader(certPath, keyPath, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gcc, err := cfg.GetConfigForClient(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gcc == nil {
+		t.Fatal("GetConfigForClient returned nil config")
+	}
+	if gcc.GetConfigForClient != nil {
+		t.Fatal("GetConfigForClient must clear its own callback to avoid infinite recursion")
+	}
+	first, err := gcc.GetCertificate(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstDER := first.Certificate[0]
+
+	writeRandomCertKey(t, dir, "cert_new.pem", "key_new.pem")
+	if err := os.Rename(filepath.Join(dir, "cert_new.pem"), certPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(filepath.Join(dir, "key_new.pem"), keyPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := reload(); err != nil {
+		t.Fatal(err)
+	}
+
+	gcc2, err := cfg.GetConfigForClient(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := gcc2.GetCertificate(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(firstDER) == string(second.Certificate[0]) {
+		t.Fatal("certificate was not reloaded through GetConfigForClient")
+	}
+}
+
+func TestServerTLSConfigReloadNilForAutoGenCert(t *testing.T) {
+	// With no cert/key configured the server generates an in-memory cert that
+	// cannot be reloaded from disk, so the reloader must be nil.
+	cfg, reload, err := NewServerTLSConfigWithReloader("", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reload != nil {
+		t.Fatal("expected nil reloader for auto-generated certificate")
+	}
+	if cfg == nil {
+		t.Fatal("expected a valid base config")
+	}
+}

--- a/server/service.go
+++ b/server/service.go
@@ -24,7 +24,9 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/fatedier/golib/crypto"
@@ -128,6 +130,10 @@ type Service struct {
 
 	tlsConfig *tls.Config
 
+	// reloadTLS re-reads the server TLS certificate/key from disk. It is wired
+	// to a SIGHUP handler so operators can rotate certificates without restart.
+	reloadTLS func() error
+
 	cfg *v1.ServerConfig
 
 	// service context
@@ -137,7 +143,7 @@ type Service struct {
 }
 
 func NewService(cfg *v1.ServerConfig) (*Service, error) {
-	tlsConfig, err := transport.NewServerTLSConfig(
+	tlsConfig, reloadTLS, err := transport.NewServerTLSConfigWithReloader(
 		cfg.Transport.TLS.CertFile,
 		cfg.Transport.TLS.KeyFile,
 		cfg.Transport.TLS.TrustedCaFile)
@@ -180,6 +186,7 @@ func NewService(cfg *v1.ServerConfig) (*Service, error) {
 		auth:              authRuntime,
 		webServer:         webServer,
 		tlsConfig:         tlsConfig,
+		reloadTLS:         reloadTLS,
 		cfg:               cfg,
 		ctx:               context.Background(),
 	}
@@ -266,6 +273,12 @@ func NewService(cfg *v1.ServerConfig) (*Service, error) {
 		address := net.JoinHostPort(cfg.BindAddr, strconv.Itoa(cfg.QUICBindPort))
 		quicTLSCfg := tlsConfig.Clone()
 		quicTLSCfg.NextProtos = []string{"frp"}
+		// Serve the reloaded certificate via the GetCertificate callback and keep
+		// this clone's static client-CA/ALPN settings. Do not delegate to
+		// GetConfigForClient: the config it returns omits NextProtos (which
+		// would break QUIC ALPN negotiation) and re-selects the certificate on
+		// every handshake.
+		quicTLSCfg.GetConfigForClient = nil
 		svr.quicListener, err = quic.ListenAddr(address, quicTLSCfg, &quic.Config{
 			MaxIdleTimeout:     time.Duration(cfg.Transport.QUIC.MaxIdleTimeout) * time.Second,
 			MaxIncomingStreams: int64(cfg.Transport.QUIC.MaxIncomingStreams),
@@ -399,11 +412,33 @@ func (svr *Service) Run(ctx context.Context) {
 
 	svr.HandleListener(svr.listener, false)
 
+	svr.handleTLSReloadSignal()
+
 	<-svr.ctx.Done()
 	// service context may not be canceled by svr.Close(), we should call it here to release resources
 	if svr.listener != nil {
 		svr.Close()
 	}
+}
+
+// handleTLSReloadSignal listens for SIGHUP and reloads the server TLS
+// certificate/key from disk when it arrives, so certificate rotation does not
+// require a restart.
+func (svr *Service) handleTLSReloadSignal() {
+	if svr.reloadTLS == nil {
+		return
+	}
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGHUP)
+	go func() {
+		for range sigCh {
+			if err := svr.reloadTLS(); err != nil {
+				log.Errorf("reload tls certificate failed: %v", err)
+			} else {
+				log.Infof("tls certificate reloaded")
+			}
+		}
+	}()
 }
 
 func (svr *Service) Close() error {


### PR DESCRIPTION
frps now reloads its TLS certificate and key on SIGHUP instead of requiring a restart, so certificate rotation does not drop existing connections.

frps 支持 SIGHUP 热重载 TLS 证书

frps 现可在收到 SIGHUP 信号时重新加载 TLS 证书与私钥，无需重启进程即可完成证书轮换， 且不会断开已有连接。

### WHY

<!-- author to complete -->
