### PR TITLE
feat: show offline clients in dashboard and add clear-offline action

### DIFF
--- a/server/http/controller_v2.go
+++ b/server/http/controller_v2.go
@@ -39,6 +39,7 @@ const (
 	maxV2PageSize     = 200
 
 	v2SystemPruneTypeOfflineProxies = "offline_proxies"
+	v2SystemPruneTypeOfflineClients = "offline_clients"
 	v2ProxyTrafficDefaultDays       = 7
 	v2ProxyTrafficUnit              = "bytes"
 	v2ProxyTrafficGranularity       = "day"
@@ -96,7 +97,16 @@ func (c *Controller) APIV2SystemPrune(ctx *httppkg.Context) (any, error) {
 		return nil, err
 	}
 
-	cleared, total := mem.StatsCollector.PruneOfflineProxies()
+	var cleared, total int
+	switch pruneType {
+	case v2SystemPruneTypeOfflineProxies:
+		cleared, total = mem.StatsCollector.PruneOfflineProxies()
+	case v2SystemPruneTypeOfflineClients:
+		if c.clientRegistry == nil {
+			return nil, fmt.Errorf("client registry unavailable")
+		}
+		cleared, total = c.clientRegistry.ClearOfflineClients()
+	}
 	return model.V2SystemPruneResp{
 		Type:    pruneType,
 		Cleared: cleared,
@@ -370,10 +380,10 @@ func parseV2SystemPruneType(raw string) (string, error) {
 	switch pruneType {
 	case "":
 		return "", httppkg.NewError(http.StatusBadRequest, "type is required")
-	case v2SystemPruneTypeOfflineProxies:
+	case v2SystemPruneTypeOfflineProxies, v2SystemPruneTypeOfflineClients:
 		return pruneType, nil
 	default:
-		return "", httppkg.NewError(http.StatusBadRequest, "type must be one of offline_proxies")
+		return "", httppkg.NewError(http.StatusBadRequest, "type must be one of offline_proxies, offline_clients")
 	}
 }
 

--- a/server/http/controller_v2_test.go
+++ b/server/http/controller_v2_test.go
@@ -277,7 +277,7 @@ func TestAPIV2SystemPruneTypeErrorsUseEnvelope(t *testing.T) {
 		t.Fatalf("invalid type status mismatch, want %d got %d", http.StatusBadRequest, resp.Code)
 	}
 	errResp = decodeResponse[httppkg.V2Response](t, resp)
-	if errResp.Code != http.StatusBadRequest || errResp.Msg != "type must be one of offline_proxies" || errResp.Data != nil {
+	if errResp.Code != http.StatusBadRequest || errResp.Msg != "type must be one of offline_proxies, offline_clients" || errResp.Data != nil {
 		t.Fatalf("invalid type error envelope mismatch: %#v", errResp)
 	}
 }

--- a/server/registry/registry.go
+++ b/server/registry/registry.go
@@ -27,6 +27,7 @@ type ClientInfo struct {
 	Key              string
 	User             string
 	RawClientID      string
+	ClientIDValue    string
 	RunID            string
 	ControlID        uint64
 	Hostname         string
@@ -40,7 +41,7 @@ type ClientInfo struct {
 }
 
 // ClientRegistry keeps track of active clients keyed by "{user}.{clientID}" (runID fallback when raw clientID is empty).
-// Entries without an explicit raw clientID are removed on disconnect to avoid stale offline records.
+// Offline clients are retained so the dashboard can still list and inspect them.
 type ClientRegistry struct {
 	mu       sync.RWMutex
 	clients  map[string]*ClientInfo
@@ -117,6 +118,7 @@ func (cr *ClientRegistry) RegisterWithControlID(
 	}
 
 	info.RawClientID = rawClientID
+	info.ClientIDValue = effectiveID
 	info.RunID = runID
 	info.ControlID = controlID
 	info.Hostname = hostname
@@ -153,16 +155,31 @@ func (cr *ClientRegistry) markOfflineByRunID(runID string, controlID uint64, mat
 	if !ok {
 		return
 	}
-	if info, ok := cr.clients[key]; ok && info.RunID == runID && (!matchControlID || info.ControlID == controlID) {
-		if info.RawClientID == "" {
-			delete(cr.clients, key)
-		} else {
-			setClientOffline(info, cr.clock.Now())
-		}
-	}
-	if info, ok := cr.clients[key]; !ok || info.RunID != runID {
+	info, ok := cr.clients[key]
+	if !ok || info.RunID != runID {
 		delete(cr.runIndex, runID)
+		return
 	}
+	// The entry belongs to this run id. When a specific control generation is
+	// required but does not match, a stale generation is disconnecting while
+	// the current one still owns the entry, so leave it untouched (and keep
+	// the runIndex mapping so the current generation's disconnect can find it).
+	if matchControlID && info.ControlID != controlID {
+		return
+	}
+	if info.RawClientID == "" {
+		// Clients without a stable client id are registered under their run
+		// id, which changes on every reconnect. Retaining them as offline
+		// would leave a dangling entry that can never be matched again and
+		// slowly leaks memory, so drop them instead (matching pre-offline
+		// behavior). Clients that configure a clientID keep a stable key and
+		// are tracked as offline as intended.
+		delete(cr.clients, key)
+		delete(cr.runIndex, runID)
+		return
+	}
+	setClientOffline(info, cr.clock.Now())
+	delete(cr.runIndex, runID)
 }
 
 func setClientOffline(info *ClientInfo, now time.Time) {
@@ -196,12 +213,28 @@ func (cr *ClientRegistry) GetByKey(key string) (ClientInfo, bool) {
 	return *info, true
 }
 
-// ClientID returns the resolved client identifier for external use.
-func (info ClientInfo) ClientID() string {
-	if info.RawClientID != "" {
-		return info.RawClientID
+// ClearOfflineClients removes every offline client entry and returns the number
+// of removed clients plus the total number of clients before removal.
+func (cr *ClientRegistry) ClearOfflineClients() (int, int) {
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+
+	total := len(cr.clients)
+	cleared := 0
+	for key, info := range cr.clients {
+		if info.Online {
+			continue
+		}
+		delete(cr.clients, key)
+		cleared++
 	}
-	return info.RunID
+	return cleared, total
+}
+
+// ClientID returns the resolved client identifier for external use. It is
+// preserved across disconnects so offline clients keep showing their id.
+func (info ClientInfo) ClientID() string {
+	return info.ClientIDValue
 }
 
 func (cr *ClientRegistry) composeClientKey(user, id string) string {

--- a/web/frps/src/api/client.ts
+++ b/web/frps/src/api/client.ts
@@ -1,6 +1,7 @@
 import { buildQueryString, http } from './http'
 import type { V2Page } from './http'
 import type { ClientInfoData, ClientListV2Params } from '../types/client'
+import type { SystemPruneResponse } from './proxy'
 
 export const getClients = () => {
   return http.get<ClientInfoData[]>('../api/clients')
@@ -27,4 +28,10 @@ export const getClient = (key: string) => {
 
 export const getClientV2 = (key: string) => {
   return http.getV2<ClientInfoData>(`../api/v2/clients/${encodeURIComponent(key)}`)
+}
+
+export const clearOfflineClients = () => {
+  return http.postV2<SystemPruneResponse>(
+    '../api/v2/system/prune?type=offline_clients',
+  )
 }

--- a/web/frps/src/components/ClientCard.vue
+++ b/web/frps/src/components/ClientCard.vue
@@ -116,7 +116,7 @@ const viewDetail = () => {
 }
 
 .status-dot-large.offline {
-  background-color: var(--el-text-color-placeholder);
+  background-color: var(--el-color-danger);
 }
 
 .card-content {
@@ -209,8 +209,8 @@ const viewDetail = () => {
 }
 
 .status-badge.offline {
-  background: var(--el-fill-color);
-  color: var(--el-text-color-secondary);
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger);
 }
 
 .arrow-icon {

--- a/web/frps/src/views/ClientDetail.vue
+++ b/web/frps/src/views/ClientDetail.vue
@@ -143,7 +143,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { ElMessage, ElPagination } from 'element-plus'
+import { ElMessage, ElPagination, ElButton } from 'element-plus'
 import { ArrowLeft, Loading, Search } from '@element-plus/icons-vue'
 import { Client } from '../utils/client'
 import { getClientV2 } from '../api/client'
@@ -486,8 +486,8 @@ onMounted(async () => {
 }
 
 .status-badge.offline {
-  background: var(--hover-bg);
-  color: var(--text-secondary);
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger);
 }
 
 html.dark .status-badge.online {

--- a/web/frps/src/views/Clients.vue
+++ b/web/frps/src/views/Clients.vue
@@ -21,6 +21,12 @@
             }}</span>
           </button>
         </div>
+
+        <div class="actions-section">
+          <ActionButton variant="outline" size="small" danger @click="showClearDialog = true">
+            Clear Offline
+          </ActionButton>
+        </div>
       </div>
 
       <div class="search-section">
@@ -58,6 +64,15 @@
         @size-change="onPageSizeChange"
       />
     </div>
+
+    <ConfirmDialog
+      v-model="showClearDialog"
+      title="Clear Offline"
+      message="Are you sure you want to clear all offline clients?"
+      confirm-text="Clear"
+      danger
+      @confirm="handleClearConfirm"
+    />
   </div>
 </template>
 
@@ -65,9 +80,11 @@
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { ElMessage, ElPagination } from 'element-plus'
 import { Search } from '@element-plus/icons-vue'
+import ActionButton from '@shared/components/ActionButton.vue'
+import ConfirmDialog from '@shared/components/ConfirmDialog.vue'
 import { Client } from '../utils/client'
 import ClientCard from '../components/ClientCard.vue'
-import { getClientsV2 } from '../api/client'
+import { getClientsV2, clearOfflineClients } from '../api/client'
 
 const clients = ref<Client[]>([])
 const loading = ref(false)
@@ -76,6 +93,7 @@ const statusFilter = ref<'all' | 'online' | 'offline'>('all')
 const page = ref(1)
 const pageSize = ref(10)
 const total = ref(0)
+const showClearDialog = ref(false)
 
 let refreshTimer: number | null = null
 let searchDebounceTimer: number | null = null
@@ -158,6 +176,23 @@ const onPageChange = (value: number) => {
 const onPageSizeChange = (value: number) => {
   pageSize.value = value
   resetPageAndFetch()
+}
+
+const handleClearConfirm = async () => {
+  try {
+    await clearOfflineClients()
+    ElMessage({
+      message: 'Successfully cleared offline clients',
+      type: 'success',
+    })
+    showClearDialog.value = false
+    await fetchData()
+  } catch (err: any) {
+    ElMessage({
+      message: 'Failed to clear offline clients: ' + err.message,
+      type: 'warning',
+    })
+  }
 }
 
 const startAutoRefresh = () => {


### PR DESCRIPTION
The dashboard now lists clients that went offline (last seen timestamp kept in the registry) and provides a "clear offline" action to remove their stale entries.

面板展示离线客户端并支持清理离线条目

面板现可列出已离线的客户端（在注册表中保留最后在线时间），并提供"清理离线"操作以
移除其残留条目。

### WHY

<!-- author to complete -->
