### PR TITLE
protocol: derive v2 control channel keys from X25519 key agreement

### DIFF
--- a/client/control_session.go
+++ b/client/control_session.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"context"
+	"crypto/ecdh"
 	"errors"
 	"fmt"
 	"io"
@@ -138,6 +139,7 @@ func (d *controlSessionDialer) exchangeLogin(conn net.Conn, loginMsg *msg.Login)
 	var wireConn *wire.Conn
 	var clientHello wire.ClientHello
 	var clientHelloPayload []byte
+	var clientKeyPriv *ecdh.PrivateKey
 
 	if d.common.Transport.WireProtocol == wire.ProtocolV2 {
 		if err := wire.WriteMagic(conn); err != nil {
@@ -147,7 +149,7 @@ func (d *controlSessionDialer) exchangeLogin(conn net.Conn, loginMsg *msg.Login)
 		wireConn = wire.NewConn(conn)
 		rw = msg.NewV2ReadWriterWithConn(wireConn)
 		var err error
-		clientHello, err = wire.NewClientHello(wire.BootstrapInfo{
+		clientHello, clientKeyPriv, err = wire.NewClientHello(wire.BootstrapInfo{
 			Transport: d.common.Transport.Protocol,
 			TLS:       lo.FromPtr(d.common.Transport.TLS.Enable) || d.common.Transport.Protocol == "wss" || d.common.Transport.Protocol == "quic",
 			TCPMux:    lo.FromPtr(d.common.Transport.TCPMux),
@@ -190,7 +192,7 @@ func (d *controlSessionDialer) exchangeLogin(conn net.Conn, loginMsg *msg.Login)
 		if serverHello.Error != "" {
 			return nil, errors.New(serverHello.Error)
 		}
-		cryptoContext, err = wire.NewClientCryptoContext(clientHelloPayload, serverHelloFrame.Payload)
+		cryptoContext, err = wire.NewClientCryptoContext(clientKeyPriv, clientHelloPayload, serverHelloFrame.Payload)
 		if err != nil {
 			return nil, err
 		}
@@ -213,9 +215,13 @@ func (d *controlSessionDialer) newControlReadWriter(conn net.Conn, cryptoContext
 		if cryptoContext == nil {
 			return nil, errors.New("missing v2 crypto negotiation")
 		}
+		ikm := cryptoContext.DeriveIKM(d.auth.EncryptionKey())
+		if len(ikm) == 0 {
+			return nil, errors.New("v2 control channel has no keying material")
+		}
 		return netpkg.NewAEADCryptoReadWriter(
 			conn,
-			d.auth.EncryptionKey(),
+			ikm,
 			netpkg.AEADCryptoRoleClient,
 			cryptoContext.Algorithm,
 			cryptoContext.TranscriptHash,

--- a/client/control_session_test.go
+++ b/client/control_session_test.go
@@ -171,7 +171,7 @@ func TestControlSessionDialerDialV2(t *testing.T) {
 			serverErrCh <- fmt.Errorf("unexpected user: %s", loginMsg.User)
 			return
 		}
-		serverHello, err := wire.NewServerHello(hello)
+		serverHello, sharedSecret, err := wire.NewServerHello(hello)
 		if err != nil {
 			serverErrCh <- err
 			return
@@ -183,6 +183,7 @@ func TestControlSessionDialerDialV2(t *testing.T) {
 		}
 		cryptoContext := wire.NewCryptoContext(
 			serverHello.Selected.Crypto.Algorithm,
+			sharedSecret,
 			clientHelloFrame.Payload,
 			serverHelloFrame.Payload,
 		)
@@ -197,7 +198,7 @@ func TestControlSessionDialerDialV2(t *testing.T) {
 
 		controlRW, err := netpkg.NewAEADCryptoReadWriter(
 			serverRaw,
-			[]byte("token"),
+			cryptoContext.DeriveIKM([]byte("token")),
 			netpkg.AEADCryptoRoleServer,
 			cryptoContext.Algorithm,
 			cryptoContext.TranscriptHash,

--- a/pkg/proto/wire/crypto.go
+++ b/pkg/proto/wire/crypto.go
@@ -15,6 +15,7 @@
 package wire
 
 import (
+	"crypto/ecdh"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
@@ -43,27 +44,61 @@ var supportedAEADAlgorithms = []string{
 type CryptoContext struct {
 	Algorithm      string
 	TranscriptHash []byte
+	SharedSecret   []byte
 }
 
-func NewClientHello(bootstrap BootstrapInfo) (ClientHello, error) {
+// DeriveIKM returns the ECDH shared secret followed by the pre-shared auth key.
+// Either may be absent.
+func (c *CryptoContext) DeriveIKM(authKey []byte) []byte {
+	ikm := make([]byte, 0, len(c.SharedSecret)+len(authKey))
+	ikm = append(ikm, c.SharedSecret...)
+	ikm = append(ikm, authKey...)
+	return ikm
+}
+
+// NewClientHello returns the hello and the ephemeral private key that
+// NewClientCryptoContext needs to complete the exchange.
+func NewClientHello(bootstrap BootstrapInfo) (ClientHello, *ecdh.PrivateKey, error) {
 	clientRandom, err := newCryptoRandom()
 	if err != nil {
-		return ClientHello{}, err
+		return ClientHello{}, nil, err
 	}
-	return clientHelloWithCryptoRandom(bootstrap, clientRandom), nil
+	priv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		return ClientHello{}, nil, fmt.Errorf("generate X25519 key: %w", err)
+	}
+	hello := clientHelloWithCryptoRandom(bootstrap, clientRandom)
+	hello.Capabilities.Crypto.ClientKeyShare = priv.PublicKey().Bytes()
+	return hello, priv, nil
 }
 
-func NewServerHello(clientHello ClientHello) (ServerHello, error) {
+func NewServerHello(clientHello ClientHello) (ServerHello, []byte, error) {
 	if err := ValidateClientHello(clientHello); err != nil {
-		return ServerHello{}, err
+		return ServerHello{}, nil, err
 	}
 	algorithm, ok := SelectAEADAlgorithm(clientHello.Capabilities.Crypto.Algorithms)
 	if !ok {
-		return ServerHello{}, fmt.Errorf("no supported crypto algorithm")
+		return ServerHello{}, nil, fmt.Errorf("no supported crypto algorithm")
 	}
 	serverRandom, err := newCryptoRandom()
 	if err != nil {
-		return ServerHello{}, err
+		return ServerHello{}, nil, err
+	}
+	var serverKeyShare, sharedSecret []byte
+	if len(clientHello.Capabilities.Crypto.ClientKeyShare) > 0 {
+		clientPub, err := ecdh.X25519().NewPublicKey(clientHello.Capabilities.Crypto.ClientKeyShare)
+		if err != nil {
+			return ServerHello{}, nil, fmt.Errorf("invalid client key share: %w", err)
+		}
+		priv, err := ecdh.X25519().GenerateKey(rand.Reader)
+		if err != nil {
+			return ServerHello{}, nil, fmt.Errorf("generate X25519 key: %w", err)
+		}
+		sharedSecret, err = priv.ECDH(clientPub)
+		if err != nil {
+			return ServerHello{}, nil, fmt.Errorf("X25519 exchange: %w", err)
+		}
+		serverKeyShare = priv.PublicKey().Bytes()
 	}
 	return ServerHello{
 		Selected: ServerSelection{
@@ -72,11 +107,12 @@ func NewServerHello(clientHello ClientHello) (ServerHello, error) {
 				UDPPacketCodec: selectUDPPacketCodec(clientHello.Capabilities.Message.UDPPacketCodecs),
 			},
 			Crypto: CryptoSelection{
-				Algorithm:    algorithm,
-				ServerRandom: serverRandom,
+				Algorithm:      algorithm,
+				ServerRandom:   serverRandom,
+				ServerKeyShare: serverKeyShare,
 			},
 		},
-	}, nil
+	}, sharedSecret, nil
 }
 
 func ValidateCryptoCapabilities(c CryptoCapabilities) error {
@@ -112,6 +148,9 @@ func ValidateServerHelloForClient(clientHello ClientHello, serverHello ServerHel
 	if len(cryptoSelection.ServerRandom) != CryptoRandomSize {
 		return fmt.Errorf("invalid crypto server random length %d, want %d", len(cryptoSelection.ServerRandom), CryptoRandomSize)
 	}
+	if len(cryptoSelection.ServerKeyShare) > 0 && len(clientHello.Capabilities.Crypto.ClientKeyShare) == 0 {
+		return fmt.Errorf("server sent a key share that was not advertised by client")
+	}
 	return nil
 }
 
@@ -122,14 +161,15 @@ func selectUDPPacketCodec(codecs []string) string {
 	return ""
 }
 
-func NewCryptoContext(algorithm string, clientHelloPayload, serverHelloPayload []byte) *CryptoContext {
+func NewCryptoContext(algorithm string, sharedSecret, clientHelloPayload, serverHelloPayload []byte) *CryptoContext {
 	return &CryptoContext{
 		Algorithm:      algorithm,
 		TranscriptHash: HashCryptoTranscript(clientHelloPayload, serverHelloPayload),
+		SharedSecret:   sharedSecret,
 	}
 }
 
-func NewClientCryptoContext(clientHelloPayload, serverHelloPayload []byte) (*CryptoContext, error) {
+func NewClientCryptoContext(clientPriv *ecdh.PrivateKey, clientHelloPayload, serverHelloPayload []byte) (*CryptoContext, error) {
 	var clientHello ClientHello
 	if err := json.Unmarshal(clientHelloPayload, &clientHello); err != nil {
 		return nil, fmt.Errorf("decode ClientHello transcript: %w", err)
@@ -142,7 +182,22 @@ func NewClientCryptoContext(clientHelloPayload, serverHelloPayload []byte) (*Cry
 		return nil, err
 	}
 
-	return NewCryptoContext(serverHello.Selected.Crypto.Algorithm, clientHelloPayload, serverHelloPayload), nil
+	var sharedSecret []byte
+	if serverKeyShare := serverHello.Selected.Crypto.ServerKeyShare; len(serverKeyShare) > 0 {
+		if clientPriv == nil {
+			return nil, fmt.Errorf("server sent a key share but client has no private key")
+		}
+		serverPub, err := ecdh.X25519().NewPublicKey(serverKeyShare)
+		if err != nil {
+			return nil, fmt.Errorf("invalid server key share: %w", err)
+		}
+		sharedSecret, err = clientPriv.ECDH(serverPub)
+		if err != nil {
+			return nil, fmt.Errorf("X25519 exchange: %w", err)
+		}
+	}
+
+	return NewCryptoContext(serverHello.Selected.Crypto.Algorithm, sharedSecret, clientHelloPayload, serverHelloPayload), nil
 }
 
 func HashCryptoTranscript(clientHelloPayload, serverHelloPayload []byte) []byte {

--- a/pkg/proto/wire/wire.go
+++ b/pkg/proto/wire/wire.go
@@ -188,8 +188,9 @@ type MessageCapabilities struct {
 }
 
 type CryptoCapabilities struct {
-	Algorithms   []string `json:"algorithms,omitempty"`
-	ClientRandom []byte   `json:"clientRandom,omitempty"`
+	Algorithms     []string `json:"algorithms,omitempty"`
+	ClientRandom   []byte   `json:"clientRandom,omitempty"`
+	ClientKeyShare []byte   `json:"clientKeyShare,omitempty"`
 }
 
 type ServerHello struct {
@@ -208,8 +209,9 @@ type MessageSelection struct {
 }
 
 type CryptoSelection struct {
-	Algorithm    string `json:"algorithm,omitempty"`
-	ServerRandom []byte `json:"serverRandom,omitempty"`
+	Algorithm      string `json:"algorithm,omitempty"`
+	ServerRandom   []byte `json:"serverRandom,omitempty"`
+	ServerKeyShare []byte `json:"serverKeyShare,omitempty"`
 }
 
 func clientHelloWithCryptoRandom(bootstrap BootstrapInfo, clientRandom []byte) ClientHello {

--- a/pkg/proto/wire/wire_test.go
+++ b/pkg/proto/wire/wire_test.go
@@ -16,6 +16,7 @@ package wire
 
 import (
 	"bytes"
+	"crypto/ecdh"
 	"encoding/binary"
 	"io"
 	"net"
@@ -28,7 +29,7 @@ func TestFrameRoundTrip(t *testing.T) {
 	var buf bytes.Buffer
 	conn := NewConn(&buf)
 
-	in := mustClientHello(t, BootstrapInfo{
+	in, _ := mustClientHello(t, BootstrapInfo{
 		Transport: "tcp",
 		TLS:       true,
 		TCPMux:    true,
@@ -112,7 +113,7 @@ func TestCheckMagicV1PreservesReadBytes(t *testing.T) {
 }
 
 func TestValidateClientHello(t *testing.T) {
-	hello := mustClientHello(t, BootstrapInfo{})
+	hello, _ := mustClientHello(t, BootstrapInfo{})
 	require.NoError(t, ValidateClientHello(hello))
 	require.Len(t, hello.Capabilities.Crypto.ClientRandom, CryptoRandomSize)
 	require.ElementsMatch(t, []string{
@@ -125,11 +126,11 @@ func TestValidateClientHello(t *testing.T) {
 }
 
 func TestValidateClientHelloRejectsInvalidCrypto(t *testing.T) {
-	hello := mustClientHello(t, BootstrapInfo{})
+	hello, _ := mustClientHello(t, BootstrapInfo{})
 	hello.Capabilities.Crypto.ClientRandom = hello.Capabilities.Crypto.ClientRandom[:CryptoRandomSize-1]
 	require.ErrorContains(t, ValidateClientHello(hello), "invalid crypto client random length")
 
-	hello = mustClientHello(t, BootstrapInfo{})
+	hello, _ = mustClientHello(t, BootstrapInfo{})
 	hello.Capabilities.Crypto.Algorithms = []string{"unknown"}
 	require.ErrorContains(t, ValidateClientHello(hello), "no supported crypto algorithm")
 }
@@ -142,10 +143,10 @@ func TestPreferredAEADAlgorithms(t *testing.T) {
 }
 
 func TestNewServerHelloSelectsFirstSupportedAEADAlgorithm(t *testing.T) {
-	hello := mustClientHello(t, BootstrapInfo{})
+	hello, _ := mustClientHello(t, BootstrapInfo{})
 	hello.Capabilities.Crypto.Algorithms = []string{"future-aead", AEADAlgorithmXChaCha20Poly1305, AEADAlgorithmAES256GCM}
 
-	serverHello, err := NewServerHello(hello)
+	serverHello, _, err := NewServerHello(hello)
 	require.NoError(t, err)
 	require.Equal(t, MessageCodecJSON, serverHello.Selected.Message.Codec)
 	require.Equal(t, UDPPacketCodecBinary, serverHello.Selected.Message.UDPPacketCodec)
@@ -154,22 +155,22 @@ func TestNewServerHelloSelectsFirstSupportedAEADAlgorithm(t *testing.T) {
 }
 
 func TestUDPPacketCodecNegotiationFallbackAndValidation(t *testing.T) {
-	hello := mustClientHello(t, BootstrapInfo{})
-	serverHello, err := NewServerHello(hello)
+	hello, _ := mustClientHello(t, BootstrapInfo{})
+	serverHello, _, err := NewServerHello(hello)
 	require.NoError(t, err)
 	require.Equal(t, UDPPacketCodecBinary, serverHello.Selected.Message.UDPPacketCodec)
 	require.NoError(t, ValidateServerHelloForClient(hello, serverHello))
 
 	legacyHello := hello
 	legacyHello.Capabilities.Message.UDPPacketCodecs = nil
-	legacyServerHello, err := NewServerHello(legacyHello)
+	legacyServerHello, _, err := NewServerHello(legacyHello)
 	require.NoError(t, err)
 	require.Empty(t, legacyServerHello.Selected.Message.UDPPacketCodec)
 	require.NoError(t, ValidateServerHelloForClient(legacyHello, legacyServerHello))
 
 	unknownOffer := hello
 	unknownOffer.Capabilities.Message.UDPPacketCodecs = []string{"unknown"}
-	unknownServerHello, err := NewServerHello(unknownOffer)
+	unknownServerHello, _, err := NewServerHello(unknownOffer)
 	require.NoError(t, err)
 	require.Empty(t, unknownServerHello.Selected.Message.UDPPacketCodec)
 
@@ -183,12 +184,12 @@ func TestUDPPacketCodecNegotiationFallbackAndValidation(t *testing.T) {
 }
 
 func TestNewClientCryptoContextValidatesServerHello(t *testing.T) {
-	hello := mustClientHello(t, BootstrapInfo{})
-	serverHello, err := NewServerHello(hello)
+	hello, clientPriv := mustClientHello(t, BootstrapInfo{})
+	serverHello, _, err := NewServerHello(hello)
 	require.NoError(t, err)
 	clientHelloPayload, serverHelloPayload := mustCryptoTranscriptPayloads(t, hello, serverHello)
 
-	ctx, err := NewClientCryptoContext(clientHelloPayload, serverHelloPayload)
+	ctx, err := NewClientCryptoContext(clientPriv, clientHelloPayload, serverHelloPayload)
 	require.NoError(t, err)
 	require.Equal(t, serverHello.Selected.Crypto.Algorithm, ctx.Algorithm)
 	require.Len(t, ctx.TranscriptHash, 32)
@@ -197,59 +198,59 @@ func TestNewClientCryptoContextValidatesServerHello(t *testing.T) {
 	tampered.Selected.Crypto.ServerRandom = append([]byte(nil), serverHello.Selected.Crypto.ServerRandom...)
 	tampered.Selected.Crypto.ServerRandom[0] ^= 0xff
 	_, tamperedServerHelloPayload := mustCryptoTranscriptPayloads(t, hello, tampered)
-	tamperedCtx, err := NewClientCryptoContext(clientHelloPayload, tamperedServerHelloPayload)
+	tamperedCtx, err := NewClientCryptoContext(clientPriv, clientHelloPayload, tamperedServerHelloPayload)
 	require.NoError(t, err)
 	require.NotEqual(t, ctx.TranscriptHash, tamperedCtx.TranscriptHash)
 }
 
 func TestNewCryptoContextBindsFullClientHelloPayload(t *testing.T) {
-	hello := mustClientHello(t, BootstrapInfo{
+	hello, _ := mustClientHello(t, BootstrapInfo{
 		Transport: "tcp",
 		TLS:       true,
 		TCPMux:    true,
 	})
-	serverHello, err := NewServerHello(hello)
+	serverHello, _, err := NewServerHello(hello)
 	require.NoError(t, err)
 	clientHelloPayload, serverHelloPayload := mustCryptoTranscriptPayloads(t, hello, serverHello)
 
-	ctx := NewCryptoContext(serverHello.Selected.Crypto.Algorithm, clientHelloPayload, serverHelloPayload)
+	ctx := NewCryptoContext(serverHello.Selected.Crypto.Algorithm, nil, clientHelloPayload, serverHelloPayload)
 
 	tamperedHello := hello
 	tamperedHello.Bootstrap.TLS = false
 	tamperedClientHelloPayload, _ := mustCryptoTranscriptPayloads(t, tamperedHello, serverHello)
-	tamperedCtx := NewCryptoContext(serverHello.Selected.Crypto.Algorithm, tamperedClientHelloPayload, serverHelloPayload)
+	tamperedCtx := NewCryptoContext(serverHello.Selected.Crypto.Algorithm, nil, tamperedClientHelloPayload, serverHelloPayload)
 	require.NotEqual(t, ctx.TranscriptHash, tamperedCtx.TranscriptHash)
 }
 
 func TestNewClientCryptoContextRejectsUnknownServerSelection(t *testing.T) {
-	hello := mustClientHello(t, BootstrapInfo{})
-	serverHello, err := NewServerHello(hello)
+	hello, clientPriv := mustClientHello(t, BootstrapInfo{})
+	serverHello, _, err := NewServerHello(hello)
 	require.NoError(t, err)
 
 	serverHello.Selected.Crypto.Algorithm = "unknown"
 	clientHelloPayload, serverHelloPayload := mustCryptoTranscriptPayloads(t, hello, serverHello)
-	_, err = NewClientCryptoContext(clientHelloPayload, serverHelloPayload)
+	_, err = NewClientCryptoContext(clientPriv, clientHelloPayload, serverHelloPayload)
 	require.ErrorContains(t, err, "unknown selected crypto algorithm")
 }
 
 func TestNewClientCryptoContextRejectsUnadvertisedServerSelection(t *testing.T) {
-	hello := mustClientHello(t, BootstrapInfo{})
+	hello, clientPriv := mustClientHello(t, BootstrapInfo{})
 	hello.Capabilities.Crypto.Algorithms = []string{AEADAlgorithmAES256GCM}
-	serverHello, err := NewServerHello(hello)
+	serverHello, _, err := NewServerHello(hello)
 	require.NoError(t, err)
 
 	serverHello.Selected.Crypto.Algorithm = AEADAlgorithmXChaCha20Poly1305
 	clientHelloPayload, serverHelloPayload := mustCryptoTranscriptPayloads(t, hello, serverHello)
-	_, err = NewClientCryptoContext(clientHelloPayload, serverHelloPayload)
+	_, err = NewClientCryptoContext(clientPriv, clientHelloPayload, serverHelloPayload)
 	require.ErrorContains(t, err, "selected crypto algorithm was not advertised by client")
 }
 
-func mustClientHello(t *testing.T, bootstrap BootstrapInfo) ClientHello {
+func mustClientHello(t *testing.T, bootstrap BootstrapInfo) (ClientHello, *ecdh.PrivateKey) {
 	t.Helper()
 
-	hello, err := NewClientHello(bootstrap)
+	hello, priv, err := NewClientHello(bootstrap)
 	require.NoError(t, err)
-	return hello
+	return hello, priv
 }
 
 func mustCryptoTranscriptPayloads(t *testing.T, hello ClientHello, serverHello ServerHello) ([]byte, []byte) {
@@ -260,4 +261,120 @@ func mustCryptoTranscriptPayloads(t *testing.T, hello ClientHello, serverHello S
 	serverHelloFrame, err := NewJSONFrame(FrameTypeServerHello, serverHello)
 	require.NoError(t, err)
 	return clientHelloFrame.Payload, serverHelloFrame.Payload
+}
+
+func TestKeyAgreementProducesSharedSecretWithoutAuthKey(t *testing.T) {
+	hello, clientPriv := mustClientHello(t, BootstrapInfo{})
+	require.NotEmpty(t, hello.Capabilities.Crypto.ClientKeyShare)
+
+	serverHello, serverSecret, err := NewServerHello(hello)
+	require.NoError(t, err)
+	require.NotEmpty(t, serverHello.Selected.Crypto.ServerKeyShare)
+	require.NotEmpty(t, serverSecret)
+
+	clientHelloPayload, serverHelloPayload := mustCryptoTranscriptPayloads(t, hello, serverHello)
+	clientCtx, err := NewClientCryptoContext(clientPriv, clientHelloPayload, serverHelloPayload)
+	require.NoError(t, err)
+	require.Equal(t, serverSecret, clientCtx.SharedSecret)
+
+	serverCtx := NewCryptoContext(serverHello.Selected.Crypto.Algorithm, serverSecret, clientHelloPayload, serverHelloPayload)
+
+	require.NotEmpty(t, clientCtx.DeriveIKM(nil))
+	require.Equal(t, serverCtx.DeriveIKM(nil), clientCtx.DeriveIKM(nil))
+}
+
+func TestKeyAgreementIsSessionUnique(t *testing.T) {
+	first, firstPriv := mustClientHello(t, BootstrapInfo{})
+	firstServerHello, firstSecret, err := NewServerHello(first)
+	require.NoError(t, err)
+	firstClientPayload, firstServerPayload := mustCryptoTranscriptPayloads(t, first, firstServerHello)
+	firstCtx, err := NewClientCryptoContext(firstPriv, firstClientPayload, firstServerPayload)
+	require.NoError(t, err)
+
+	second, secondPriv := mustClientHello(t, BootstrapInfo{})
+	secondServerHello, _, err := NewServerHello(second)
+	require.NoError(t, err)
+	secondClientPayload, secondServerPayload := mustCryptoTranscriptPayloads(t, second, secondServerHello)
+	secondCtx, err := NewClientCryptoContext(secondPriv, secondClientPayload, secondServerPayload)
+	require.NoError(t, err)
+
+	require.NotEqual(t, firstSecret, secondCtx.SharedSecret)
+	require.NotEqual(t, firstCtx.DeriveIKM(nil), secondCtx.DeriveIKM(nil))
+}
+
+func TestKeyAgreementBackwardCompatibleWithPeerWithoutKeyShare(t *testing.T) {
+	hello, _ := mustClientHello(t, BootstrapInfo{})
+	hello.Capabilities.Crypto.ClientKeyShare = nil
+
+	serverHello, secret, err := NewServerHello(hello)
+	require.NoError(t, err)
+	require.Empty(t, serverHello.Selected.Crypto.ServerKeyShare)
+	require.Empty(t, secret)
+
+	clientHelloPayload, serverHelloPayload := mustCryptoTranscriptPayloads(t, hello, serverHello)
+	ctx, err := NewClientCryptoContext(nil, clientHelloPayload, serverHelloPayload)
+	require.NoError(t, err)
+	require.Empty(t, ctx.SharedSecret)
+	require.Equal(t, []byte("token"), ctx.DeriveIKM([]byte("token")))
+}
+
+func TestClientRejectsUnadvertisedServerKeyShare(t *testing.T) {
+	hello, _ := mustClientHello(t, BootstrapInfo{})
+	hello.Capabilities.Crypto.ClientKeyShare = nil
+
+	serverHello, _, err := NewServerHello(hello)
+	require.NoError(t, err)
+	serverHello.Selected.Crypto.ServerKeyShare = make([]byte, 32)
+
+	clientHelloPayload, serverHelloPayload := mustCryptoTranscriptPayloads(t, hello, serverHello)
+	_, err = NewClientCryptoContext(nil, clientHelloPayload, serverHelloPayload)
+	require.ErrorContains(t, err, "not advertised by client")
+}
+
+func TestKeyAgreementStrippedClientKeyShareLeavesNoKeyingMaterial(t *testing.T) {
+	hello, clientPriv := mustClientHello(t, BootstrapInfo{})
+	stripped := hello
+	stripped.Capabilities.Crypto.ClientKeyShare = nil
+
+	serverHello, serverSecret, err := NewServerHello(stripped)
+	require.NoError(t, err)
+	require.Empty(t, serverSecret)
+
+	clientHelloPayload, serverHelloPayload := mustCryptoTranscriptPayloads(t, hello, serverHello)
+	ctx, err := NewClientCryptoContext(clientPriv, clientHelloPayload, serverHelloPayload)
+	require.NoError(t, err)
+	require.Empty(t, ctx.SharedSecret)
+	require.Empty(t, ctx.DeriveIKM(nil))
+}
+
+func TestKeyAgreementRejectsMalformedKeyShares(t *testing.T) {
+	for _, size := range []int{1, 31, 33} {
+		hello, _ := mustClientHello(t, BootstrapInfo{})
+		hello.Capabilities.Crypto.ClientKeyShare = make([]byte, size)
+		_, _, err := NewServerHello(hello)
+		require.ErrorContains(t, err, "invalid client key share")
+	}
+
+	hello, clientPriv := mustClientHello(t, BootstrapInfo{})
+	serverHello, _, err := NewServerHello(hello)
+	require.NoError(t, err)
+	serverHello.Selected.Crypto.ServerKeyShare = make([]byte, 31)
+	clientHelloPayload, serverHelloPayload := mustCryptoTranscriptPayloads(t, hello, serverHello)
+	_, err = NewClientCryptoContext(clientPriv, clientHelloPayload, serverHelloPayload)
+	require.ErrorContains(t, err, "invalid server key share")
+}
+
+func TestKeyAgreementRejectsLowOrderPoint(t *testing.T) {
+	hello, _ := mustClientHello(t, BootstrapInfo{})
+	hello.Capabilities.Crypto.ClientKeyShare = make([]byte, 32)
+	_, _, err := NewServerHello(hello)
+	require.Error(t, err)
+
+	hello, clientPriv := mustClientHello(t, BootstrapInfo{})
+	serverHello, _, err := NewServerHello(hello)
+	require.NoError(t, err)
+	serverHello.Selected.Crypto.ServerKeyShare = make([]byte, 32)
+	clientHelloPayload, serverHelloPayload := mustCryptoTranscriptPayloads(t, hello, serverHello)
+	_, err = NewClientCryptoContext(clientPriv, clientHelloPayload, serverHelloPayload)
+	require.ErrorContains(t, err, "X25519 exchange")
 }

--- a/server/service.go
+++ b/server/service.go
@@ -609,9 +609,13 @@ func (ac *acceptedConnection) newControlReadWriter(rw io.ReadWriter, key []byte)
 		if ac.cryptoContext == nil {
 			return nil, fmt.Errorf("missing v2 crypto negotiation")
 		}
+		ikm := ac.cryptoContext.DeriveIKM(key)
+		if len(ikm) == 0 {
+			return nil, fmt.Errorf("v2 control channel has no keying material")
+		}
 		return netpkg.NewAEADCryptoReadWriter(
 			rw,
-			key,
+			ikm,
 			netpkg.AEADCryptoRoleServer,
 			ac.cryptoContext.Algorithm,
 			ac.cryptoContext.TranscriptHash,
@@ -649,7 +653,7 @@ func (ac *acceptedConnection) handleClientHello(conn net.Conn, wireConn *wire.Co
 		return fmt.Errorf("decode ClientHello: %w", err)
 	}
 
-	serverHello, err := wire.NewServerHello(hello)
+	serverHello, sharedSecret, err := wire.NewServerHello(hello)
 	if err != nil {
 		serverHello = wire.DefaultServerHello()
 		serverHello.Error = err.Error()
@@ -666,6 +670,7 @@ func (ac *acceptedConnection) handleClientHello(conn net.Conn, wireConn *wire.Co
 	}
 	cryptoContext := wire.NewCryptoContext(
 		serverHello.Selected.Crypto.Algorithm,
+		sharedSecret,
 		frame.Payload,
 		serverHelloFrame.Payload,
 	)

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -117,7 +117,7 @@ func TestServiceAcceptConnectionTracksClientHelloPresence(t *testing.T) {
 				}
 				wireConn := wire.NewConn(clientConn)
 				if tc.clientHelloPresent {
-					hello, err := wire.NewClientHello(wire.BootstrapInfo{})
+					hello, _, err := wire.NewClientHello(wire.BootstrapInfo{})
 					if err != nil {
 						clientErrCh <- err
 						return

--- a/test/e2e/v1/basic/wire.go
+++ b/test/e2e/v1/basic/wire.go
@@ -166,6 +166,38 @@ var _ = ginkgo.Describe("[Feature: WireProtocol]", func() {
 		})
 	}
 
+	for _, tc := range []struct {
+		name         string
+		wireProtocol string
+		token        string
+	}{
+		{name: "v2 without a pre-shared token", wireProtocol: "v2"},
+		{name: "v2 with a pre-shared token", wireProtocol: "v2", token: "123456"},
+		{name: "v1 with a pre-shared token", wireProtocol: "v1", token: "123456"},
+	} {
+		ginkgo.It(tc.name, func() {
+			var authConf string
+			if tc.token != "" {
+				authConf = fmt.Sprintf("auth.token = %q", tc.token)
+			}
+			serverConf := consts.DefaultServerConfig + authConf
+			tcpPortName := port.GenName("WireControlKey")
+			clientConf := consts.DefaultClientConfig + authConf + fmt.Sprintf(`
+			transport.wireProtocol = %q
+
+			[[proxies]]
+			name = "tcp"
+			type = "tcp"
+			localPort = {{ .%s }}
+			remotePort = {{ .%s }}
+			`, tc.wireProtocol, framework.TCPEchoServerPort, tcpPortName)
+
+			f.RunProcesses(serverConf, []string{clientConf})
+
+			framework.NewRequestExpect(f).PortName(tcpPortName).Ensure()
+		})
+	}
+
 	ginkgo.It("reports client wire protocol", func() {
 		webPort := f.AllocPort()
 		serverConf := consts.DefaultServerConfig + fmt.Sprintf(`


### PR DESCRIPTION
### WHY

The v2 control channel derives its AEAD keys with

```go
hkdf.Key(sha256.New, key, transcriptHash, info, AEADKeySize)   // pkg/util/net/conn.go
```

`key` is `auth.EncryptionKey()`, which returns `[]byte(resolved.Token)`. `resolved.Token`
is only populated inside `if resolved.Method == v1.AuthMethodToken` (`pkg/auth/auth.go`),
so with `auth.method = oidc` it is empty on both sides.

The salt is `HashCryptoTranscript(clientHelloPayload, serverHelloPayload)` over two frames
sent in cleartext before encryption starts, and `info` is a constant. For OIDC deployments
every input to the KDF is then public, so an observer of the handshake derives the same
directional keys. This matters most behind TLS-terminating infrastructure, which sees the
hellos.

### WHAT

Add an ephemeral X25519 key share to `ClientHello`/`ServerHello` and prepend the ECDH
output to the HKDF input keying material. Token deployments keep contributing their
pre-shared secret and additionally gain forward secrecy.

Both `newControlReadWriter`s refuse to open a v2 channel when the resulting keying
material is empty, so a stripped key share fails closed instead of silently falling back
to a publicly derivable key.

### Compatibility

With `auth.method = token`, wire-compatible in both directions: a peer that offers no key
share is answered without one, the token still keys the channel, and the transcripts match
because both sides hash the raw hello payloads.

With an auth method that has no pre-shared secret, a peer carrying this change will refuse
to talk to a v2 peer that predates it, rather than negotiating a keyless channel. That is
the combination the change exists to fix, so it fails closed deliberately.

### Limitations

The exchange is unauthenticated on its own. An active attacker who rewrites both hellos can
substitute their own key shares and man-in-the-middle the channel, exactly as before this
change — the empty-IKM check makes the stripping variant fail closed, it does not make the
exchange authenticated. This removes passive key recovery, not active attack. Binding the
exchange to the authenticated identity needs a transcript confirmation after login and is
left out to keep this change small.

Out of scope, both still keyed by the raw auth token: the v1 control channel
(`NewCryptoReadWriter`) and work connections using `transport.useEncryption`.

### Tests

`pkg/proto/wire`: shared secret agreement with an empty auth key, per-session uniqueness,
the no-key-share fallback, rejection of an unsolicited server key share, a stripped client
key share leaving no keying material, malformed key-share lengths on both sides, and
low-order points.

`test/e2e/v1/basic/wire.go`: v2 without a token, v2 with a token, v1 with a token.

`go test ./pkg/proto/wire/... ./pkg/util/net/... ./client/... ./server/...` and
`ginkgo --focus="WireProtocol|BinaryUDPPacket|ControlReplacement" ./test/e2e` pass.
